### PR TITLE
Add the OpenSSF Best Practices badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 # Platform Mesh
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/platform-mesh/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/platform-mesh)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12932/badge)](https://www.bestpractices.dev/projects/12932)
 [![REUSE status](https://api.reuse.software/badge/github.com/platform-mesh/platform-mesh)](https://api.reuse.software/info/github.com/platform-mesh/platform-mesh)
 
 ## Description


### PR DESCRIPTION
Add the OpenSSF Best Practices badge to `README.md`. The badge was previously added in the `ocm` repository, however that repository is not used any longer and it got archived.

A request for URL change on the badge has been requested so it points to this repository instead of `ocm`: https://github.com/ossf/best-practices-badge/issues/2861