### PR TITLE
rename gateway API package

### DIFF
--- a/apis/gateway/const.go
+++ b/apis/gateway/const.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apis
+package gateway
 
 import "time"
 

--- a/apis/gateway/const_test.go
+++ b/apis/gateway/const_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apis
+package gateway
 
 import (
 	"strings"


### PR DESCRIPTION
Since this package was moved out of the graphql-gateway, the name does not match the directory name anymore and was confusing.