### PR TITLE
Guard between race when multiple providers are at play

### DIFF
--- a/operators/security-operator/internal/subroutine/idp/subroutine.go
+++ b/operators/security-operator/internal/subroutine/idp/subroutine.go
@@ -18,6 +18,7 @@ package idp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -40,7 +41,27 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 )
+
+// clusterNotReadyRequeue is how long to wait before retrying when the
+// logical cluster has not yet been engaged by the multicluster provider. This
+// is an expected transient condition during operator startup, before the
+// provider has finished engaging all clusters.
+const clusterNotReadyRequeue = 5 * time.Second
+
+// pendingIfClusterNotReady converts a transient "cluster not yet engaged by
+// the multicluster provider" error into a Pending result, so the object is
+// retried without being marked as failed. It returns ok=false for any other
+// error (or nil), in which case the caller should surface the original result.
+func pendingIfClusterNotReady(ctx context.Context, err error) (subroutines.Result, bool) {
+	if err == nil || !errors.Is(err, multicluster.ErrClusterNotFound) {
+		return subroutines.OK(), false
+	}
+	logger.LoadLoggerFromContext(ctx).Info().Err(err).
+		Msg("cluster not engaged by multicluster provider yet, requeueing")
+	return subroutines.Pending(clusterNotReadyRequeue, "waiting for cluster to be engaged by the multicluster provider"), true
+}
 
 type subroutine struct {
 	keycloakBaseURL string
@@ -91,6 +112,14 @@ func (s *subroutine) newOIDCClient(realmName string) (clientreg.Client, *keycloa
 }
 
 func (s *subroutine) Finalize(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	result, err := s.finalize(ctx, obj)
+	if res, ok := pendingIfClusterNotReady(ctx, err); ok {
+		return res, nil
+	}
+	return result, err
+}
+
+func (s *subroutine) finalize(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
 	idpToDelete := obj.(*pmcorev1alpha1.IdentityProviderConfiguration)
 	log := logger.LoadLoggerFromContext(ctx)
 	realmName := idpToDelete.Name
@@ -154,6 +183,14 @@ func (s *subroutine) Finalizers(_ ctrlruntimeclient.Object) []string {
 func (s *subroutine) GetName() string { return "IdentityProviderConfiguration" }
 
 func (s *subroutine) Process(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	result, err := s.process(ctx, obj)
+	if res, ok := pendingIfClusterNotReady(ctx, err); ok {
+		return res, nil
+	}
+	return result, err
+}
+
+func (s *subroutine) process(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
 	idpConfig := obj.(*pmcorev1alpha1.IdentityProviderConfiguration)
 	log := logger.LoadLoggerFromContext(ctx)
 


### PR DESCRIPTION
On operator startup, the IDP reconciler can run before the multicluster provider has finished engaging the `root:orgs` cluster. When that happens, fetching the orgs client fails with cluster not found, the reconcile is marked as a `hard Error`, and the object gets stuck — its status stays `Ready=False` and it never recovers on its own:

```
failed to process client bob: failed to get registration access token from secret:
getting orgs client: getting cluster: cluster with name root:orgs not found: cluster not found
```
Fix:

Treat "cluster not yet engaged by the multicluster provider" as a transient condition instead of a failure. When `multicluster.ErrClusterNotFound` is detected, the subroutine now returns a `Pending` result that requeues, so the object self-heals once the provider finishes engaging the cluster — no error spam, no `stuck Error` state. Any other error is still surfaced as before.


Just to be honest: This is not an ideal fix. The root cause of this is that we are acting on 2 apiexportendpointslices and somehow merging the state. So we get a race between 2 providers. If this will not help - we need to rewamp bigger part in how security-operator is built