### PR TITLE
Enable more linters globally again

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,8 @@ run:
 linters:
   default: none
   enable:
+    - asciicheck
+    - bidichk
     - copyloopvar
     - dupword
     - durationcheck
@@ -39,6 +41,7 @@ linters:
     - nakedret
     - nilerr
     - nolintlint
+    - nosprintfhostport
     - prealloc
     - predeclared
     - revive
@@ -46,6 +49,7 @@ linters:
     - unconvert
     - unused
     - usestdlibvars
+    - wastedassign
     - whitespace
   settings:
     importas:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,6 +74,7 @@ linters:
           alias: ctrlruntimeclient
       no-unaliased: true
     revive:
+      enable-default-rules: true
       rules:
         - name: var-naming
           disabled: true
@@ -82,6 +83,10 @@ linters:
         - name: package-comments
           disabled: true
         - name: blank-imports
+          disabled: true
+        - name: unused-parameter
+          disabled: true
+        - name: unexported-return
           disabled: true
     govet:
       enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,6 +83,11 @@ linters:
           disabled: true
         - name: blank-imports
           disabled: true
+    govet:
+      enable:
+        - nilness # find tautologies / impossible conditions
+        - sortslice # check the argument type of sort.Slice
+        - unusedwrite # checks for unused writes
     paths:
       - third_party$
       - builtin$

--- a/golang-commons/context/service_context_test.go
+++ b/golang-commons/context/service_context_test.go
@@ -115,10 +115,9 @@ func TestAddAndGetAuthHeaderToContext(t *testing.T) {
 			if test.expectError {
 				assert.Error(t, err)
 				return
-			} else {
-				assert.NoError(t, err)
 			}
 
+			assert.NoError(t, err)
 			assert.Equal(t, test.authHeader, val)
 		})
 	}

--- a/golang-commons/controller/testSupport/testApiObjects.go
+++ b/golang-commons/controller/testSupport/testApiObjects.go
@@ -42,6 +42,7 @@ func (t *TestApiObject) DeepCopyObject() runtime.Object {
 	}
 	return nil
 }
+
 func (t *TestApiObject) DeepCopy() *TestApiObject {
 	if t == nil {
 		return nil
@@ -50,10 +51,11 @@ func (t *TestApiObject) DeepCopy() *TestApiObject {
 	t.DeepCopyInto(out)
 	return out
 }
-func (m *TestApiObject) DeepCopyInto(out *TestApiObject) {
-	*out = *m
-	out.TypeMeta = m.TypeMeta
-	m.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+
+func (t *TestApiObject) DeepCopyInto(out *TestApiObject) {
+	*out = *t
+	out.TypeMeta = t.TypeMeta
+	t.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 }
 
 type TestNoStatusApiObject struct {
@@ -75,8 +77,8 @@ func (t *TestNoStatusApiObject) DeepCopy() *TestNoStatusApiObject {
 	t.DeepCopyInto(out)
 	return out
 }
-func (m *TestNoStatusApiObject) DeepCopyInto(out *TestNoStatusApiObject) {
-	*out = *m
-	out.TypeMeta = m.TypeMeta
-	m.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+func (t *TestNoStatusApiObject) DeepCopyInto(out *TestNoStatusApiObject) {
+	*out = *t
+	out.TypeMeta = t.TypeMeta
+	t.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 }

--- a/golang-commons/controller/testSupport/testSupport.go
+++ b/golang-commons/controller/testSupport/testSupport.go
@@ -187,7 +187,7 @@ func (f FailureScenarioSubroutine) Finalizers(instance runtimeobject.RuntimeObje
 	return []string{FailureScenarioSubroutineFinalizer}
 }
 
-func (c FailureScenarioSubroutine) GetName() string {
+func (f FailureScenarioSubroutine) GetName() string {
 	return "FailureScenarioSubroutine"
 }
 
@@ -223,21 +223,21 @@ type ContextValueSubroutine struct {
 
 const ContextValueKey = keys.ContextKey("ContextValueKey")
 
-func (f ContextValueSubroutine) Process(ctx context.Context, r runtimeobject.RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
+func (ContextValueSubroutine) Process(ctx context.Context, r runtimeobject.RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
 	if instance, ok := r.(*TestApiObject); ok {
 		instance.Status.Some = ctx.Value(ContextValueKey).(string)
 	}
 	return controllerruntime.Result{}, nil
 }
 
-func (f ContextValueSubroutine) Finalize(_ context.Context, _ runtimeobject.RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
+func (ContextValueSubroutine) Finalize(_ context.Context, _ runtimeobject.RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
 	return controllerruntime.Result{}, nil
 }
 
-func (f ContextValueSubroutine) Finalizers(instance runtimeobject.RuntimeObject) []string {
+func (ContextValueSubroutine) Finalizers(instance runtimeobject.RuntimeObject) []string {
 	return []string{}
 }
 
-func (c ContextValueSubroutine) GetName() string {
+func (ContextValueSubroutine) GetName() string {
 	return "ContextValueSubroutine"
 }

--- a/golang-commons/errors/errors.go
+++ b/golang-commons/errors/errors.go
@@ -53,7 +53,7 @@ func Sentinel(msg string, args ...any) error {
 // interpolating of message parameters. Use this when you want the stack trace to start at
 // the place you create the error.
 func New(msg string, args ...any) error {
-	return PopStack(errors.New(fmt.Sprintf(msg, args...)))
+	return PopStack(fmt.Errorf(msg, args...))
 }
 
 // EnsureStack checks if error has a stack, if not adds stack information, otherwise leaves the error unmodified.

--- a/golang-commons/errors/errors.go
+++ b/golang-commons/errors/errors.go
@@ -53,7 +53,8 @@ func Sentinel(msg string, args ...any) error {
 // interpolating of message parameters. Use this when you want the stack trace to start at
 // the place you create the error.
 func New(msg string, args ...any) error {
-	return PopStack(fmt.Errorf(msg, args...))
+	//nolint:revive // due to the way we unwrap the stacktrace in PopStack(), we have to use errors.New() instead of fmt.Errorf
+	return PopStack(errors.New(fmt.Sprintf(msg, args...)))
 }
 
 // EnsureStack checks if error has a stack, if not adds stack information, otherwise leaves the error unmodified.

--- a/golang-commons/jwt/spiffe.go
+++ b/golang-commons/jwt/spiffe.go
@@ -30,6 +30,7 @@ func GetSpiffeUrlValue(header http.Header) *string {
 	if len(uriVal) > 0 {
 		return &uriVal
 	}
+
 	return nil
 }
 
@@ -37,7 +38,7 @@ func GetURIValue(headerVal string) string {
 	match := spiffeUriReg.FindSubmatch([]byte(headerVal))
 	if len(match) == 2 {
 		return string(match[1])
-	} else {
-		return ""
 	}
+
+	return ""
 }

--- a/golang-commons/traces/otel_test.go
+++ b/golang-commons/traces/otel_test.go
@@ -134,8 +134,6 @@ func TestInitProvider_HappyPath(t *testing.T) {
 
 func TestInitProvider_GRPCClientError(t *testing.T) {
 	cfg := Config{
-		ServiceName:       "fail-service",
-		ServiceVersion:    "1.0.0",
 		CollectorEndpoint: "invalid:endpoint",
 	}
 

--- a/operators/extension-manager-operator/pkg/validation/validate.go
+++ b/operators/extension-manager-operator/pkg/validation/validate.go
@@ -88,9 +88,9 @@ func (cC *contentConfiguration) Validate(input []byte, contentType string) (stri
 	merr := validateSchemaBytes(cC.schema, rawJSON)
 	if merr.Len() == 0 {
 		return string(rawJSON), merr
-	} else {
-		return "", merr
 	}
+
+	return "", merr
 }
 
 func validateSchemaBytes(schema []byte, input []byte) *multierror.Error {

--- a/operators/extension-manager-operator/pkg/validation/validate_test.go
+++ b/operators/extension-manager-operator/pkg/validation/validate_test.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"encoding/json"
 	"log"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
@@ -426,26 +427,16 @@ func getJSONSchemaFixture() []byte {
 
 func TestWithSchema(t *testing.T) {
 	cC := NewContentConfiguration()
-	empty := ""
-	err := cC.WithSchema([]byte(empty))
+	err := cC.WithSchema([]byte(""))
 	assert.Error(t, err)
 }
 
 func allErrorsContained(merr multierror.Error, expectedErrors []string) bool {
 	for _, err := range merr.Errors {
-		found := false
-		errStr := ""
-		expectedError := ""
-		for _, expectedError = range expectedErrors {
-			errStr = err.Error()
-			if errStr == expectedError {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(expectedErrors, err.Error()) {
 			return false
 		}
 	}
+
 	return true
 }

--- a/operators/search-operator/internal/subroutine/apibinding_watcher.go
+++ b/operators/search-operator/internal/subroutine/apibinding_watcher.go
@@ -53,7 +53,7 @@ type apiBindingWatcherSubroutine struct {
 // NewAPIBindingWatcherSubroutine creates a new APIBinding watcher subroutine.
 // orgsClient must be scoped to the root:orgs workspace.
 // localCfg must be the admin kcp REST config.
-func NewAPIBindingWatcherSubroutine(mgr mcmanager.Manager, orgsClient ctrlruntimeclient.Client, localCfg *rest.Config, indexPrefix string) (*apiBindingWatcherSubroutine, error) {
+func NewAPIBindingWatcherSubroutine(mgr mcmanager.Manager, orgsClient ctrlruntimeclient.Client, localCfg *rest.Config, indexPrefix string) (lifecyclesubroutine.Subroutine, error) {
 	rootCfg, err := stripPathFromConfig(localCfg)
 	if err != nil {
 		return nil, err

--- a/operators/security-operator/cmd/initializer.go
+++ b/operators/security-operator/cmd/initializer.go
@@ -133,9 +133,9 @@ var initializerCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 		fgaClient := openfgav1.NewOpenFGAServiceClient(conn)
 		storeIDGetter := fga.NewCachingStoreIDGetter(
+			cmd.Context(),
 			fgaClient,
 			initializerCfg.FGA.StoreIDCacheTTL,
-			cmd.Context(),
 			log,
 		)
 

--- a/operators/security-operator/cmd/operator.go
+++ b/operators/security-operator/cmd/operator.go
@@ -152,9 +152,9 @@ var operatorCmd = &cobra.Command{
 
 		fga := openfgav1.NewOpenFGAServiceClient(conn)
 		storeIDGetter := fga2.NewCachingStoreIDGetter(
+			ctx,
 			fga,
 			operatorCfg.FGA.StoreIDCacheTTL,
-			ctx,
 			log,
 		)
 

--- a/operators/security-operator/cmd/system.go
+++ b/operators/security-operator/cmd/system.go
@@ -121,9 +121,9 @@ var systemCmd = &cobra.Command{
 		fgaClient := openfgav1.NewOpenFGAServiceClient(conn)
 
 		storeIDGetter := fga.NewCachingStoreIDGetter(
+			ctx,
 			fgaClient,
 			systemCfg.FGA.StoreIDCacheTTL,
-			ctx,
 			log,
 		)
 

--- a/operators/security-operator/cmd/terminator.go
+++ b/operators/security-operator/cmd/terminator.go
@@ -97,9 +97,9 @@ var terminatorCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 		fgaClient := openfgav1.NewOpenFGAServiceClient(conn)
 		storeIDGetter := fga.NewCachingStoreIDGetter(
+			cmd.Context(),
 			fgaClient,
 			terminatorCfg.FGA.StoreIDCacheTTL,
-			cmd.Context(),
 			log,
 		)
 		kcpClientGetter := iclient.NewConfigSchemeKCPClientGetter(mgr.GetLocalManager().GetConfig(), mgr.GetLocalManager().GetScheme())

--- a/operators/security-operator/internal/config/config.go
+++ b/operators/security-operator/internal/config/config.go
@@ -199,12 +199,12 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Webhooks.CertDir, "webhooks-cert-dir", c.Webhooks.CertDir, "Set webhook certificate directory")
 }
 
-func (config Config) InitializerName() string {
-	return config.WorkspacePath + ":" + config.WorkspaceTypeName
+func (c Config) InitializerName() string {
+	return c.WorkspacePath + ":" + c.WorkspaceTypeName
 }
 
-func (config Config) TerminatorName() string {
-	return config.WorkspacePath + ":" + config.WorkspaceTypeName
+func (c Config) TerminatorName() string {
+	return c.WorkspacePath + ":" + c.WorkspaceTypeName
 }
 
 // MultiProviderName returns a cluster name with provider prefix and separator for multi provider.

--- a/operators/security-operator/internal/fga/storeid_getter.go
+++ b/operators/security-operator/internal/fga/storeid_getter.go
@@ -41,7 +41,7 @@ type CachingStoreIDGetter struct {
 	logger *logger.Logger
 }
 
-func NewCachingStoreIDGetter(fga openfgav1.OpenFGAServiceClient, ttl time.Duration, loadCtx context.Context, log *logger.Logger) *CachingStoreIDGetter {
+func NewCachingStoreIDGetter(loadCtx context.Context, fga openfgav1.OpenFGAServiceClient, ttl time.Duration, log *logger.Logger) *CachingStoreIDGetter {
 	loader := &storeIDLoader{fga: fga, loadCtx: loadCtx}
 
 	cache := ttlcache.New(

--- a/operators/security-operator/internal/fga/storeid_getter_test.go
+++ b/operators/security-operator/internal/fga/storeid_getter_test.go
@@ -41,7 +41,7 @@ func TestCachingStoreIDGetter_Get(t *testing.T) {
 		}, nil).Once()
 
 		log := testlogger.New()
-		getter := NewCachingStoreIDGetter(client, 5*time.Minute, context.Background(), log.Logger)
+		getter := NewCachingStoreIDGetter(context.Background(), client, 5*time.Minute, log.Logger)
 
 		id, err := getter.Get(context.Background(), "foo")
 		require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestCachingStoreIDGetter_Get(t *testing.T) {
 
 		loadCtx := context.Background()
 		log := testlogger.New()
-		getter := NewCachingStoreIDGetter(client, 5*time.Minute, loadCtx, log.Logger)
+		getter := NewCachingStoreIDGetter(loadCtx, client, 5*time.Minute, log.Logger)
 
 		id1, err := getter.Get(context.Background(), "foo")
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestCachingStoreIDGetter_Get(t *testing.T) {
 
 		loadCtx := context.Background()
 		log := testlogger.New()
-		getter := NewCachingStoreIDGetter(client, 5*time.Minute, loadCtx, log.Logger)
+		getter := NewCachingStoreIDGetter(loadCtx, client, 5*time.Minute, log.Logger)
 
 		id, err := getter.Get(context.Background(), "missing-store")
 		assert.Error(t, err)
@@ -95,7 +95,7 @@ func TestCachingStoreIDGetter_Get(t *testing.T) {
 
 		loadCtx := context.Background()
 		log := testlogger.New()
-		getter := NewCachingStoreIDGetter(client, 5*time.Minute, loadCtx, log.Logger)
+		getter := NewCachingStoreIDGetter(loadCtx, client, 5*time.Minute, log.Logger)
 
 		id, err := getter.Get(context.Background(), "foo")
 		assert.Error(t, err)

--- a/services/iam-service/cmd/server.go
+++ b/services/iam-service/cmd/server.go
@@ -69,7 +69,7 @@ var serverCmd = &cobra.Command{
 
 		mgr := setupManager(ctx, log)
 		router := setupRouter(ctx, mgr, setupFGAClient())
-		start(serviceCfg, router, ctx, log, defaultCfg.IsLocal)
+		start(ctx, serviceCfg, router, log, defaultCfg.IsLocal)
 	},
 }
 
@@ -192,7 +192,7 @@ func setupManager(ctx context.Context, log *logger.Logger) mcmanager.Manager {
 	return mgr
 }
 
-func start(serviceCfg *config.ServiceConfig, router *chi.Mux, ctx context.Context, log *logger.Logger, isLocal bool) {
+func start(ctx context.Context, serviceCfg *config.ServiceConfig, router *chi.Mux, log *logger.Logger, isLocal bool) {
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", serviceCfg.Port),
 		Handler:      router,

--- a/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/bearer.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/bearer.go
@@ -42,7 +42,7 @@ func NewBearerHandler(baseRT, unauthorizedRT http.RoundTripper) *BearerHandler {
 }
 
 // RoundTrip implements union.Handler.
-func (h *BearerHandler) RoundTrip(req *http.Request) (*http.Response, error, bool) {
+func (h *BearerHandler) RoundTrip(req *http.Request) (*http.Response, bool, error) {
 	ctx := req.Context()
 	logger := log.FromContext(ctx)
 
@@ -50,7 +50,7 @@ func (h *BearerHandler) RoundTrip(req *http.Request) (*http.Response, error, boo
 	if !ok || token == "" {
 		logger.V(4).WithValues("path", req.URL.Path).Error(nil, "No token found for resource request, denying")
 		resp, err := h.unauthorizedRT.RoundTrip(req)
-		return resp, err, true
+		return resp, true, err
 	}
 
 	req = utilnet.CloneRequest(req)
@@ -58,5 +58,5 @@ func (h *BearerHandler) RoundTrip(req *http.Request) (*http.Response, error, boo
 
 	logger.V(4).WithValues("path", req.URL.Path).Info("Using bearer token authentication")
 	resp, err := h.baseRT.RoundTrip(req)
-	return resp, err, true
+	return resp, true, err
 }

--- a/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/discovery.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/discovery.go
@@ -34,16 +34,16 @@ func NewDiscoveryHandler(adminRT http.RoundTripper) *DiscoveryHandler {
 }
 
 // RoundTrip implements union.Handler.
-func (h *DiscoveryHandler) RoundTrip(req *http.Request) (*http.Response, error, bool) {
+func (h *DiscoveryHandler) RoundTrip(req *http.Request) (*http.Response, bool, error) {
 	if !isDiscoveryRequest(req) {
-		return nil, nil, false
+		return nil, false, nil
 	}
 
 	logger := log.FromContext(req.Context())
 	logger.V(4).WithValues("path", req.URL.Path).Info("Discovery request detected, allowing with admin credentials")
 
 	resp, err := h.adminRT.RoundTrip(req)
-	return resp, err, true
+	return resp, true, err
 }
 
 func isDiscoveryRequest(req *http.Request) bool {

--- a/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/union/union.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/roundtripper/union/union.go
@@ -23,7 +23,7 @@ import (
 
 // Handler processes HTTP requests and indicates whether it handled the request.
 type Handler interface {
-	RoundTrip(req *http.Request) (resp *http.Response, err error, handled bool)
+	RoundTrip(req *http.Request) (resp *http.Response, handled bool, err error)
 }
 
 type roundTripperUnion struct {
@@ -32,7 +32,7 @@ type roundTripperUnion struct {
 
 func (u *roundTripperUnion) RoundTrip(req *http.Request) (*http.Response, error) {
 	for _, h := range u.handlers {
-		resp, err, handled := h.RoundTrip(req)
+		resp, handled, err := h.RoundTrip(req)
 		if handled {
 			return resp, err
 		}
@@ -56,6 +56,6 @@ type singleHandler struct {
 }
 
 func (s *singleHandler) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err, _ := s.h.RoundTrip(req)
+	resp, _, err := s.h.RoundTrip(req)
 	return resp, err
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
@@ -376,7 +376,7 @@ func TestRunWatch_ContextCancellation_StopsRetryLoop(t *testing.T) {
 	case _, ok := <-resultChannel:
 		if ok {
 			// Drain remaining
-			for range resultChannel {
+			for range resultChannel { //nolint:revive // will be potentially fixed by https://github.com/mgechev/revive/pull/1710
 			}
 		}
 	}


### PR DESCRIPTION
This does what the label says, adding more linters. All of these are, in this configuration at least, pretty harmless. One could go full-revive but this would cause a lot of minor changes throughout the repo, IMHO not really super duper worth it.