### PR TITLE
Append boilerplate to CRDs, fix `task generate`

### DIFF
--- a/golang-commons/Taskfile.yaml
+++ b/golang-commons/Taskfile.yaml
@@ -27,6 +27,10 @@ tasks:
     deps: [tools:mockery]
     cmds:
       - "{{.BIN}}/mockery"
+  generate:
+    desc: Run code generation (mocks).
+    cmds:
+      - task: mockery
   fmt:
     cmds:
       - go fmt ./...

--- a/operators/account-operator/config/crd/core.platform-mesh.io_accountinfos.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_accountinfos.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_accounts.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_accounts.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_apiexportpolicies.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_apiexportpolicies.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_authorizationmodels.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_authorizationmodels.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_identityproviderconfigurations.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_identityproviderconfigurations.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_invites.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_invites.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/account-operator/config/crd/core.platform-mesh.io_stores.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_stores.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/backup-operator/config/crd/backup.platform-mesh.io_platformbackups.yaml
+++ b/operators/backup-operator/config/crd/backup.platform-mesh.io_platformbackups.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/backup-operator/config/crd/backup.platform-mesh.io_platformrestores.yaml
+++ b/operators/backup-operator/config/crd/backup.platform-mesh.io_platformrestores.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/extension-manager-operator/Taskfile.yaml
+++ b/operators/extension-manager-operator/Taskfile.yaml
@@ -27,10 +27,10 @@ vars:
   CRD_DIRECTORY: config/crd/bases
   SEDCMD:
     sh: |
-      if [ "$(go env GOOS)" = "darwin" ]; then
-        echo "sed -i ''"
-      else
+      if sed --version >/dev/null 2>&1; then
         echo "sed -i"
+      else
+        echo "sed -i ''"
       fi
 
 tasks:

--- a/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_contentconfigurations.yaml
+++ b/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_contentconfigurations.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_providermetadatas.yaml
+++ b/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_providermetadatas.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/extension-manager-operator/config/out/ui.platform-mesh.io_contentconfigurations.yaml
+++ b/operators/extension-manager-operator/config/out/ui.platform-mesh.io_contentconfigurations.yaml
@@ -1,4 +1,17 @@
 {{ if not .Values.kcp.enabled }}
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/extension-manager-operator/config/out/ui.platform-mesh.io_providermetadatas.yaml
+++ b/operators/extension-manager-operator/config/out/ui.platform-mesh.io_providermetadatas.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/kcp-migration-operator/config/crd/migration.platform-mesh.io_kcpmigrations.yaml
+++ b/operators/kcp-migration-operator/config/crd/migration.platform-mesh.io_kcpmigrations.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/resource-sharding-operator/config/crd/sharding.platform-mesh.io_resourceshardings.yaml
+++ b/operators/resource-sharding-operator/config/crd/sharding.platform-mesh.io_resourceshardings.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/search-operator/config/crd/bases/search.platform-mesh.io_searchindices.yaml
+++ b/operators/search-operator/config/crd/bases/search.platform-mesh.io_searchindices.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_accountinfos.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_accountinfos.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_accounts.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_accounts.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_apiexportpolicies.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_apiexportpolicies.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_authorizationmodels.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_authorizationmodels.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_identityproviderconfigurations.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_identityproviderconfigurations.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_invites.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_invites.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_stores.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_stores.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operators/terminal-controller-manager/config/crd/bases/terminal.platform-mesh.io_terminals.yaml
+++ b/operators/terminal-controller-manager/config/crd/bases/terminal.platform-mesh.io_terminals.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
+++ b/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
@@ -1,3 +1,16 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/subroutines/Taskfile.yaml
+++ b/subroutines/Taskfile.yaml
@@ -27,6 +27,12 @@ tasks:
     cmds:
       - go build ./...
 
+  generate:
+    desc: Run code generation (no generated artifacts in this module).
+    cmds:
+      - cmd: 'true'
+        silent: true
+
   lint:
     desc: Run golangci-lint
     cmds:

--- a/tools/Taskfile.yaml
+++ b/tools/Taskfile.yaml
@@ -132,7 +132,7 @@ tasks:
     internal: true
     deps: [controller-gen]
     cmds:
-      - '{{.BIN}}/controller-gen rbac:roleName=manager-role crd paths={{.TOPLEVEL}}/apis{{.PATH}} output:crd:artifacts:config={{.OUTPUT}}'
+      - '{{.BIN}}/controller-gen rbac:roleName=manager-role crd:headerFile={{.HACK}}/boilerplate/boilerplate.yaml.txt paths={{.TOPLEVEL}}/apis{{.PATH}} output:crd:artifacts:config={{.OUTPUT}}'
 
   generate-deepcopy:
     internal: true


### PR DESCRIPTION
This adds the license boilerplate to the generated CRDs. There are still plenty of YAML files that need the boilerplate, working on that as well, but pushing chunk by chunk.

`task generate` wasn't working for me. I made some changes to make it work, please verify that it works for you.