### PR TITLE
Update controller-tools to v0.20.1

### DIFF
--- a/operators/account-operator/config/crd/core.platform-mesh.io_accountinfos.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_accountinfos.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: accountinfos.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_accounts.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_accounts.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: accounts.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_apiexportpolicies.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_apiexportpolicies.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: apiexportpolicies.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_authorizationmodels.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_authorizationmodels.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: authorizationmodels.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_identityproviderconfigurations.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_identityproviderconfigurations.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: identityproviderconfigurations.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_invites.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_invites.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: invites.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/account-operator/config/crd/core.platform-mesh.io_stores.yaml
+++ b/operators/account-operator/config/crd/core.platform-mesh.io_stores.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: stores.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/backup-operator/config/crd/backup.platform-mesh.io_platformbackups.yaml
+++ b/operators/backup-operator/config/crd/backup.platform-mesh.io_platformbackups.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: platformbackups.backup.platform-mesh.io
 spec:
   group: backup.platform-mesh.io

--- a/operators/backup-operator/config/crd/backup.platform-mesh.io_platformrestores.yaml
+++ b/operators/backup-operator/config/crd/backup.platform-mesh.io_platformrestores.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: platformrestores.backup.platform-mesh.io
 spec:
   group: backup.platform-mesh.io

--- a/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_contentconfigurations.yaml
+++ b/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_contentconfigurations.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: contentconfigurations.ui.platform-mesh.io
 spec:
   group: ui.platform-mesh.io

--- a/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_providermetadatas.yaml
+++ b/operators/extension-manager-operator/config/crd/bases/ui.platform-mesh.io_providermetadatas.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: providermetadatas.ui.platform-mesh.io
 spec:
   group: ui.platform-mesh.io

--- a/operators/extension-manager-operator/config/out/ui.platform-mesh.io_contentconfigurations.yaml
+++ b/operators/extension-manager-operator/config/out/ui.platform-mesh.io_contentconfigurations.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: contentconfigurations.ui.platform-mesh.io
 spec:
   group: ui.platform-mesh.io

--- a/operators/extension-manager-operator/config/out/ui.platform-mesh.io_providermetadatas.yaml
+++ b/operators/extension-manager-operator/config/out/ui.platform-mesh.io_providermetadatas.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: providermetadatas.ui.platform-mesh.io
 spec:
   group: ui.platform-mesh.io

--- a/operators/kcp-migration-operator/config/crd/migration.platform-mesh.io_kcpmigrations.yaml
+++ b/operators/kcp-migration-operator/config/crd/migration.platform-mesh.io_kcpmigrations.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: kcpmigrations.migration.platform-mesh.io
 spec:
   group: migration.platform-mesh.io

--- a/operators/resource-sharding-operator/config/crd/sharding.platform-mesh.io_resourceshardings.yaml
+++ b/operators/resource-sharding-operator/config/crd/sharding.platform-mesh.io_resourceshardings.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: resourceshardings.sharding.platform-mesh.io
 spec:
   group: sharding.platform-mesh.io

--- a/operators/search-operator/config/crd/bases/search.platform-mesh.io_searchindices.yaml
+++ b/operators/search-operator/config/crd/bases/search.platform-mesh.io_searchindices.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: searchindices.search.platform-mesh.io
 spec:
   group: search.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_accountinfos.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_accountinfos.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: accountinfos.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_accounts.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_accounts.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: accounts.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_apiexportpolicies.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_apiexportpolicies.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: apiexportpolicies.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_authorizationmodels.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_authorizationmodels.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: authorizationmodels.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_identityproviderconfigurations.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_identityproviderconfigurations.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: identityproviderconfigurations.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_invites.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_invites.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: invites.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/security-operator/config/crd/bases/core.platform-mesh.io_stores.yaml
+++ b/operators/security-operator/config/crd/bases/core.platform-mesh.io_stores.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: stores.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/operators/terminal-controller-manager/config/crd/bases/terminal.platform-mesh.io_terminals.yaml
+++ b/operators/terminal-controller-manager/config/crd/bases/terminal.platform-mesh.io_terminals.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: terminals.terminal.platform-mesh.io
 spec:
   group: terminal.platform-mesh.io

--- a/services/rebac-authz-webhook/Taskfile.yaml
+++ b/services/rebac-authz-webhook/Taskfile.yaml
@@ -29,6 +29,10 @@ tasks:
     cmds:
       - task --list-all
 
+  generate:
+    cmds:
+      - task: mockery
+
   ## Development
   docker-build:
     cmds:

--- a/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
+++ b/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: marketplaceentries.marketplace.platform-mesh.io
 spec:
   group: marketplace.platform-mesh.io

--- a/tools/Taskfile.yaml
+++ b/tools/Taskfile.yaml
@@ -35,7 +35,7 @@ vars:
     sh: echo "$(git rev-parse --show-toplevel)"
   BIN: '{{.TOPLEVEL}}/bin'
   HACK: '{{.TOPLEVEL}}/hack'
-  CONTROLLER_TOOLS_VERSION: v0.16.4
+  CONTROLLER_TOOLS_VERSION: v0.20.1
   ENVTEST_K8S_VERSION: "1.35.0"
   ENVTEST_VERSION: release-0.23
   GOLANGCI_LINT_VERSION: 2.12.2


### PR DESCRIPTION
This PR updates controller-tools to v0.20.1 which corresponds to Kubernetes v1.35.

I didn't find any significant issue while upgrading.

There are mentions of other versions in search-operator's Makefile and kubernetes-graphql-gateway's Taskfile. For the former, the Makefile shouldn't be used, we'll see if we're going to drop it or handle it in a different way. graphql-gateway is still WIP (#67).