### PR TITLE
Add Trivy-based SBOM scanning for account-operator

### DIFF
--- a/.github/workflows/account-operator.yml
+++ b/.github/workflows/account-operator.yml
@@ -313,3 +313,14 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  scan-sbom:
+    needs: [version, docker-build-push, image-ocm]
+    uses: platform-mesh/.github/.github/workflows/job-trivy-sbom.yml@main
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    with:
+      componentName: github.com/platform-mesh/images/account-operator
+      componentVersion: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Backporting https://github.com/platform-mesh/account-operator/pull/278 to the monorepo.

More information can be found in https://github.com/platform-mesh/backlog/issues/226