### PR TITLE
Wire in legacy jobs

### DIFF
--- a/.github/workflows/account-operator.yml
+++ b/.github/workflows/account-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/backup-operator.yml
+++ b/.github/workflows/backup-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/backup-operator/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/backup-operator:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/backup-operator
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/backup-operator/')

--- a/.github/workflows/extension-manager-operator.yml
+++ b/.github/workflows/extension-manager-operator.yml
@@ -202,7 +202,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/iam-service.yml
+++ b/.github/workflows/iam-service.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -332,10 +332,29 @@ jobs:
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
 
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/iam-service/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/iam-service:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/iam-service
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
+
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/iam-service/')
     needs: [version, docker-build-push, image-ocm]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-sbom.yml@main
+    uses: ./.github/workflows/job-trivy-sbom.yml
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/job-trivy-image.yml
+++ b/.github/workflows/job-trivy-image.yml
@@ -55,6 +55,6 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # v2.25.4
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/job-trivy-image.yml
+++ b/.github/workflows/job-trivy-image.yml
@@ -1,0 +1,60 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Local (vendored) copy of platform-mesh/.github's job-trivy-image.yml.
+#
+# Kept in-repo so the per-component pipelines run image scanning from this
+# repository (no cross-repo dependency on platform-mesh/.github@main), pinned
+# alongside the rest of the workflows. Behaviour is identical to upstream.
+
+name: Container Security Scan
+on:
+  workflow_call:
+    inputs:
+      imageRef:
+        description: 'Full image reference to scan (e.g. ghcr.io/platform-mesh/security-operator:1.2.3)'
+        required: true
+        type: string
+      severity:
+        description: 'Severity levels to scan for (default: CRITICAL,HIGH)'
+        type: string
+        default: 'CRITICAL,HIGH'
+      exitCode:
+        description: 'Exit code to use if vulnerabilities are found (default: 0 - do not fail the workflow)'
+        type: string
+        default: '0'
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: ${{ inputs.imageRef }}
+          severity: ${{ inputs.severity }}
+          exit-code: ${{ inputs.exitCode }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # v2.25.4
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/kcp-migration-operator.yml
+++ b/.github/workflows/kcp-migration-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/kcp-migration-operator/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/kcp-migration-operator:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/kcp-migration-operator
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/kcp-migration-operator/')

--- a/.github/workflows/rebac-authz-webhook.yml
+++ b/.github/workflows/rebac-authz-webhook.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/rebac-authz-webhook/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/rebac-authz-webhook:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/rebac-authz-webhook
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/rebac-authz-webhook/')

--- a/.github/workflows/resource-sharding-operator.yml
+++ b/.github/workflows/resource-sharding-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/resource-sharding-operator/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/resource-sharding-operator:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/resource-sharding-operator
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/resource-sharding-operator/')

--- a/.github/workflows/search-operator.yml
+++ b/.github/workflows/search-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/search-operator/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/search-operator:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/search-operator
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/search-operator/')

--- a/.github/workflows/search-service.yml
+++ b/.github/workflows/search-service.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/search-service/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/search-service:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/search-service
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/search-service/')

--- a/.github/workflows/security-operator.yml
+++ b/.github/workflows/security-operator.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/terminal-controller-manager.yml
+++ b/.github/workflows/terminal-controller-manager.yml
@@ -202,7 +202,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -332,6 +332,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/terminal-controller-manager/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/terminal-controller-manager:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/terminal-controller-manager
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/terminal-controller-manager/')

--- a/.github/workflows/virtual-workspaces.yml
+++ b/.github/workflows/virtual-workspaces.yml
@@ -201,7 +201,7 @@ jobs:
   trivy-image:
     if: github.ref == 'refs/heads/main'
     needs: [docker-build-latest]
-    uses: platform-mesh/.github/.github/workflows/job-trivy-image.yml@main
+    uses: ./.github/workflows/job-trivy-image.yml
     permissions:
       contents: read
       packages: read
@@ -331,6 +331,25 @@ jobs:
       # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
+
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/virtual-workspaces/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@main
+    secrets: inherit
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/virtual-workspaces:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/virtual-workspaces
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
 
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/virtual-workspaces/')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized container vulnerability scan workflow used across releases.
  * Added support for an additional legacy image publishing path for tag-based releases.

* **Bug Fixes**
  * Updated release workflows to use local scanning and publishing steps, improving consistency across projects.
  * Kept existing release and scan behavior intact while adjusting registry handling for older tag formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->