### PR TITLE
Fix random typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ task validate   # Run lint + test
 
   To actually update the Go version used for Platform Mesh, adjust the various `Dockerfiles`.
 
-* Similarily, the dependencies in **libraries** should not be updated unless necessary to be
+* Similarly, the dependencies in **libraries** should not be updated unless necessary to be
   compatible with the modules of the operators/services. The libraries like `golang-commons` or `apis`
   are meant to provide the broadest possible compatibility, making them as easy to integrate as
   possible.

--- a/contrib/adr/adr-01-account-model.md
+++ b/contrib/adr/adr-01-account-model.md
@@ -37,7 +37,7 @@ The account model that operates is platform specific. The account model is mostl
 This option involves creating a new CRD in that can be used to define the account model from an external perspective but can be used in kcp, with accounts managed as custom resources.
 This option implements accounts as CRDs with a strict 1:1 mapping to KCP workspaces, using initializers for atomic creation and setup.
 The account CRD should be the minimum frame, not to grow. There need to be other ways to extend partner/customer specific account implementation for platform.
-The account model itself is living outside KCP and can be managed external from it, but kcp needs to work with that model to achive account models goals.
+The account model itself is living outside KCP and can be managed external from it, but kcp needs to work with that model to achieve account models goals.
 
 ```mermaid
 graph TD
@@ -213,7 +213,7 @@ The proposal is to with option 1, and the poc for the MVP can then validate that
 - Custom initializers for different providers within kcp
 - Pluggable initialization steps
 - Support for future requirements
-- account model can be extended and defined as per need basis independent of kcp, but allows platform operators to custome to their own needs
+- account model can be extended and defined as per need basis independent of kcp, but allows platform operators to customize to their own needs
 
 4. Operational Benefits:
 - Clear status tracking

--- a/contrib/adr/adr-01-account-model.md
+++ b/contrib/adr/adr-01-account-model.md
@@ -1,4 +1,4 @@
-# ADR: Account Model Implementation in Platform Mesh using KCP
+# ADR: Account Model Implementation in Platform Mesh using kcp
 
 ## Status: Proposed
 
@@ -9,11 +9,11 @@
 ## Date: TBD
 
 ## Technical Story:
-Evaluate implementation options for the account model in Platform Mesh using KCP to create a flexible, scalable, and interoperable system for managing accounts, services and workload instances.
+Evaluate implementation options for the account model in Platform Mesh using kcp to create a flexible, scalable, and interoperable system for managing accounts, services and workload instances.
 
 ## Context and Problem Statement
 
-We need to implement an account model for Platform Mesh using KCP. The account model should be simple, scalable, and not locked to regions. It should support service and workload management, distinguish between services and applications, and allow for the decoupling of orthogonal aspects such as quotas, service validation, and access control. The core question is how to implement this account model effectively using KCP's workspace concepts and the Kubernetes Resource Model (KRM).
+We need to implement an account model for Platform Mesh using kcp. The account model should be simple, scalable, and not locked to regions. It should support service and workload management, distinguish between services and applications, and allow for the decoupling of orthogonal aspects such as quotas, service validation, and access control. The core question is how to implement this account model effectively using kcp's workspace concepts and the Kubernetes Resource Model (KRM).
 
 The account model that operates is platform specific. The account model is mostly like a central piece in a star schema, with additional extensions/dimensions as needed by the platform which can be specific to each implementation of the platform mesh. These can be handled as extensions to the account model, but the core account model should be kept simple and not allowed to grow.
 
@@ -21,7 +21,7 @@ The account model that operates is platform specific. The account model is mostl
 
 1. Need for a simple and scalable account model
 2. Requirement to support hierarchical account structures
-3. Desire to leverage KCP's workspace capabilities efficiently
+3. Desire to leverage kcp's workspace capabilities efficiently
 4. Need for clear distinction between services and workloads
 5. Requirement for extensibility to accommodate various provider-specific needs
 6. Desire for orthogonal aspects to be decoupled from the core account model
@@ -35,9 +35,9 @@ The account model that operates is platform specific. The account model is mostl
 ### Option 1: Custom Resource Definition (CRD) for Account Model
 
 This option involves creating a new CRD in that can be used to define the account model from an external perspective but can be used in kcp, with accounts managed as custom resources.
-This option implements accounts as CRDs with a strict 1:1 mapping to KCP workspaces, using initializers for atomic creation and setup.
+This option implements accounts as CRDs with a strict 1:1 mapping to kcp workspaces, using initializers for atomic creation and setup.
 The account CRD should be the minimum frame, not to grow. There need to be other ways to extend partner/customer specific account implementation for platform.
-The account model itself is living outside KCP and can be managed external from it, but kcp needs to work with that model to achieve account models goals.
+The account model itself is living outside kcp and can be managed external from it, but kcp needs to work with that model to achieve account models goals.
 
 ```mermaid
 graph TD
@@ -69,13 +69,13 @@ graph TD
 ```
 
 Pros:
-- Native Kubernetes approach, easily integrable with KCP
+- Native Kubernetes approach, easily integrable with kcp
 - Allows for declarative management of accounts
 - Can be extended using additional fields or annotations
 - Facilitates versioning and API evolution
 - Atomic account creation through initializer pattern
 - Clear, predictable 1:1 relationship with workspaces
-- Built-in validation and dependency management through initializers for creation and status, but validation for aspects on account through interfaces in KCP
+- Built-in validation and dependency management through initializers for creation and status, but validation for aspects on account through interfaces in kcp
 - Supports hierarchical account structures
 - Facilitates staged resource creation
 - Clear status tracking through conditions
@@ -91,15 +91,15 @@ Cons:
 - Need for careful timeout and retry handling
 
 Important Considerations:
-- Cascading of accounts needs investigation regarding KCP sharding capabilities if account model is concept in KCP and makes use of KCP's sharding
-- The KCP framework needs to support a mechanism by which an account model can be supported. This does not mean that the account model is part of the KCP framework, but that mechanisms exist to create account model
+- Cascading of accounts needs investigation regarding kcp sharding capabilities if account model is concept in kcp and makes use of kcp's sharding
+- The kcp framework needs to support a mechanism by which an account model can be supported. This does not mean that the account model is part of the kcp framework, but that mechanisms exist to create account model
 - At the moment it is 1:1 account to workspace for the MVP, unless otherwise specified by use cases
 - Self-referencing tree structure allows creation of child accounts
 - There needs to be a root account and a root workspace, the rest flows from there
 
-### Option 2: KCP Workspace as the Core Account Representation
+### Option 2: kcp Workspace as the Core Account Representation
 
-This option uses KCP workspaces as the primary representation of accounts, with additional metadata stored in workspace annotations or labels.
+This option uses kcp workspaces as the primary representation of accounts, with additional metadata stored in workspace annotations or labels.
 
 ```mermaid
 graph TD
@@ -128,23 +128,23 @@ graph TD
 ```
 
 Pros:
-- Leverages KCP's existing hierarchical workspace model
+- Leverages kcp's existing hierarchical workspace model
 - Provides built-in isolation and access control mechanisms
 - Allows for easy implementation of hierarchical structures
 - Facilitates management of resources within account context
-- Simpler approach and more KCP native
+- Simpler approach and more kcp native
 
 Cons:
 - Limited flexibility in storing complex account data
 - May require additional controllers to manage account-specific operations
 - Could lead to overloading of workspace concepts
-- More tight coupling between account and workspace and KCP to account
-- More required to define context for externals outside KCP for an account model (might not be sufficient for all use cases, e.g. you need to build more work on top)
+- More tight coupling between account and workspace and kcp to account
+- More required to define context for externals outside kcp for an account model (might not be sufficient for all use cases, e.g. you need to build more work on top)
 - Would need additional validation maybe via an additional webhook implementation
 
-### Option 3: KCP as a Service with Encapsulated Account Model (external to KCP)
+### Option 3: kcp as a Service with Encapsulated Account Model (external to kcp)
 
-This option positions KCP as a service that can be consumed by other teams, with the account model built as a layer on top.
+This option positions kcp as a service that can be consumed by other teams, with the account model built as a layer on top.
 
 ```mermaid
 graph TD
@@ -152,8 +152,8 @@ graph TD
         A[External Account Service] --> B[Account API]
         B --> C[Account Store]
 
-        subgraph "KCP Layer"
-            D[KCP Service]
+        subgraph "kcp Layer"
+            D[kcp Service]
             E[Workspaces]
             F[Resources]
         end
@@ -181,9 +181,9 @@ graph TD
 ```
 
 Pros:
-- Clear separation of concerns between KCP and account management
+- Clear separation of concerns between kcp and account management
 - Flexibility to evolve account model independently
-- Can leverage existing KCP features while maintaining abstraction
+- Can leverage existing kcp features while maintaining abstraction
 - Loose coupling
 
 Cons:
@@ -264,7 +264,7 @@ The proposal is to with option 1, and the poc for the MVP can then validate that
 
 ## Related Documents
 
-- KCP Workspace Documentation
+- kcp Workspace Documentation
 - Platform Mesh Architecture Overview
 - Service Provider Integration Guide
 

--- a/contrib/poc/kcp-poc-mfp.md
+++ b/contrib/poc/kcp-poc-mfp.md
@@ -1,16 +1,16 @@
-# KCP and Micro Frontend Platform (MFP) Integration POC
+# kcp and Micro Frontend Platform (MFP) Integration POC
 
 ## Overview
 
-This POC demonstrates the integration between KCP (Kubernetes Control Planes) and a Micro Frontend Platform (MFP), showcasing how workload management and frontend services can be orchestrated across multiple workspaces and clusters.
+This POC demonstrates the integration between kcp (Kubernetes Control Planes) and a Micro Frontend Platform (MFP), showcasing how workload management and frontend services can be orchestrated across multiple workspaces and clusters.
 
 ## Architecture
 
-### KCP Workspace Structure
+### kcp Workspace Structure
 
-![KCP Workspace Structure](../assets/apeirora-poc-design-infrav1.png)
+![kcp Workspace Structure](../assets/apeirora-poc-design-infrav1.png)
 
-The KCP instance is organized into several key workspaces:
+The kcp instance is organized into several key workspaces:
 
 1. **Root Workspace**
    - Base workspace that contains all other workspaces
@@ -40,7 +40,7 @@ The MSP Control Plane provides the actual Kubernetes cluster where workloads are
 
 - Namespace: `prefix-apeirora-example`
 - Workload: HTTPBin service deployment
-- Bidirectional sync with KCP example workspace
+- Bidirectional sync with kcp example workspace
 
 ### Micro Frontend Platform Integration
 
@@ -49,7 +49,7 @@ The MFP architecture consists of:
 1. **OpenMFP Cluster**
    - Account UI for user management
    - Gateway for routing
-   - Integration with KCP through account-operator
+   - Integration with kcp through account-operator
 
 2. **MSP Cluster**
    - Consumer UI for end-users
@@ -64,11 +64,11 @@ The POC uses HTTPBin as an example service to demonstrate:
 
 
 1. **Resource Definition**
-   - Defined in KCP example workspace
+   - Defined in kcp example workspace
    - Synchronized to MSP cluster
 
 2. **Deployment Flow**
-   - KCP manages the service definition
+   - kcp manages the service definition
    - MSP cluster handles actual deployment
    - Bidirectional synchronization ensures consistency
 
@@ -84,16 +84,16 @@ The POC uses HTTPBin as an example service to demonstrate:
    - Isolated resource management
 
 2. **Centralized Control**
-   - KCP provides unified control plane
+   - kcp provides unified control plane
    - Consistent resource management across clusters
 
 3. **Frontend Integration**
    - MFP provides user interfaces for different personas
-   - Seamless integration with KCP resources
+   - Seamless integration with kcp resources
 
 4. **Managed Services**
    - MSP provides actual compute resources
-   - Automated synchronization with KCP definitions
+   - Automated synchronization with kcp definitions
 
 ## Implementation Details
 
@@ -108,8 +108,8 @@ The POC uses HTTPBin as an example service to demonstrate:
    ```
 
 2. **Resource Synchronization**
-   - KCP to MSP: Service definitions and configurations
-   - MSP to KCP: Status updates and health information
+   - kcp to MSP: Service definitions and configurations
+   - MSP to kcp: Status updates and health information
 
 3. **Frontend Components**
    - Account management UI
@@ -117,4 +117,4 @@ The POC uses HTTPBin as an example service to demonstrate:
    - Operator dashboard
    - HTTPBin specific controls
 
-This POC demonstrates how KCP can be used to manage complex, multi-cluster deployments while integrating with a micro frontend platform for comprehensive service management and user interaction.
+This POC demonstrates how kcp can be used to manage complex, multi-cluster deployments while integrating with a micro frontend platform for comprehensive service management and user interaction.

--- a/golang-commons/controller/README.md
+++ b/golang-commons/controller/README.md
@@ -128,7 +128,7 @@ Features of the `lifecycle` package:
 func (l *LifecycleManager) SetupWithManager(mgr ctrl.Manager, maxReconciles int, reconcilerName string, instance RuntimeObject, debugLabelValue string, r reconcile.Reconciler, log *logger.Logger, eventPredicates ...predicate.Predicate) error
 ```
 
-The **debugLabelValue** parameter enables filtering of the resources based on a `debug.platform-mesh.io` label. If the label has the value passed in **debugLabelValue**, the resource will be reconciled in the `Process` function of the subroutine and all other resources will be skipped. If the value is empty string, all resources will be reconciled. This could be useful in debuging situations.
+The **debugLabelValue** parameter enables filtering of the resources based on a `debug.platform-mesh.io` label. If the label has the value passed in **debugLabelValue**, the resource will be reconciled in the `Process` function of the subroutine and all other resources will be skipped. If the value is empty string, all resources will be reconciled. This could be useful in debugging situations.
 
 ```yaml
 apiVersion: myorg.com/v1alpha1

--- a/golang-commons/controller/lifecycle/controllerruntime/lifecycle_test.go
+++ b/golang-commons/controller/lifecycle/controllerruntime/lifecycle_test.go
@@ -148,7 +148,7 @@ func TestLifecycle(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
-	t.Run("WthConditionManagement", func(t *testing.T) {
+	t.Run("WithConditionManagement", func(t *testing.T) {
 		// Given
 		fakeClient := pmtesting.CreateFakeClient(t, &pmtesting.TestApiObject{})
 		_, log := createLifecycleManager([]subroutine.Subroutine{}, fakeClient)

--- a/golang-commons/controller/lifecycle/spread/spread_test.go
+++ b/golang-commons/controller/lifecycle/spread/spread_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGetNextReconcilationTime(t *testing.T) {
+func TestGetNextReconciliationTime(t *testing.T) {
 	expectedEarliest := 12 * time.Hour
 	expectedLatest := 24 * time.Hour
 

--- a/golang-commons/controller/lifecycle/subroutine/subroutine.go
+++ b/golang-commons/controller/lifecycle/subroutine/subroutine.go
@@ -32,7 +32,7 @@ type Subroutine interface {
 	Finalizers(instance runtimeobject.RuntimeObject) []string
 }
 
-// Terminator can be implemeted to act as KCP terminator[0], i.e. act on
+// Terminator can be implemented to act as KCP terminator[0], i.e. act on
 // reconciles for LogicalClusters with deletion timestamp but without finalizer.
 // Use together with LifecycleManager.WithTerminator(string) to ensure removal
 // of the terminator on successful reconciliation.

--- a/golang-commons/controller/lifecycle/subroutine/subroutine.go
+++ b/golang-commons/controller/lifecycle/subroutine/subroutine.go
@@ -32,7 +32,7 @@ type Subroutine interface {
 	Finalizers(instance runtimeobject.RuntimeObject) []string
 }
 
-// Terminator can be implemented to act as KCP terminator[0], i.e. act on
+// Terminator can be implemented to act as kcp terminator[0], i.e. act on
 // reconciles for LogicalClusters with deletion timestamp but without finalizer.
 // Use together with LifecycleManager.WithTerminator(string) to ensure removal
 // of the terminator on successful reconciliation.
@@ -42,7 +42,7 @@ type Terminator interface {
 	Terminate(ctx context.Context, instance runtimeobject.RuntimeObject) (ctrl.Result, errors.OperatorError)
 }
 
-// Initializer can be implemented to act as KCP initializer[0], i.e. act on
+// Initializer can be implemented to act as kcp initializer[0], i.e. act on
 // reconciles for LogicalClusters without deletion timestamp. Use together with
 // LifecycleManager.WithInitializer(string) to ensure removal of the terminator
 // on successful reconciliation.

--- a/golang-commons/logger/README.md
+++ b/golang-commons/logger/README.md
@@ -16,7 +16,7 @@ logConfig := logger.DefaultConfig()
 logConfig.Name = "my-service"
 logConfig.Level = "debug"
 
-// ceate logger
+// create logger
 log, err := logger.New(logConfig)
 if err != nil {
 	fmt.Println("failed to create logger: %s", err)
@@ -49,7 +49,7 @@ For testing it is possible to pass a `&bytes.Buffer{}` as `Output` to collect lo
 
 ### Usage
 
-The logger uses a chained syntax for creating log entrys.
+The logger uses a chained syntax for creating log entries.
 You start with the level you want to log in, then optional fields that further describe the context of an error and finally the message itself.
 
 This will create a log entry with level fatal, sets the error as a field in the log output and prints the message "init failed":
@@ -112,7 +112,7 @@ This makes testing easier and is in general best practice.
 ### Platform Mesh Logger from Zerolog
 
 Because the Platform Mesh logger internally embeds Zerolog it is compatible with new versions of Zerolog.
-Nevertheless, because of this embeding, some functions return Zerolog instances.
+Nevertheless, because of this embedding, some functions return Zerolog instances.
 It is very easy to return a new Platform Mesh logger from a Zerolog instance using this helper function:
 ```go
 log := NewFromZerolog(zerologger)

--- a/golang-commons/middleware/requestid_test.go
+++ b/golang-commons/middleware/requestid_test.go
@@ -45,7 +45,7 @@ func TestSetRequestIdWithIncomingHeader(t *testing.T) {
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 }
 
-func TestSetRequestIdWitoutIncomingHeader(t *testing.T) {
+func TestSetRequestIdWithoutIncomingHeader(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		val := GetRequestId(r.Context())
 		assert.Len(t, val, 36)

--- a/golang-commons/sentry/README.md
+++ b/golang-commons/sentry/README.md
@@ -108,7 +108,7 @@ be skipped when sending errors (e.g. E2E tenant) can be provided as arguments.
 
 ### Recover panics
 
-There are rare circumstances where a Go program can crash with a panic. This happens if a `nil` pointer is de-referended
+There are rare circumstances where a Go program can crash with a panic. This happens if a `nil` pointer is de-referenced
 or a not existent map index is accessed. In order to send these errors to Sentry and log them there is a `Recover` func in the Sentry package.
 This function can be used in `main()` to record all panics (but not recover from them). It is also possible to use it in
 functions that are likely to panic (and then recover without crashing). However, if the `Recover()` function is used in `main()` only,

--- a/operators/account-operator/internal/controller/account_controller_setup_test.go
+++ b/operators/account-operator/internal/controller/account_controller_setup_test.go
@@ -72,7 +72,7 @@ const (
 	relativeBinaryAssetsDirectory = "../../bin"
 )
 
-// setupKCP starts KCP and sets up the basic platform-mesh workspace structure
+// setupKCP starts kcp and sets up the basic platform-mesh workspace structure
 // and configuration.
 func (s *AccountTestSuite) setupKCP() {
 	s.env = &envtest.Environment{AttachKcpOutput: false, KcpStopTimeout: time.Second * 30}
@@ -80,12 +80,12 @@ func (s *AccountTestSuite) setupKCP() {
 	s.env.KcpStartTimeout = 2 * time.Minute
 	s.env.KcpStopTimeout = 30 * time.Second
 
-	// Set the context in case using an existing KCP instance.
+	// Set the context in case using an existing kcp instance.
 	if os.Getenv("USE_EXISTING_KCP") != "" && os.Getenv("EXISTING_KCP_CONTEXT") == "" {
 		s.env.ExistingKcpContext = "base"
 	}
 
-	// Prevents KCP from cleaning up workspace fixtures before shutdown, the
+	// Prevents kcp from cleaning up workspace fixtures before shutdown, the
 	// instance controlled by envtest is ephemeral anyway.
 	if os.Getenv("PRESERVE") == "" {
 		s.Require().NoError(os.Setenv("PRESERVE", "true"))
@@ -185,7 +185,7 @@ func (s *AccountTestSuite) setupKCP() {
 			return false
 		}
 		return len(endpointSlice.Status.APIExportEndpoints) > 0 && endpointSlice.Status.APIExportEndpoints[0].URL != ""
-	}, 10*time.Second, 200*time.Millisecond, "KCP should automatically create APIExportEndpointSlice with populated endpoints")
+	}, 10*time.Second, 200*time.Millisecond, "kcp should automatically create APIExportEndpointSlice with populated endpoints")
 
 	s.Require().NotEmpty(endpointSlice.Status.APIExportEndpoints, "APIExportEndpointSlice should have at least one endpoint")
 	s.Require().NotEqual("", endpointSlice.Status.APIExportEndpoints[0].URL, "APIExportEndpointSlice endpoint URL should not be empty")

--- a/operators/account-operator/internal/controller/account_controller_test.go
+++ b/operators/account-operator/internal/controller/account_controller_test.go
@@ -127,7 +127,7 @@ func (s *AccountTestSuite) SetupSuite() {
 
 func (s *AccountTestSuite) TearDownSuite() {
 	if err := s.env.Stop(); err != nil {
-		s.T().Logf("Error stopping KCP environment: %v", err)
+		s.T().Logf("Error stopping kcp environment: %v", err)
 	}
 	s.cancel(fmt.Errorf("tearing down test suite"))
 }

--- a/operators/account-operator/pkg/subroutines/workspace/workspace_test.go
+++ b/operators/account-operator/pkg/subroutines/workspace/workspace_test.go
@@ -157,7 +157,7 @@ func TestProcess(t *testing.T) {
 		expectError   bool
 	}{
 		{
-			name: "shuold create workspace if not exists",
+			name: "should create workspace if not exists",
 			obj: &pmcorev1alpha1.Account{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",

--- a/operators/backup-operator/CLAUDE.md
+++ b/operators/backup-operator/CLAUDE.md
@@ -50,7 +50,7 @@ Follows the **account-operator** conventions exactly:
 - Controllers live in `internal/controller/`.
 - Each controller holds a `*lifecycle.Lifecycle` from `go.platform-mesh.io/subroutines/lifecycle` and delegates `Reconcile()` to it.
 - Reconcilers are registered with the **multicluster-runtime** manager via `mcbuilder.ControllerManagedBy(mgr)` (not the standard controller-runtime builder).
-- The manager is created with a **path-aware KCP provider** (`github.com/kcp-dev/multicluster-provider/path-aware`), enabling reconciliation across kcp logical clusters.
+- The manager is created with a **path-aware kcp provider** (`github.com/kcp-dev/multicluster-provider/path-aware`), enabling reconciliation across kcp logical clusters.
 
 ### Entry point
 `main.go` → `cmd.Execute()` → Cobra root (`cmd/root.go`) registers the scheme and adds the `operator` sub-command → `cmd/operator.go` builds the `mcmanager`, wires both controllers, and calls `mgr.Start()`.

--- a/operators/backup-operator/pkg/topology/topology.go
+++ b/operators/backup-operator/pkg/topology/topology.go
@@ -105,7 +105,7 @@ func Validate(source, target *Manifest) error {
 		})
 	}
 
-	// Compare KCP shards by name (order-independent).
+	// Compare kcp shards by name (order-independent).
 	sourceShards := shardsByName(source.Kcp.Shards)
 	targetShards := shardsByName(target.Kcp.Shards)
 

--- a/operators/extension-manager-operator/README.md
+++ b/operators/extension-manager-operator/README.md
@@ -15,16 +15,16 @@ For reference, see the [RFC for Platform Mesh Extension Management - CDM Process
 - Services to allow validation of content configuration at runtime while developing a micro frontend on the developers system.
 - Ability to provide validation feedback while keeping the last validated content configuration.
 
-## KCP vs. K8S
+## kcp vs. K8S
 
-The operator always runs with **multicluster-runtime** and optionally reconciles against an APIExportEndpointSlice using the KCP APIExport provider. The relevant three configuration parameters are:
+The operator always runs with **multicluster-runtime** and optionally reconciles against an APIExportEndpointSlice using the kcp APIExport provider. The relevant three configuration parameters are:
 
 * The `KUBECONFIG` environment variable will be used for reconciling, defaulting to `ctrl.GetConfigOrDie()`.
 * The optional `--leader-elect` CLI switch enables leader election and will use `rest.InClusterConfig()` for election.
 * The opitonal `--kcp-api-export-endpoint-slice-name` enables the APIExport provider.
 
 In practice this means:
-* To reconcile against a KCP instance, configure `KUBECONFIG` to point to KCP and set `--kcp-api-export-endpoint-slice-name` accordingly. Optionally enable `--leader-election` when running as Pod in a k8s cluster to use in-cluster leader election.
+* To reconcile against a kcp instance, configure `KUBECONFIG` to point to kcp and set `--kcp-api-export-endpoint-slice-name` accordingly. Optionally enable `--leader-election` when running as Pod in a k8s cluster to use in-cluster leader election.
 * To reconcile against plain K8S and running as Pod in k8s, optionally enable `--leader-election` and leave the the other two variables unset.
 
 ## Getting Started

--- a/operators/extension-manager-operator/internal/controller/contentconfiguration_controller_test.go
+++ b/operators/extension-manager-operator/internal/controller/contentconfiguration_controller_test.go
@@ -163,7 +163,7 @@ func (suite *ContentConfigurationTestSuite) SetupSuite() {
 	// (same as multicluster-provider e2e: providerConfig.Host += provider.RequestPath()).
 	providerConfig := rest.CopyConfig(kcpConfig)
 	providerConfig.Host = strings.TrimSuffix(providerConfig.Host, "/") + suite.provider.RequestPath()
-	// KCP envtest often fails discovery with "failed to get server groups: unknown" when the client
+	// kcp envtest often fails discovery with "failed to get server groups: unknown" when the client
 	// uses HTTP/2 (default). Force HTTP/1.1 so the cache's discovery client uses it (same as operator).
 	providerConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 		if tr, ok := rt.(*http.Transport); ok {

--- a/operators/extension-manager-operator/pkg/validation/validate_test.go
+++ b/operators/extension-manager-operator/pkg/validation/validate_test.go
@@ -151,7 +151,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:        "test_node_category_invalidobject",
-			input:       validation_test.GetInalidYAML_node_category_object(),
+			input:       validation_test.GetInvalidYAML_node_category_object(),
 			contentType: "yaml",
 			expected:    "",
 			expectError: true,

--- a/operators/extension-manager-operator/pkg/validation/validation_test/fixtures.go
+++ b/operators/extension-manager-operator/pkg/validation/validation_test/fixtures.go
@@ -439,7 +439,7 @@ func GetValidJSON_node_category_object() string {
 }`
 }
 
-func GetInalidYAML_node_category_object() string {
+func GetInvalidYAML_node_category_object() string {
 	return `
 name: overview2
 luigiConfigFragment:

--- a/operators/security-operator/.testcoverage.yml
+++ b/operators/security-operator/.testcoverage.yml
@@ -26,6 +26,6 @@ exclude:
     - ^internal/controller # skip covering controller directory (for now)
     - authorization_model_controller\.go$
     - internal/subroutine/workspace_initializer.go$
-    - ^internal/client # requires a live KCP API server
-    - ^internal/terminatingworkspaces # requires a live KCP API server
-    - ^internal/initializingworkspaces # requires a live KCP API server
+    - ^internal/client # requires a live kcp API server
+    - ^internal/terminatingworkspaces # requires a live kcp API server
+    - ^internal/initializingworkspaces # requires a live kcp API server

--- a/operators/security-operator/AGENTS.md
+++ b/operators/security-operator/AGENTS.md
@@ -40,7 +40,7 @@ Providers:
 ## Project structure
 - `api/`: API definitions (CRDs)
 - `cmd/`: Command entry points
-- `internal/client/`: KCP client helpers
+- `internal/client/`: kcp client helpers
 - `internal/config/`: operator config
 - `internal/controller/`: kubernetes controllers
 - `internal/fga/`: tuples and storeID management for OpenFGA
@@ -51,7 +51,7 @@ Providers:
 - `internal/test/`: integration tests
 - `internal/webhook/`: validating webhook
 - `pkg/`: HTTP client configuration for OAuth dynamic client registration
-- `config/resources/`: KCP API resources
+- `config/resources/`: kcp API resources
 - `bin/`
 - `main.go`
 - `go.mod`
@@ -65,7 +65,7 @@ Providers:
 - `CODE_OF_CONDUCT.md`
 - `AGENTS.md`
 
-## KCP structure
+## kcp structure
 - root (workspace types, used by initializer, terminator)
     - orgs (store, IDP, account `orgA`)
         - orgA (invite, accountInfo for account `orgA`, account `accB`)

--- a/operators/security-operator/CONTRIBUTING.md
+++ b/operators/security-operator/CONTRIBUTING.md
@@ -43,7 +43,7 @@ docker build -t <image name which is used in the cluster with the tag> .
 
 kind load docker-image <image name which is used in the cluster with the tag> --name=platform-mesh
 ```
-After it you need to restart security operator's pods and they will fetch a local image automaticly
+After it you need to restart security operator's pods and they will fetch a local image automatically
 
 If you want to use another image name and tag use this approach
 

--- a/operators/security-operator/README.md
+++ b/operators/security-operator/README.md
@@ -8,7 +8,7 @@ Security-operator is responsible for security related configuration in Platform-
 
 ## API description
 - **Store** - serves as CRD representation of OpenFGA store entity. Stores are created during logical clusters initialization phase or at deployment phase of Platform-mesh installation. When created, dedicated controller will create a **store** in OpenFGA.
-- **AuthorizationModel** - serves as CRD representaiton of OpenFGA Authorization model entity. AuthorizationModels are created when not default ApiBinding is created in the user's workspace. When created, dedicated controller will update Authorization model in the related store in OpenFGA.
+- **AuthorizationModel** - serves as CRD representation of OpenFGA Authorization model entity. AuthorizationModels are created when not default ApiBinding is created in the user's workspace. When created, dedicated controller will update Authorization model in the related store in OpenFGA.
 - **Invite** - serves as a mechanism for inviting people in your organization by their email
 - **IdentityProviderConfiguration (IDP)** - CRD for realm configuration in Keycloak and OIDC clients management. IDP is created during logical clusters initialization phase or at deployment phase of Platform-mesh installation.
 - **ApiExportPolicy** - CRD for granting **bind** permissions. When provider creates an API to share this API with other customers of Platform-mesh, he needs to get **bind** permissions and after this other users will be able to bind provider's API and use it
@@ -17,10 +17,10 @@ Security-operator is responsible for security related configuration in Platform-
 - **Initialization of logical clusters** - This feature consist of 2 parts:
     - **organization level logical clusters** - operator creates **Store**, **IDP**, **Invite**, **WorkspaceAuthenticationConfiguration** resources to initialize an organization
     - **account level logical clusters** - operator creates additional tuples in organization's store for accounts hieracy
-- **Authorization Model generation** - to execute authorization checks in OpenFGA against custom resource which are created by the use, operator generatos Authorization Model for each resource in ApiExport when the ApiExport is bound (ApiBinding is created). The model is created in the workspace where **ApiExport** and **ApiResourceSchema** resource live.
+- **Authorization Model generation** - to execute authorization checks in OpenFGA against custom resource which are created by the user, operator generates Authorization Model for each resource in ApiExport when the ApiExport is bound (ApiBinding is created). The model is created in the workspace where **ApiExport** and **ApiResourceSchema** resource live.
 - **OIDC management** - Keycloak serves as the internal Identity Provider within Platform Mesh. After IDP resource is created and reconciled successfully, **WorkspaceAuthenticationConfiguration** resource is created and configured to use keycloak as identity provider for kcp authentication
 - **ApiExport bindability control** - ApiExportPolicy controller creates all necessary tuples in OpenFGA to support authorization checks for **bind** kcp's verb. More information about this [ApiExportPolicy ADR](https://github.com/platform-mesh/architecture/blob/main/adr/002-apiexport-binding-access-control.md)
-- **Reconcile logical cluster** - securtity-operator reconciles logical clusters after they are initialized and applies the same logic as initializer does. It keeps already initialized logical clusters up to date if something has been changed in initializing flow.
+- **Reconcile logical cluster** - security-operator reconciles logical clusters after they are initialized and applies the same logic as initializer does. It keeps already initialized logical clusters up to date if something has been changed in initializing flow.
 
 ## Getting started
 

--- a/operators/security-operator/cmd/initializer.go
+++ b/operators/security-operator/cmd/initializer.go
@@ -51,7 +51,7 @@ var initializerCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		restCfg, err := getKubeconfigFromPath(initializerCfg.KCP.Kubeconfig)
 		if err != nil {
-			log.Error().Err(err).Msg("unable to get KCP kubeconfig")
+			log.Error().Err(err).Msg("unable to get kcp kubeconfig")
 			os.Exit(1)
 		}
 

--- a/operators/security-operator/cmd/model_generator.go
+++ b/operators/security-operator/cmd/model_generator.go
@@ -52,7 +52,7 @@ var modelGeneratorCmd = &cobra.Command{
 
 		restCfg, err := getKubeconfigFromPath(generatorCfg.KCP.Kubeconfig)
 		if err != nil {
-			log.Error().Err(err).Msg("unable to get KCP kubeconfig")
+			log.Error().Err(err).Msg("unable to get kcp kubeconfig")
 			return err
 		}
 

--- a/operators/security-operator/cmd/operator.go
+++ b/operators/security-operator/cmd/operator.go
@@ -71,7 +71,7 @@ var operatorCmd = &cobra.Command{
 
 		restCfg, err := getKubeconfigFromPath(operatorCfg.KCP.Kubeconfig)
 		if err != nil {
-			log.Error().Err(err).Msg("unable to get KCP kubeconfig")
+			log.Error().Err(err).Msg("unable to get kcp kubeconfig")
 			return err
 		}
 

--- a/operators/security-operator/cmd/system.go
+++ b/operators/security-operator/cmd/system.go
@@ -53,7 +53,7 @@ var systemCmd = &cobra.Command{
 
 		restCfg, err := getKubeconfigFromPath(systemCfg.KCP.Kubeconfig)
 		if err != nil {
-			log.Error().Err(err).Msg("unable to get KCP kubeconfig")
+			log.Error().Err(err).Msg("unable to get kcp kubeconfig")
 			return err
 		}
 

--- a/operators/security-operator/cmd/terminator.go
+++ b/operators/security-operator/cmd/terminator.go
@@ -45,7 +45,7 @@ var terminatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		kcpCfg, err := getKubeconfigFromPath(terminatorCfg.KCP.Kubeconfig)
 		if err != nil {
-			log.Error().Err(err).Msg("unable to get KCP kubeconfig")
+			log.Error().Err(err).Msg("unable to get kcp kubeconfig")
 			os.Exit(1)
 		}
 

--- a/operators/security-operator/hack/update-kubeconfig.sh
+++ b/operators/security-operator/hack/update-kubeconfig.sh
@@ -34,10 +34,10 @@ if ! kind get clusters | grep -q "^platform-mesh$"; then
 fi
 
 echo ""
-echo "Retrieving credentials from KCP kubeconfig..."
+echo "Retrieving credentials from kcp kubeconfig..."
 
 if [ ! -f "$KCP_KUBECONFIG" ]; then
-    echo "Error: KCP kubeconfig not found at $KCP_KUBECONFIG"
+    echo "Error: kcp kubeconfig not found at $KCP_KUBECONFIG"
     exit 1
 fi
 

--- a/operators/security-operator/internal/client/logicalcluster.go
+++ b/operators/security-operator/internal/client/logicalcluster.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NewForLogicalCluster returns a client for a given logical cluster name or
-// path, based on a KCP base config.
+// path, based on a kcp base config.
 func NewForLogicalCluster(config *rest.Config, scheme *runtime.Scheme, clusterKey logicalcluster.Name) (ctrlruntimeclient.Client, error) {
 	path := fmt.Sprintf("/clusters/%s", clusterKey)
 

--- a/operators/security-operator/internal/config/config.go
+++ b/operators/security-operator/internal/config/config.go
@@ -160,7 +160,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.FGA.ObjectType, "fga-object-type", c.FGA.ObjectType, "Set the OpenFGA object type for account tuples")
 	fs.StringVar(&c.FGA.ParentRelation, "fga-parent-relation", c.FGA.ParentRelation, "Set the OpenFGA parent relation name")
 	fs.StringVar(&c.FGA.CreatorRelation, "fga-creator-relation", c.FGA.CreatorRelation, "Set the OpenFGA creator relation name")
-	fs.StringVar(&c.KCP.Kubeconfig, "kcp-kubeconfig", c.KCP.Kubeconfig, "Set the KCP kubeconfig path")
+	fs.StringVar(&c.KCP.Kubeconfig, "kcp-kubeconfig", c.KCP.Kubeconfig, "Set the kcp kubeconfig path")
 	fs.StringVar(&c.APIExportEndpointSlices.CorePlatformMeshIO, "api-export-endpoint-slice-name", c.APIExportEndpointSlices.CorePlatformMeshIO, "Set the core.platform-mesh.io APIExportEndpointSlice name")
 	fs.StringVar(&c.APIExportEndpointSlices.SystemPlatformMeshIO, "system-api-export-endpoint-slice-name", c.APIExportEndpointSlices.SystemPlatformMeshIO, "Set the system.platform-mesh.io APIExportEndpointSlice name")
 	fs.StringVar(&c.CoreModulePath, "core-module-path", c.CoreModulePath, "Set the path to the core module FGA model file")

--- a/operators/security-operator/internal/fga/storeid_getter.go
+++ b/operators/security-operator/internal/fga/storeid_getter.go
@@ -91,7 +91,7 @@ func (m *CachingStoreIDGetter) Get(ctx context.Context, storeName string) (strin
 
 type storeIDLoader struct {
 	fga       openfgav1.OpenFGAServiceClient
-	loadErrer error
+	loadError error
 	loadCtx   context.Context
 }
 
@@ -108,7 +108,7 @@ func (l *storeIDLoader) Load(c *ttlcache.Cache[string, string], storeName string
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
-			l.loadErrer = fmt.Errorf("listing Stores in OpenFGA: %w", err)
+			l.loadError = fmt.Errorf("listing Stores in OpenFGA: %w", err)
 			return nil
 		}
 
@@ -131,7 +131,7 @@ func (l *storeIDLoader) Load(c *ttlcache.Cache[string, string], storeName string
 // this.
 // [0] https://github.com/jellydator/ttlcache/issues/74#issuecomment-1133012806
 func (l *storeIDLoader) Err() error {
-	return l.loadErrer
+	return l.loadError
 }
 
 var _ StoreIDGetter = (*CachingStoreIDGetter)(nil)

--- a/operators/security-operator/internal/platformmesh/account_path.go
+++ b/operators/security-operator/internal/platformmesh/account_path.go
@@ -29,7 +29,7 @@ const (
 	rootWorkspace = "root"
 	orgsWorkspace = "orgs"
 
-	kcpWorkpaceSeparator = ":"
+	kcpWorkspaceSeparator = ":"
 )
 
 // IsPlatformMeshAccountPath returns whether a value is a platform-mesh account
@@ -37,7 +37,7 @@ const (
 // workspace tree "root:orgs".
 func IsPlatformMeshAccountPath(value string) bool {
 	_, valid := logicalcluster.NewValidatedPath(value)
-	parts := strings.Split(value, kcpWorkpaceSeparator)
+	parts := strings.Split(value, kcpWorkspaceSeparator)
 
 	return valid && len(parts) > 2 && parts[0] == rootWorkspace && parts[1] == orgsWorkspace
 }
@@ -70,14 +70,14 @@ func NewAccountPathFromLogicalCluster(lc *kcpcorev1alpha1.LogicalCluster) (Accou
 
 // IsOrg returns true if the AccountPath is an organisation.
 func (a AccountPath) IsOrg() bool {
-	parts := strings.Split(a.String(), kcpWorkpaceSeparator)
+	parts := strings.Split(a.String(), kcpWorkspaceSeparator)
 	return len(parts) == 3
 }
 
 // Org returns the AccountPath's parent organisation.
 func (a AccountPath) Org() AccountPath {
-	parts := strings.Split(a.String(), kcpWorkpaceSeparator)
+	parts := strings.Split(a.String(), kcpWorkspaceSeparator)
 	return AccountPath{
-		Path: logicalcluster.NewPath(strings.Join(parts[:3], kcpWorkpaceSeparator)),
+		Path: logicalcluster.NewPath(strings.Join(parts[:3], kcpWorkspaceSeparator)),
 	}
 }

--- a/operators/security-operator/internal/platformmesh/account_path.go
+++ b/operators/security-operator/internal/platformmesh/account_path.go
@@ -33,7 +33,7 @@ const (
 )
 
 // IsPlatformMeshAccountPath returns whether a value is a platform-mesh account
-// path, i.e. a canonical KCP workspace path child to the platform-mesh account
+// path, i.e. a canonical kcp workspace path child to the platform-mesh account
 // workspace tree "root:orgs".
 func IsPlatformMeshAccountPath(value string) bool {
 	_, valid := logicalcluster.NewValidatedPath(value)

--- a/operators/security-operator/internal/subroutine/invite_test.go
+++ b/operators/security-operator/internal/subroutine/invite_test.go
@@ -82,7 +82,7 @@ func TestInviteSubroutine_Initialize(t *testing.T) {
 			expectedResult: subroutines.OK(),
 		},
 		{
-			name: "KCP client getter error",
+			name: "kcp client getter error",
 			setupMocks: func(_ *mocks.MockClient, _ *mocks.MockClient, _ *mocks.MockManager, kcpHelper *mocks.MockKCPClientGetter) {
 				kcpHelper.EXPECT().NewClientFromContext(mock.Anything).Return(nil, assert.AnError).Once()
 			},

--- a/operators/security-operator/internal/subroutine/store_test.go
+++ b/operators/security-operator/internal/subroutine/store_test.go
@@ -287,7 +287,7 @@ func TestFinalize(t *testing.T) {
 			},
 		},
 		{
-			name: "should not reconcile successfully deletion is errorneous",
+			name: "should not reconcile successfully deletion is erroneous",
 			store: &pmcorev1alpha1.Store{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "store",

--- a/operators/security-operator/internal/subroutine/workspace_initializer.go
+++ b/operators/security-operator/internal/subroutine/workspace_initializer.go
@@ -99,7 +99,7 @@ func (w *workspaceInitializer) reconcile(ctx context.Context, obj ctrlruntimecli
 	}, &ai); err != nil && !apierrors.IsNotFound(err) {
 		return subroutines.OK(), fmt.Errorf("getting AccountInfo for LogicalCluster: %w", err)
 	} else if apierrors.IsNotFound(err) {
-		return subroutines.StopWithRequeue(5*time.Second, "AccountInfo not found yet, requeueing"), nil
+		return subroutines.StopWithRequeue(5*time.Second, "AccountInfo not found yet, requeuing"), nil
 	}
 
 	orgsClient, err := w.kcpClientGetter.NewClientForLogicalCluster(ctx, "root:orgs")
@@ -157,13 +157,13 @@ func (w *workspaceInitializer) reconcile(ctx context.Context, obj ctrlruntimecli
 	}); err != nil {
 		return subroutines.OK(), fmt.Errorf("unable to create/update store: %w", err)
 	} else if result == controllerutil.OperationResultCreated || result == controllerutil.OperationResultUpdated {
-		return subroutines.StopWithRequeue(5*time.Second, "store needed to be updated, requeueing"), nil
+		return subroutines.StopWithRequeue(5*time.Second, "store needed to be updated, requeuing"), nil
 	}
 
 	// Check if Store applied tuple changes
 	for _, t := range tuples {
 		if !slices.Contains(store.Status.ManagedTuples, t) {
-			return subroutines.StopWithRequeue(5*time.Second, "store does not yet contain all specified tuples, requeueing"), nil
+			return subroutines.StopWithRequeue(5*time.Second, "store does not yet contain all specified tuples, requeuing"), nil
 		}
 	}
 

--- a/operators/security-operator/internal/test/integration/suite_test.go
+++ b/operators/security-operator/internal/test/integration/suite_test.go
@@ -226,7 +226,7 @@ func (suite *IntegrationSuite) setupPlatformMesh(t *testing.T) {
 			return false
 		}
 		return len(endpointSlice.Status.APIExportEndpoints) > 0 && endpointSlice.Status.APIExportEndpoints[0].URL != ""
-	}, 10*time.Second, 200*time.Millisecond, "KCP should automatically create APIExportEndpointSlice with populated endpoints")
+	}, 10*time.Second, 200*time.Millisecond, "kcp should automatically create APIExportEndpointSlice with populated endpoints")
 
 	suite.Require().NotEmpty(endpointSlice.Status.APIExportEndpoints, "APIExportEndpointSlice should have at least one endpoint")
 	suite.Require().NotEqual("", endpointSlice.Status.APIExportEndpoints[0].URL, "APIExportEndpointSlice endpoint URL should not be empty")

--- a/services/iam-service/.mockery.yaml
+++ b/services/iam-service/.mockery.yaml
@@ -119,7 +119,7 @@ packages:
           filename: mock_KeycloakClientInterface.go
           structname: KeycloakClientInterface
 
-  # Workspace ClientFactory - External dependency for KCP workspace client creation
+  # Workspace ClientFactory - External dependency for kcp workspace client creation
   go.platform-mesh.io/iam-service/pkg/workspace:
     config:
       dir: pkg/fga/mocks

--- a/services/iam-service/AGENTS.md
+++ b/services/iam-service/AGENTS.md
@@ -1,6 +1,6 @@
 ## Repository Description
 - `iam-service` provides a GraphQL API for user and role management in Platform Mesh.
-- It manages users, roles, and related authorization state through OpenFGA, Keycloak, and KCP-backed resources.
+- It manages users, roles, and related authorization state through OpenFGA, Keycloak, and kcp-backed resources.
 - This is a Go service built around [gqlgen](https://github.com/99designs/gqlgen), [OpenFGA](https://github.com/openfga/openfga), [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime), and [multicluster-runtime](https://github.com/kubernetes-sigs/multicluster-runtime).
 - Read the org-wide [AGENTS.md](https://github.com/platform-mesh/.github/blob/main/AGENTS.md) for general conventions.
 
@@ -22,25 +22,25 @@
 - `input/roles.yaml`: role definitions consumed by the service.
 
 ## Architecture
-This is a GraphQL service with thin transport wiring and most domain behavior split between resolver services, OpenFGA integration, Keycloak integration, and KCP-aware middleware.
+This is a GraphQL service with thin transport wiring and most domain behavior split between resolver services, OpenFGA integration, Keycloak integration, and kcp-aware middleware.
 
 ### Runtime model
 - `cmd/server.go` starts an `mcmanager.Manager` backed by an APIExport provider for `core.platform-mesh.io`; leader election is intentionally disabled.
 - The HTTP router is chi-based and serves `/graphql`, `/healthz`, and `/readyz`; the GraphQL playground is exposed only in local mode.
-- The manager's local config is also reused to derive a root-cluster KCP client and account/workspace helpers.
+- The manager's local config is also reused to derive a root-cluster kcp client and account/workspace helpers.
 
 ### Request flow
-- Middleware built in `setupRouter` injects KCP user context before GraphQL execution.
+- Middleware built in `setupRouter` injects kcp user context before GraphQL execution.
 - GraphQL directives are part of the authorization path: the `Authorized` directive uses OpenFGA plus `AccountInfo` and workspace lookups.
 - `pkg/resolver/pm.Service` is the main service layer behind resolvers; it composes FGA, Keycloak, pagination, sorting, and user transformation.
 
 ### Domain model
 - User and role mutations are backed by OpenFGA tuples and role definitions from `input/roles.yaml`, not a relational database.
 - Keycloak is the identity source for user lookup/enrichment; OpenFGA is the authorization source.
-- KCP workspace and `AccountInfo` lookups provide tenant and workspace context needed to resolve resource-scoped permissions.
+- kcp workspace and `AccountInfo` lookups provide tenant and workspace context needed to resolve resource-scoped permissions.
 
 ### Configuration and tests
-- `cmd/server.go` derives the root KCP host by stripping the multicluster path from the manager config; changing that logic affects all cluster lookups.
+- `cmd/server.go` derives the root kcp host by stripping the multicluster path from the manager config; changing that logic affects all cluster lookups.
 - GraphQL schema, mocks, and Keycloak client code are generated and must stay in sync with source definitions.
 
 ## Commands

--- a/services/iam-service/CONTRIBUTING.md
+++ b/services/iam-service/CONTRIBUTING.md
@@ -4,13 +4,13 @@ We want to make contributing to this project as easy and transparent as possible
 
 ## Project Overview
 
-This is the Platform Mesh IAM (Identity and Access Management) service, a Go-based microservice that provides a GraphQL API for user management and authorization. The service has been refactored to use OpenFGA as the primary backend for authorization data and KCP for multi-cluster resource management, eliminating the need for a traditional database. It integrates with Keycloak for identity management.
+This is the Platform Mesh IAM (Identity and Access Management) service, a Go-based microservice that provides a GraphQL API for user management and authorization. The service has been refactored to use OpenFGA as the primary backend for authorization data and kcp for multi-cluster resource management, eliminating the need for a traditional database. It integrates with Keycloak for identity management.
 
 ## Development Setup
 
 ### Prerequisites
 1. Go 1.26.0+ (check [go.mod](go.mod) for exact version)
-2. Platform Mesh installation (OpenFGA and KCP)
+2. Platform Mesh installation (OpenFGA and kcp)
 3. Task runner (optional but recommended)
 
 ### Environment Setup
@@ -80,8 +80,8 @@ task validate
 - **Entry Point**: `main.go` → `cmd/` → `cmd/server.go`
 - **Transport Layer**: GraphQL API via gqlgen
 - **Service Layer**: Business logic in `pkg/service/` and `pkg/resolver/`
-- **Integration Layer**: OpenFGA (gRPC client), Keycloak for identity management, KCP for multi-cluster management
-- **Data Backend**: OpenFGA for authorization data, KCP for resource management (no traditional database), IDP for User Data
+- **Integration Layer**: OpenFGA (gRPC client), Keycloak for identity management, kcp for multi-cluster management
+- **Data Backend**: OpenFGA for authorization data, kcp for resource management (no traditional database), IDP for User Data
 
 ## Development Patterns
 
@@ -99,7 +99,7 @@ task validate
 ### Multi-tenancy
 - Tenant information extracted from JWT tokens
 - Tenant-scoped authorization through OpenFGA
-- KCP-based multi-cluster resource management
+- kcp-based multi-cluster resource management
 
 ## Common Development Tasks
 
@@ -134,7 +134,7 @@ You are welcome to contribute with your pull requests. These steps explain the c
 - **GraphQL**: gqlgen for schema-first GraphQL API
 - **Authorization**: OpenFGA for fine-grained access control (gRPC client)
 - **Identity**: Keycloak integration for user management
-- **Multi-cluster**: KCP (Kubernetes Control Plane) for resource management
+- **Multi-cluster**: kcp (Kubernetes Control Plane) for resource management
 - **Build**: Task (Taskfile.yaml)
 - **Testing**: Standard Go testing with testify
 - **Logging**: zerolog for structured logging

--- a/services/iam-service/hack/update-kubeconfig.sh
+++ b/services/iam-service/hack/update-kubeconfig.sh
@@ -34,10 +34,10 @@ if ! kind get clusters | grep -q "^platform-mesh$"; then
 fi
 
 echo ""
-echo "Retrieving credentials from KCP kubeconfig..."
+echo "Retrieving credentials from kcp kubeconfig..."
 
 if [ ! -f "$KCP_KUBECONFIG" ]; then
-    echo "Error: KCP kubeconfig not found at $KCP_KUBECONFIG"
+    echo "Error: kcp kubeconfig not found at $KCP_KUBECONFIG"
     exit 1
 fi
 

--- a/services/iam-service/pkg/accountinfo/accountinfo.go
+++ b/services/iam-service/pkg/accountinfo/accountinfo.go
@@ -57,7 +57,7 @@ func (a *accountInfoRetriever) Get(ctx context.Context, accountPath multicluster
 
 	//FIXME: This lock was necessary as we saw race conditions when processing multiple requests in parallel
 	// The issue occurs when a cluster is requested for the first time and multiple requests are processed simultaneously
-	// We will work with the KCP team to identify the root cause and remove this lock in future
+	// We will work with the kcp team to identify the root cause and remove this lock in future
 	mu := a.getClusterLock(accountPath)
 	mu.Lock()
 	defer mu.Unlock()

--- a/services/iam-service/pkg/context/context.go
+++ b/services/iam-service/pkg/context/context.go
@@ -27,24 +27,24 @@ import (
 type contextKey string
 
 const (
-	// kcpContextKey is the key for storing KCP user context
+	// kcpContextKey is the key for storing kcp user context
 	kcpContextKey contextKey = "KCPContext"
 	// clusterIdContextKey is the key for storing Cluster ID
 	clusterIdContextKey contextKey = "clusterId"
 )
 
-// KCPContext holds KCP-related user information
+// KCPContext holds kcp-related user information
 type KCPContext struct {
 	IDMTenant        string
 	OrganizationName string
 }
 
-// SetKCPContext stores KCP context information in the request context
+// SetKCPContext stores kcp context information in the request context
 func SetKCPContext(ctx context.Context, kcpCtx KCPContext) context.Context {
 	return context.WithValue(ctx, kcpContextKey, kcpCtx)
 }
 
-// GetKCPContext retrieves KCP context information from the request context
+// GetKCPContext retrieves kcp context information from the request context
 func GetKCPContext(ctx context.Context) (KCPContext, error) {
 	val := ctx.Value(kcpContextKey)
 	if val == nil {

--- a/services/iam-service/pkg/context/context_test.go
+++ b/services/iam-service/pkg/context/context_test.go
@@ -27,22 +27,22 @@ import (
 func TestKCPContext(t *testing.T) {
 	ctx := context.Background()
 
-	// Test setting and getting KCP context
+	// Test setting and getting kcp context
 	kcpCtx := KCPContext{
 		IDMTenant:        "test-tenant",
 		OrganizationName: "test-org",
 	}
 
-	// Set KCP context
+	// Set kcp context
 	ctxWithKCP := SetKCPContext(ctx, kcpCtx)
 
-	// Get KCP context
+	// Get kcp context
 	retrievedKCP, err := GetKCPContext(ctxWithKCP)
 	require.NoError(t, err)
 	assert.Equal(t, kcpCtx.IDMTenant, retrievedKCP.IDMTenant)
 	assert.Equal(t, kcpCtx.OrganizationName, retrievedKCP.OrganizationName)
 
-	// Test getting KCP context from empty context
+	// Test getting kcp context from empty context
 	_, err = GetKCPContext(ctx)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "kcp user context not found in context")

--- a/services/iam-service/pkg/directive/authorized_test.go
+++ b/services/iam-service/pkg/directive/authorized_test.go
@@ -156,7 +156,7 @@ func TestAuthorized_HappyPath(t *testing.T) {
 	token := createTestWebToken()
 	ctx = context.WithValue(ctx, keys.WebTokenCtxKey, token)
 
-	// Setup KCP context
+	// Setup kcp context
 	kcpCtx := appcontext.KCPContext{
 		IDMTenant:        "test-tenant",
 		OrganizationName: "test-org",
@@ -215,7 +215,7 @@ func TestAuthorized_ErrorCases(t *testing.T) {
 			expectedError: "failed to get web token from context",
 		},
 		{
-			name: "missing KCP context",
+			name: "missing kcp context",
 			setupContext: func() context.Context {
 				ctx, _ := setupTestContext()
 				token := createTestWebToken()

--- a/services/iam-service/pkg/keycloak/service.go
+++ b/services/iam-service/pkg/keycloak/service.go
@@ -103,7 +103,7 @@ func (s *Service) UserByMail(ctx context.Context, userID string) (*graph.User, e
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
 		metrics.KeycloakRequests.WithLabelValues("user_by_mail", "error").Inc()
-		return nil, errors.Wrap(err, "failed to get KCP user context")
+		return nil, errors.Wrap(err, "failed to get kcp user context")
 	}
 
 	realm := kctx.IDMTenant
@@ -142,7 +142,7 @@ func (s *Service) GetUsers(ctx context.Context) ([]*graph.User, error) {
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
 		metrics.KeycloakRequests.WithLabelValues("get_users", "error").Inc()
-		return nil, errors.Wrap(err, "failed to get KCP user context")
+		return nil, errors.Wrap(err, "failed to get kcp user context")
 	}
 
 	realm := kctx.IDMTenant
@@ -231,7 +231,7 @@ func (s *Service) GetUsersByEmails(ctx context.Context, emails []string) (map[st
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
 		metrics.KeycloakRequests.WithLabelValues("get_users_by_emails", "error").Inc()
-		return nil, errors.Wrap(err, "failed to get KCP user context")
+		return nil, errors.Wrap(err, "failed to get kcp user context")
 	}
 
 	realm := kctx.IDMTenant

--- a/services/iam-service/pkg/keycloak/service_test.go
+++ b/services/iam-service/pkg/keycloak/service_test.go
@@ -485,7 +485,7 @@ func TestGetUsersByEmails_EmptySlice(t *testing.T) {
 }
 
 func TestGetUsersByEmails_NoKCPContext(t *testing.T) {
-	// Test missing KCP context
+	// Test missing kcp context
 	ctx := context.Background()
 	service := &Service{}
 
@@ -1041,7 +1041,7 @@ func TestGetUsers_Success(t *testing.T) {
 }
 
 func TestGetUsers_NoKCPContext(t *testing.T) {
-	// Test GetUsers without KCP context
+	// Test GetUsers without kcp context
 	ctx := context.Background()
 	service := &Service{}
 

--- a/services/iam-service/pkg/middleware/kcp/kcp.go
+++ b/services/iam-service/pkg/middleware/kcp/kcp.go
@@ -116,11 +116,11 @@ func checkToken(ctx context.Context, authHeader string, subdomain string, cfg *r
 	log := logger.LoadLoggerFromContext(ctx)
 	clusterUrl, err := url.Parse(cfg.Host)
 	if err != nil {
-		log.Error().Err(errors.WithStack(err)).Msg("Error parsing KCP host URL")
+		log.Error().Err(errors.WithStack(err)).Msg("Error parsing kcp host URL")
 	}
 
 	if clusterUrl == nil {
-		return false, errors.New("invalid KCP host URL")
+		return false, errors.New("invalid kcp host URL")
 	}
 
 	clusterPath := fmt.Sprintf("root:orgs:%s", subdomain)

--- a/services/iam-service/pkg/middleware/kcp/kcp_test.go
+++ b/services/iam-service/pkg/middleware/kcp/kcp_test.go
@@ -177,11 +177,11 @@ func TestCheckToken_InvalidURL(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, result)
-	assert.Contains(t, err.Error(), "invalid KCP host URL")
+	assert.Contains(t, err.Error(), "invalid kcp host URL")
 }
 
 func TestCheckToken_ValidURL(t *testing.T) {
-	// Create a mock HTTP server to simulate KCP API
+	// Create a mock HTTP server to simulate kcp API
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check the request path and authorization
 		expectedPath := "/clusters/root:orgs:test-org/version"
@@ -558,7 +558,7 @@ func TestSetKCPUserContext_IDMTenantSuccess(t *testing.T) {
 	}
 	log, _ := logger.New(logger.Config{Level: "debug"})
 
-	// Create a mock KCP server
+	// Create a mock kcp server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Simulate successful auth check
 		w.WriteHeader(http.StatusOK)
@@ -574,7 +574,7 @@ func TestSetKCPUserContext_IDMTenantSuccess(t *testing.T) {
 	middleware := New(restConfig, excludedTenants, mockTenantRetriever, log)
 	middlewareFunc := middleware.SetKCPUserContext()
 
-	// Handler that checks if KCP context was set correctly
+	// Handler that checks if kcp context was set correctly
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		kcpCtx, err := appcontext.GetKCPContext(r.Context())
 		assert.NoError(t, err)
@@ -669,7 +669,7 @@ func TestSetKCPUserContext_TokenCheckFailure(t *testing.T) {
 	mockTenantRetriever := &mockIDMTenantRetriever{}
 	log, _ := logger.New(logger.Config{Level: "debug"})
 
-	// Create a mock KCP server that returns unauthorized
+	// Create a mock kcp server that returns unauthorized
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -746,7 +746,7 @@ func TestSetKCPUserContext_SubdomainPatterns(t *testing.T) {
 	mockTenantRetriever := &mockIDMTenantRetriever{}
 	log, _ := logger.New(logger.Config{Level: "debug"})
 
-	// Create a mock KCP server
+	// Create a mock kcp server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/services/iam-service/pkg/workspace/client.go
+++ b/services/iam-service/pkg/workspace/client.go
@@ -27,12 +27,12 @@ import (
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 )
 
-// ClientFactory creates a client for a specific KCP workspace
+// ClientFactory creates a client for a specific kcp workspace
 type ClientFactory interface {
 	New(ctx context.Context, accountPath multicluster.ClusterName) (ctrlruntimeclient.Client, error)
 }
 
-// KCPClient implements ClientFactory for KCP workspaces
+// KCPClient implements ClientFactory for kcp workspaces
 type KCPClient struct {
 	mgr mcmanager.Manager
 }

--- a/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/discovery_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/discovery_test.go
@@ -35,13 +35,13 @@ func TestIsDiscoveryRequest(t *testing.T) {
 		{name: "api group", method: http.MethodGet, path: "/apis/apps", expected: true},
 		{name: "api group version", method: http.MethodGet, path: "/apis/apps/v1", expected: true},
 
-		// KCP paths: /services/{ws}/clusters/{cl}/...
+		// kcp paths: /services/{ws}/clusters/{cl}/...
 		{name: "kcp services api", method: http.MethodGet, path: "/services/ws/clusters/cl/api", expected: true},
 		{name: "kcp services api version", method: http.MethodGet, path: "/services/ws/clusters/cl/api/v1", expected: true},
 		{name: "kcp services apis group", method: http.MethodGet, path: "/services/ws/clusters/cl/apis/apps", expected: true},
 		{name: "kcp services apis group version", method: http.MethodGet, path: "/services/ws/clusters/cl/apis/apps/v1", expected: true},
 
-		// KCP paths: /clusters/{cl}/...
+		// kcp paths: /clusters/{cl}/...
 		{name: "kcp clusters api", method: http.MethodGet, path: "/clusters/cl/api", expected: true},
 		{name: "kcp clusters api version", method: http.MethodGet, path: "/clusters/cl/api/v1", expected: true},
 		{name: "kcp clusters apis group", method: http.MethodGet, path: "/clusters/cl/apis/apps", expected: true},

--- a/services/kubernetes-graphql-gateway/listener/controllers/resource/resource_controller.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/resource/resource_controller.go
@@ -153,7 +153,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 		}
 	}
 
-	// This is plugable function to get cluster metadata for the given cluster name.
+	// This is pluggable function to get cluster metadata for the given cluster name.
 	var metadata *pmgatewayv1alpha1.ClusterMetadata
 	if r.clusterMetadataFunc != nil {
 		var err error

--- a/services/kubernetes-graphql-gateway/listener/controllers/resource/resource_controller_test.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/resource/resource_controller_test.go
@@ -93,7 +93,7 @@ func (suite *ResourceControllerTestSuite) SetupSuite() {
 		listenerConfig.SchemaHandler,
 		listenerConfig.Options.AnchorResource,
 		listenerConfig.Options.ResourceGVR,
-		listenerConfig.Options.AdditonalPathAnnotationKey,
+		listenerConfig.Options.AdditionalPathAnnotationKey,
 		listenerConfig.Options.ClusterMetadataFunc,
 		listenerConfig.Options.ClusterURLResolverFunc,
 	)

--- a/services/kubernetes-graphql-gateway/listener/options/options.go
+++ b/services/kubernetes-graphql-gateway/listener/options/options.go
@@ -74,7 +74,7 @@ type ExtraOptions struct {
 	// GRPCMaxSendMsgSize is the maximum gRPC message size in bytes the server will send.
 	GRPCMaxSendMsgSize int
 
-	AdditonalPathAnnotationKey string
+	AdditionalPathAnnotationKey string
 
 	// CacheNamespaces restricts the cache to these namespaces for namespaced resources.
 	// Cluster-scoped resources are unaffected.
@@ -157,7 +157,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.AnchorResource, "anchor-resource", options.AnchorResource, "Resource to watch as anchor for kubernetes provider (default: default)")
 	fs.StringVar(&options.ResourceGVR, "reconciler-gvr", options.ResourceGVR, "The GroupVersionResource which the reconciler will be watching (default: namespaces.v1)")
 
-	fs.StringVar(&options.AdditonalPathAnnotationKey, "additional-path-annotation-key", options.AdditonalPathAnnotationKey, "additional path annotation key for workspace schema generation")
+	fs.StringVar(&options.AdditionalPathAnnotationKey, "additional-path-annotation-key", options.AdditionalPathAnnotationKey, "additional path annotation key for workspace schema generation")
 
 	fs.StringSliceVar(&options.CacheNamespaces, "cache-namespaces", options.CacheNamespaces, "Namespaces to restrict the cache to for namespaced resources (e.g. secrets, configmaps). Cluster-scoped resources are unaffected. When empty, all namespaces are cached")
 

--- a/services/kubernetes-graphql-gateway/listener/server.go
+++ b/services/kubernetes-graphql-gateway/listener/server.go
@@ -61,7 +61,7 @@ func NewServer(ctx context.Context, c *Config) (*Server, error) {
 			s.Config.SchemaHandler,
 			c.Options.AnchorResource,
 			c.Options.ResourceGVR,
-			c.Options.AdditonalPathAnnotationKey,
+			c.Options.AdditionalPathAnnotationKey,
 			c.Options.ClusterMetadataFunc,
 			c.Options.ClusterURLResolverFunc,
 		)

--- a/services/rebac-authz-webhook/README.md
+++ b/services/rebac-authz-webhook/README.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-The Platform Mesh IAM Authorizaton Webhook is a kubernetes authorization webhook that uses openFGA to answer authorization requests from kubernetes.
+The Platform Mesh IAM Authorization Webhook is a kubernetes authorization webhook that uses openFGA to answer authorization requests from kubernetes.
 
 ## kcp Configuration
 

--- a/services/rebac-authz-webhook/cmd/serve.go
+++ b/services/rebac-authz-webhook/cmd/serve.go
@@ -74,7 +74,7 @@ func NewServeCmd() *cobra.Command {
 				klog.Exit(err, "unable to construct cluster provider")
 			}
 
-			// Use Root KCP config for manager
+			// Use Root kcp config for manager
 			mgr, err := mcmanager.New(restCfg, provider, mcmanager.Options{
 				Scheme: scheme,
 				Logger: klog.NewKlogr(),

--- a/services/rebac-authz-webhook/pkg/config/config.go
+++ b/services/rebac-authz-webhook/pkg/config/config.go
@@ -77,5 +77,5 @@ func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&cfg.Webhook.CacheMissTTL, "webhook-cache-miss-ttl", cfg.Webhook.CacheMissTTL, "Duration after which cache miss count resets for a cluster")
 	fs.DurationVar(&cfg.Webhook.CacheMissCleanupInterval, "webhook-cache-miss-cleanup-interval", cfg.Webhook.CacheMissCleanupInterval, "Interval at which cache miss keys are checked for expiration")
 	fs.DurationVar(&cfg.Webhook.CacheMissRetryAfter, "webhook-cache-miss-retry-after", cfg.Webhook.CacheMissRetryAfter, "Delay before retrying on cache miss")
-	fs.StringVar(&cfg.APIExportEndpointSliceName, "kcp-api-export-endpoint-slice-name", cfg.APIExportEndpointSliceName, "Set the KCP API export endpoint slice name")
+	fs.StringVar(&cfg.APIExportEndpointSliceName, "kcp-api-export-endpoint-slice-name", cfg.APIExportEndpointSliceName, "Set the kcp API export endpoint slice name")
 }

--- a/services/search-service/internal/clients/kcp/access_validator.go
+++ b/services/search-service/internal/clients/kcp/access_validator.go
@@ -44,12 +44,12 @@ func NewOrgAccessValidator(restCfg *rest.Config, log *logger.Logger) (*OrgAccess
 
 	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("create KCP HTTP client: %w", err)
+		return nil, fmt.Errorf("create kcp HTTP client: %w", err)
 	}
 
 	baseURL, err := url.Parse(cfg.Host)
 	if err != nil {
-		return nil, fmt.Errorf("parse KCP host URL: %w", err)
+		return nil, fmt.Errorf("parse kcp host URL: %w", err)
 	}
 	baseURL.Path = ""
 
@@ -62,7 +62,7 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)
 	if err != nil {
-		return false, fmt.Errorf("create KCP auth request: %w", err)
+		return false, fmt.Errorf("create kcp auth request: %w", err)
 	}
 	req.Header.Set("Authorization", authHeader)
 
@@ -72,8 +72,8 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 			Err(err).
 			Str("organization", org).
 			Str("clusterPath", clusterPath).
-			Msg("KCP org token validation request failed")
-		return false, fmt.Errorf("execute KCP auth request: %w", err)
+			Msg("kcp org token validation request failed")
+		return false, fmt.Errorf("execute kcp auth request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -85,7 +85,7 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 			Str("organization", org).
 			Str("clusterPath", clusterPath).
 			Int("statusCode", resp.StatusCode).
-			Msg("KCP org token validation denied request")
+			Msg("kcp org token validation denied request")
 		return false, nil
 	default:
 		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
@@ -97,7 +97,7 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 		if bodySnippet != "" {
 			logEvt = logEvt.Str("responseBody", bodySnippet)
 		}
-		logEvt.Msg("KCP org token validation returned unexpected status")
+		logEvt.Msg("kcp org token validation returned unexpected status")
 
 		if strings.HasPrefix(fmt.Sprintf("%d", resp.StatusCode), "5") {
 			return false, fmt.Errorf("kcp auth check failed with status %d", resp.StatusCode)

--- a/services/search-service/internal/clients/kcp/searchindex_resolver.go
+++ b/services/search-service/internal/clients/kcp/searchindex_resolver.go
@@ -47,12 +47,12 @@ const searchIndexOrgClusterIDLabel = "search.platform-mesh.io/org-cluster-id"
 func NewSearchIndexResolver(restCfg *rest.Config, cfg config.SearchIndexConfig, log *logger.Logger) (*SearchIndexResolver, error) {
 	scopedCfg, err := configForKCPCluster(cfg.WorkspacePath, restCfg)
 	if err != nil {
-		return nil, fmt.Errorf("create KCP workspace config: %w", err)
+		return nil, fmt.Errorf("create kcp workspace config: %w", err)
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(scopedCfg)
 	if err != nil {
-		return nil, fmt.Errorf("create KCP dynamic client: %w", err)
+		return nil, fmt.Errorf("create kcp dynamic client: %w", err)
 	}
 
 	return &SearchIndexResolver{

--- a/services/virtual-workspaces/pkg/contentconfiguration/server.go
+++ b/services/virtual-workspaces/pkg/contentconfiguration/server.go
@@ -95,7 +95,7 @@ func BuildVirtualWorkspace(
 					return nil, err
 				}
 
-				storeageProvider := storage.CreateStorageProviderFunc(
+				storageProvider := storage.CreateStorageProviderFunc(
 					dynamicClient,
 					storage.ContentConfigurationLookup(dynamicClient, cfg, providerWSCluster.Name.String()),
 				)
@@ -106,7 +106,7 @@ func BuildVirtualWorkspace(
 					Resource: "contentconfigurations",
 				}
 
-				return apidefinition.NewSingleResourceProvider(mainConfig, gvr, &resourceSchema, storeageProvider), nil
+				return apidefinition.NewSingleResourceProvider(mainConfig, gvr, &resourceSchema, storageProvider), nil
 			},
 		},
 	}

--- a/services/virtual-workspaces/pkg/marketplace/server.go
+++ b/services/virtual-workspaces/pkg/marketplace/server.go
@@ -84,7 +84,7 @@ func BuildVirtualWorkspace(
 
 				marketplaceFilter := storage.Marketplace(provider, cfg)
 
-				storeageProvider := storage.CreateStorageProviderFunc(
+				storageProvider := storage.CreateStorageProviderFunc(
 					dynamicClient,
 					marketplaceFilter,
 				)
@@ -95,7 +95,7 @@ func BuildVirtualWorkspace(
 					Resource: resourceSchema.Spec.Names.Plural,
 				}
 
-				return apidefinition.NewSingleResourceProvider(mainConfig, gvr, &resourceSchema, storeageProvider), nil
+				return apidefinition.NewSingleResourceProvider(mainConfig, gvr, &resourceSchema, storageProvider), nil
 			},
 		},
 	}

--- a/subroutines/lifecycle/lifecycle.go
+++ b/subroutines/lifecycle/lifecycle.go
@@ -367,7 +367,7 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		patchErr := l.patchChanges(ctx, cl, original, obj)
 		if patchErr != nil {
 			if apierrors.IsConflict(patchErr) {
-				logger.V(1).Info("conflict during patch, requeueing")
+				logger.V(1).Info("conflict during patch, requeuing")
 				return reconcile.Result{RequeueAfter: time.Second}, nil
 			}
 			return reconcile.Result{}, errors.Join(subroutineErr, patchErr)


### PR DESCRIPTION
This ran `typos` across the codebase, fixing most everything (a few identifiers with typos were left to keep compatibility)

I also took the liberty to replace all uppercase'd kcp with their lowercase equivalent.