### PR TITLE
update kcp apigen to 0.31.1

### DIFF
--- a/tools/Taskfile.yaml
+++ b/tools/Taskfile.yaml
@@ -43,7 +43,7 @@ vars:
   GO_TEST_COVERAGE_VERSION: v2.18.8
   MOCKERY_VERSION: v3.7.0
   OAPI_VERSION: v2.7.1
-  KCP_APIGEN_VERSION: v0.30.1
+  KCP_APIGEN_VERSION: v0.31.1
   # kcp release used by the operators' envtest suites (see component test-e2e).
   KCP_VERSION: 0.31.1
 


### PR DESCRIPTION
Just to make sure the apigen version is aligned with the kcp version.