### PR TITLE
remove defunct readme badges

### DIFF
--- a/golang-commons/README.md
+++ b/golang-commons/README.md
@@ -1,9 +1,5 @@
 # Platform Mesh - golang-commons
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/go.platform-mesh.io/golang-commons/badge)](https://scorecard.dev/viewer/?uri=go.platform-mesh.io/golang-commons)
-![Build Status](https://go.platform-mesh.io/golang-commons/actions/workflows/ci.yml/badge.svg)
-[![REUSE status](
-https://api.reuse.software/badge/go.platform-mesh.io/golang-commons)](https://api.reuse.software/info/go.platform-mesh.io/golang-commons)
 ## Description
 
 golang-commons contains golang library packages to be reused across microservices and operators/controllers. The scope includes, but is not limited to:

--- a/golang-commons/REUSE.toml
+++ b/golang-commons/REUSE.toml
@@ -14,7 +14,7 @@
 
 version = 1
 SPDX-PackageName = "golang-commons"
-SPDX-PackageDownloadLocation = "https://go.platform-mesh.io/golang-commons"
+SPDX-PackageDownloadLocation = "https://github.com/platform-mesh/platform-mesh"
 
 [[annotations]]
 path = "**"

--- a/operators/account-operator/README.md
+++ b/operators/account-operator/README.md
@@ -2,8 +2,6 @@
 > This Repository is under development and not ready for productive use. It is in an alpha stage. That means APIs and concepts may change on short notice including breaking changes or complete removal of apis.
 
 # platform-mesh - account-operator
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/account-operator/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/account-operator)
-![Build Status](https://github.com/platform-mesh/account-operator/actions/workflows/ci.yml/badge.svg)
 
 ## Description
 
@@ -19,7 +17,7 @@ The platform-mesh account-operator manages the core Account resource which is a 
 ## Getting started
 
 - For running and building the account-operator, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository.
-- To deploy the account-operator to kubernetes, please refer to the [helm-charts](https://github.com/platform-mesh/helm-charts) repository. 
+- To deploy the account-operator to kubernetes, please refer to the [helm-charts](https://github.com/platform-mesh/helm-charts) repository.
 
 ## Releasing
 

--- a/operators/extension-manager-operator/README.md
+++ b/operators/extension-manager-operator/README.md
@@ -3,11 +3,6 @@
 
 # Platform Mesh - Extension Manager Operator
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/go.platform-mesh.io/extension-manager-operator/badge)](https://scorecard.dev/viewer/?uri=go.platform-mesh.io/extension-manager-operator)
-![Build Status](https://go.platform-mesh.io/extension-manager-operator/actions/workflows/ci.yml/badge.svg)
-[![REUSE status](
-https://api.reuse.software/badge/go.platform-mesh.io/extension-manager-operator)](https://api.reuse.software/info/go.platform-mesh.io/extension-manager-operator)
-
 ## Description
 
 The extension-manager-operator implements the lifecycle management of a Kubernetes CRD `ContentConfiguration` resource, which is a Kubernetes Resource/API for configuration of Micro Frontends in Platform Mesh.
@@ -44,10 +39,10 @@ The release is performed automatically through a GitHub Actions Workflow. New Ve
 The extension-manager-operators an installation of go. Checkout the [go.mod](go.mod) for the required go version and dependencies.
 
 ## Support, Feedback, Contributing
-This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://go.platform-mesh.io/extension-manager-operator/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
+This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/platform-mesh/platform-mesh/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
 ## Security / Disclosure
-If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://go.platform-mesh.io/extension-manager-operator/security/policy) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
+If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/platform-mesh/platform-mesh/security/policy) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
 
 ## Contributing
 

--- a/operators/security-operator/README.md
+++ b/operators/security-operator/README.md
@@ -2,11 +2,9 @@
 > This Repository is under development and not ready for productive use. It is in an alpha stage. That means APIs and concepts may change on short notice including breaking changes or complete removal of apis.
 
 # platform-mesh - security-operator
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/security-operator/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/security-operator)
-![build status](https://github.com/platform-mesh/security-operator/actions/workflows/ci.yml/badge.svg)
 
 ## Description
-Security-operator is responsible for security related configuration in Platform-mesh. 
+Security-operator is responsible for security related configuration in Platform-mesh.
 
 ## API description
 - **Store** - serves as CRD representation of OpenFGA store entity. Stores are created during logical clusters initialization phase or at deployment phase of Platform-mesh installation. When created, dedicated controller will create a **store** in OpenFGA.
@@ -18,7 +16,7 @@ Security-operator is responsible for security related configuration in Platform-
 ## Features
 - **Initialization of logical clusters** - This feature consist of 2 parts:
     - **organization level logical clusters** - operator creates **Store**, **IDP**, **Invite**, **WorkspaceAuthenticationConfiguration** resources to initialize an organization
-    - **account level logical clusters** - operator creates additional tuples in organization's store for accounts hieracy 
+    - **account level logical clusters** - operator creates additional tuples in organization's store for accounts hieracy
 - **Authorization Model generation** - to execute authorization checks in OpenFGA against custom resource which are created by the use, operator generatos Authorization Model for each resource in ApiExport when the ApiExport is bound (ApiBinding is created). The model is created in the workspace where **ApiExport** and **ApiResourceSchema** resource live.
 - **OIDC management** - Keycloak serves as the internal Identity Provider within Platform Mesh. After IDP resource is created and reconciled successfully, **WorkspaceAuthenticationConfiguration** resource is created and configured to use keycloak as identity provider for kcp authentication
 - **ApiExport bindability control** - ApiExportPolicy controller creates all necessary tuples in OpenFGA to support authorization checks for **bind** kcp's verb. More information about this [ApiExportPolicy ADR](https://github.com/platform-mesh/architecture/blob/main/adr/002-apiexport-binding-access-control.md)
@@ -27,7 +25,7 @@ Security-operator is responsible for security related configuration in Platform-
 ## Getting started
 
 - For running and building the security-operator, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository.
-- To deploy the security-operator to kubernetes, please refer to the [helm-charts](https://github.com/platform-mesh/helm-charts) repository. 
+- To deploy the security-operator to kubernetes, please refer to the [helm-charts](https://github.com/platform-mesh/helm-charts) repository.
 
 ## Releasing
 

--- a/operators/security-operator/REUSE.toml
+++ b/operators/security-operator/REUSE.toml
@@ -14,7 +14,7 @@
 
 version = 1
 SPDX-PackageName = "security-operator"
-SPDX-PackageDownloadLocation = "https://github.com/platform-mesh/security-operator"
+SPDX-PackageDownloadLocation = "https://github.com/platform-mesh/platform-mesh"
 
 [[annotations]]
 path = "**"

--- a/subroutines/README.md
+++ b/subroutines/README.md
@@ -1,10 +1,5 @@
 # Platform Mesh - subroutines
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/go.platform-mesh.io/subroutines/badge)](https://scorecard.dev/viewer/?uri=go.platform-mesh.io/subroutines)
-[![CI](https://go.platform-mesh.io/subroutines/actions/workflows/ci.yml/badge.svg)](https://go.platform-mesh.io/subroutines/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/go.platform-mesh.io/subroutines.svg)](https://pkg.go.dev/go.platform-mesh.io/subroutines)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-
 ## Description
 
 subroutines is a lifecycle engine for Kubernetes controllers built on [multicluster-runtime](https://github.com/platform-mesh/multicluster-runtime). It offers explicit Result-based flow control, opt-in condition/status management, and built-in observability.

--- a/subroutines/SECURITY.md
+++ b/subroutines/SECURITY.md
@@ -8,7 +8,7 @@ If you discover a security vulnerability in this project, please report it respo
 
 Instead, please report them via GitHub's private vulnerability reporting feature:
 
-1. Go to the [Security tab](https://go.platform-mesh.io/subroutines/security) of this repository.
+1. Go to the [Security tab](https://github.com/platform-mesh/platform-mesh/security) of this repository.
 2. Click **"Report a vulnerability"**.
 3. Provide a description of the vulnerability and steps to reproduce it.
 


### PR DESCRIPTION
This fixes a few URLs that were over-eagerly replaced when sed'ing `github.com/platform-mesh/...` to `go.platform-mesh.io/...`.

I also removed all the badges from the READMEs of the components that are already integrated. All these badges function on a per-repository level and so don't really work well in each component's README.