### PR TITLE
begin reducing ctrlruntime dependencies in the APIs

### DIFF
--- a/apis/backup/v1alpha1/groupversion_info.go
+++ b/apis/backup/v1alpha1/groupversion_info.go
@@ -20,17 +20,33 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+const (
+	GroupName    = "backup.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "backup.platform-mesh.io", Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&PlatformBackup{},
+		&PlatformBackupList{},
+		&PlatformRestore{},
+		&PlatformRestoreList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/backup/v1alpha1/platformbackup_types.go
+++ b/apis/backup/v1alpha1/platformbackup_types.go
@@ -132,10 +132,6 @@ type PlatformBackupList struct {
 	Items           []PlatformBackup `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&PlatformBackup{}, &PlatformBackupList{})
-}
-
 func (b *PlatformBackup) GetConditions() []metav1.Condition  { return b.Status.Conditions }
 func (b *PlatformBackup) SetConditions(c []metav1.Condition) { b.Status.Conditions = c }
 func (b *PlatformBackup) GetObservedGeneration() int64       { return b.Status.ObservedGeneration }

--- a/apis/backup/v1alpha1/platformrestore_types.go
+++ b/apis/backup/v1alpha1/platformrestore_types.go
@@ -100,10 +100,6 @@ type PlatformRestoreList struct {
 	Items           []PlatformRestore `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&PlatformRestore{}, &PlatformRestoreList{})
-}
-
 func (r *PlatformRestore) GetConditions() []metav1.Condition  { return r.Status.Conditions }
 func (r *PlatformRestore) SetConditions(c []metav1.Condition) { r.Status.Conditions = c }
 func (r *PlatformRestore) GetObservedGeneration() int64       { return r.Status.ObservedGeneration }

--- a/apis/core/v1alpha1/account_info_types.go
+++ b/apis/core/v1alpha1/account_info_types.go
@@ -87,7 +87,3 @@ type AccountInfoList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AccountInfo `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&AccountInfo{}, &AccountInfoList{})
-}

--- a/apis/core/v1alpha1/account_types.go
+++ b/apis/core/v1alpha1/account_types.go
@@ -92,10 +92,6 @@ type AccountList struct {
 	Items           []Account `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&Account{}, &AccountList{})
-}
-
 func (i *Account) GetObservedGeneration() int64                { return i.Status.ObservedGeneration }
 func (i *Account) SetObservedGeneration(g int64)               { i.Status.ObservedGeneration = g }
 func (i *Account) GetNextReconcileTime() metav1.Time           { return i.Status.NextReconcileTime }

--- a/apis/core/v1alpha1/apiexportpolicy_types.go
+++ b/apis/core/v1alpha1/apiexportpolicy_types.go
@@ -72,7 +72,3 @@ type APIExportPolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []APIExportPolicy `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&APIExportPolicy{}, &APIExportPolicyList{})
-}

--- a/apis/core/v1alpha1/authorizationmodel_types.go
+++ b/apis/core/v1alpha1/authorizationmodel_types.go
@@ -77,7 +77,3 @@ type AuthorizationModelList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AuthorizationModel `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&AuthorizationModel{}, &AuthorizationModelList{})
-}

--- a/apis/core/v1alpha1/groupversion_info.go
+++ b/apis/core/v1alpha1/groupversion_info.go
@@ -20,17 +20,43 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+const (
+	GroupName    = "core.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "core.platform-mesh.io", Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Account{},
+		&AccountList{},
+		&AccountInfo{},
+		&AccountInfoList{},
+		&APIExportPolicy{},
+		&APIExportPolicyList{},
+		&AuthorizationModel{},
+		&AuthorizationModelList{},
+		&IdentityProviderConfiguration{},
+		&IdentityProviderConfigurationList{},
+		&Invite{},
+		&InviteList{},
+		&Store{},
+		&StoreList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/core/v1alpha1/identityproviderconfiguration_types.go
+++ b/apis/core/v1alpha1/identityproviderconfiguration_types.go
@@ -99,7 +99,3 @@ type IdentityProviderConfigurationList struct {
 }
 
 var _ conditions.ConditionAccessor = &IdentityProviderConfiguration{}
-
-func init() {
-	SchemeBuilder.Register(&IdentityProviderConfiguration{}, &IdentityProviderConfigurationList{})
-}

--- a/apis/core/v1alpha1/invite_types.go
+++ b/apis/core/v1alpha1/invite_types.go
@@ -75,7 +75,3 @@ type InviteList struct {
 }
 
 var _ conditions.ConditionAccessor = &Invite{}
-
-func init() {
-	SchemeBuilder.Register(&Invite{}, &InviteList{})
-}

--- a/apis/core/v1alpha1/store_types.go
+++ b/apis/core/v1alpha1/store_types.go
@@ -86,7 +86,3 @@ type StoreList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Store `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Store{}, &StoreList{})
-}

--- a/apis/gateway/v1alpha1/groupversion_info.go
+++ b/apis/gateway/v1alpha1/groupversion_info.go
@@ -21,19 +21,21 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	GroupName    = "gateway.platform-mesh.io"
+	GroupVersion = "v1alpha1"
+)
+
 var (
-	// GroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "gateway.platform-mesh.io", Version: "v1alpha1"}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
 
 // Adds the list of known types to api.Scheme.

--- a/apis/marketplace/v1alpha1/groupversion_info.go
+++ b/apis/marketplace/v1alpha1/groupversion_info.go
@@ -20,17 +20,31 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "marketplace.platform-mesh.io", Version: "v1alpha1"}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &runtime.SchemeBuilder{}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+const (
+	GroupName    = "marketplace.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
+)
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&MarketplaceEntry{},
+		&MarketplaceEntryList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/marketplace/v1alpha1/marketplaceentry_types.go
+++ b/apis/marketplace/v1alpha1/marketplaceentry_types.go
@@ -20,7 +20,6 @@ import (
 	pmuiv1alpha1 "go.platform-mesh.io/apis/ui/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 )
@@ -63,15 +62,4 @@ type MarketplaceEntryList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []MarketplaceEntry `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(func(s *runtime.Scheme) error {
-		s.AddKnownTypes(GroupVersion,
-			&MarketplaceEntry{},
-			&MarketplaceEntryList{},
-		)
-		metav1.AddToGroupVersion(s, GroupVersion)
-		return nil
-	})
 }

--- a/apis/migration/v1alpha1/groupversion_info.go
+++ b/apis/migration/v1alpha1/groupversion_info.go
@@ -20,17 +20,31 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+const (
+	GroupName    = "migration.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "migration.platform-mesh.io", Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&KCPMigration{},
+		&KCPMigrationList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/migration/v1alpha1/kcpmigration_types.go
+++ b/apis/migration/v1alpha1/kcpmigration_types.go
@@ -231,10 +231,6 @@ type KCPMigrationList struct {
 	Items           []KCPMigration `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&KCPMigration{}, &KCPMigrationList{})
-}
-
 // RuntimeObject interface implementation for golang-commons lifecycle framework
 
 func (m *KCPMigration) GetObservedGeneration() int64 {

--- a/apis/search/v1alpha1/groupversion_info.go
+++ b/apis/search/v1alpha1/groupversion_info.go
@@ -20,13 +20,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 const (
-	// GroupName is the group name used in this package.
-	GroupName = "search.platform-mesh.io"
+	GroupName    = "search.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 
 	// AccountKind is the Kind name for Account resources.
 	AccountKind = "Account"
@@ -36,12 +37,20 @@ const (
 )
 
 var (
-	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&SearchIndex{},
+		&SearchIndexList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/search/v1alpha1/searchindex_types.go
+++ b/apis/search/v1alpha1/searchindex_types.go
@@ -116,7 +116,3 @@ type SearchIndexList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []SearchIndex `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&SearchIndex{}, &SearchIndexList{})
-}

--- a/apis/terminal/v1alpha1/groupversion_info.go
+++ b/apis/terminal/v1alpha1/groupversion_info.go
@@ -20,17 +20,31 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+const (
+	GroupName    = "terminal.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "terminal.platform-mesh.io", Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 )
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Terminal{},
+		&TerminalList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/terminal/v1alpha1/terminal_types.go
+++ b/apis/terminal/v1alpha1/terminal_types.go
@@ -105,10 +105,6 @@ type TerminalList struct {
 	Items           []Terminal `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&Terminal{}, &TerminalList{})
-}
-
 // GetObservedGeneration returns the observed generation
 func (t *Terminal) GetObservedGeneration() int64 { return t.Status.ObservedGeneration }
 

--- a/apis/ui/v1alpha1/contentconfiguration_types.go
+++ b/apis/ui/v1alpha1/contentconfiguration_types.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -87,17 +86,6 @@ type ContentConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ContentConfiguration `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(func(s *runtime.Scheme) error {
-		s.AddKnownTypes(GroupVersion,
-			&ContentConfiguration{},
-			&ContentConfigurationList{},
-		)
-		metav1.AddToGroupVersion(s, GroupVersion)
-		return nil
-	})
 }
 
 func (i *ContentConfiguration) GetConditions() []metav1.Condition { return i.Status.Conditions }

--- a/apis/ui/v1alpha1/groupversion_info.go
+++ b/apis/ui/v1alpha1/groupversion_info.go
@@ -20,17 +20,33 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "ui.platform-mesh.io", Version: "v1alpha1"}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &runtime.SchemeBuilder{}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+const (
+	GroupName    = "ui.platform-mesh.io"
+	GroupVersion = "v1alpha1"
 )
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion is group version used to register these objects.
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
+)
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&ContentConfiguration{},
+		&ContentConfigurationList{},
+		&ProviderMetadata{},
+		&ProviderMetadataList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/apis/ui/v1alpha1/providermetadata_types.go
+++ b/apis/ui/v1alpha1/providermetadata_types.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Icon struct {
@@ -89,15 +88,4 @@ type ProviderMetadataList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ProviderMetadata `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(func(s *runtime.Scheme) error {
-		s.AddKnownTypes(GroupVersion,
-			&ProviderMetadata{},
-			&ProviderMetadataList{},
-		)
-		metav1.AddToGroupVersion(s, GroupVersion)
-		return nil
-	})
 }

--- a/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
+++ b/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
@@ -191,7 +191,7 @@ func (s *IndexableResourceWatcherSubroutine) Process(ctx context.Context, instan
 
 	// Contextual Tuples (Permissions field), build parent hierarchy from AccountInfo
 	orgObject := buildFGAObjectName(pmsearchv1alpha1.GroupName, pmsearchv1alpha1.AccountKind, accountInfo.Spec.Organization.OriginClusterId, accountInfo.Spec.Organization.Name, "")
-	accountObject := buildFGAObjectName(pmcorev1alpha1.GroupVersion.Group, pmsearchv1alpha1.AccountKind, accountInfo.Spec.Account.OriginClusterId, accountInfo.Spec.Account.Name, "")
+	accountObject := buildFGAObjectName(pmcorev1alpha1.GroupName, pmsearchv1alpha1.AccountKind, accountInfo.Spec.Account.OriginClusterId, accountInfo.Spec.Account.Name, "")
 	doc.AccountName = accountInfo.Spec.Account.Name
 	doc.AccountID = accountInfo.Spec.Account.OriginClusterId
 

--- a/services/iam-service/pkg/directive/authorized_test.go
+++ b/services/iam-service/pkg/directive/authorized_test.go
@@ -98,12 +98,8 @@ func setupTestContext() (context.Context, *logger.Logger) {
 }
 
 func setupFakeClient(t *testing.T, objects ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
-	rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.GroupVersion})
-	rm.Add(schema.GroupVersionKind{
-		Group:   pmcorev1alpha1.GroupVersion.Group,
-		Version: pmcorev1alpha1.GroupVersion.Version,
-		Kind:    "AccountInfo",
-	}, meta.RESTScopeNamespace)
+	rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.SchemeGroupVersion})
+	rm.Add(pmcorev1alpha1.SchemeGroupVersion.WithKind("AccountInfo"), meta.RESTScopeNamespace)
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, pmcorev1alpha1.AddToScheme(scheme))
@@ -826,12 +822,8 @@ func TestTestIfResourceExists(t *testing.T) {
 				// Setup with cluster-scoped REST mapping
 				ai := createTestAccountInfo()
 
-				rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.GroupVersion})
-				rm.Add(schema.GroupVersionKind{
-					Group:   pmcorev1alpha1.GroupVersion.Group,
-					Version: pmcorev1alpha1.GroupVersion.Version,
-					Kind:    "AccountInfo",
-				}, meta.RESTScopeRoot) // Cluster-scoped
+				rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.SchemeGroupVersion})
+				rm.Add(pmcorev1alpha1.SchemeGroupVersion.WithKind("AccountInfo"), meta.RESTScopeRoot) // Cluster-scoped
 
 				scheme := runtime.NewScheme()
 				require.NoError(t, pmcorev1alpha1.AddToScheme(scheme))
@@ -843,7 +835,7 @@ func TestTestIfResourceExists(t *testing.T) {
 					Build()
 			},
 			resourceCtx: &graph.ResourceContext{
-				Group: "core.platform-mesh.io",
+				Group: pmcorev1alpha1.GroupName,
 				Kind:  "AccountInfo",
 				Resource: &graph.Resource{
 					Name:      "account",
@@ -858,7 +850,7 @@ func TestTestIfResourceExists(t *testing.T) {
 				return setupFakeClient(t) // Empty client
 			},
 			resourceCtx: &graph.ResourceContext{
-				Group: "core.platform-mesh.io",
+				Group: pmcorev1alpha1.GroupName,
 				Kind:  "AccountInfo",
 				Resource: &graph.Resource{
 					Name:      "nonexistent-account",
@@ -871,12 +863,8 @@ func TestTestIfResourceExists(t *testing.T) {
 			name: "resource not found - cluster scoped",
 			setupClient: func(t *testing.T) ctrlruntimeclient.Client {
 				// Setup with cluster-scoped REST mapping but no objects
-				rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.GroupVersion})
-				rm.Add(schema.GroupVersionKind{
-					Group:   pmcorev1alpha1.GroupVersion.Group,
-					Version: pmcorev1alpha1.GroupVersion.Version,
-					Kind:    "AccountInfo",
-				}, meta.RESTScopeRoot)
+				rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{pmcorev1alpha1.SchemeGroupVersion})
+				rm.Add(pmcorev1alpha1.SchemeGroupVersion.WithKind("AccountInfo"), meta.RESTScopeRoot) // Cluster-scoped
 
 				scheme := runtime.NewScheme()
 				require.NoError(t, pmcorev1alpha1.AddToScheme(scheme))
@@ -887,7 +875,7 @@ func TestTestIfResourceExists(t *testing.T) {
 					Build() // No objects
 			},
 			resourceCtx: &graph.ResourceContext{
-				Group: "core.platform-mesh.io",
+				Group: pmcorev1alpha1.GroupName,
 				Kind:  "AccountInfo",
 				Resource: &graph.Resource{
 					Name:      "nonexistent-account",

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -221,7 +221,7 @@ func Marketplace(provider *apiexport.Provider, cfg config.ServiceConfig) forward
 			}
 
 			var results unstructured.UnstructuredList
-			results.SetGroupVersionKind(pmmarketplacev1alpha1.GroupVersion.WithKind("MarketplaceEntryList"))
+			results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
 
 			// For each provider, find matching APIExports across all shards
 			for _, provider := range providerList.Items {
@@ -268,7 +268,7 @@ func Marketplace(provider *apiexport.Provider, cfg config.ServiceConfig) forward
 					}
 
 					us := unstructured.Unstructured{Object: unstructuredEntry}
-					us.SetGroupVersionKind(pmmarketplacev1alpha1.GroupVersion.WithKind("MarketplaceEntry"))
+					us.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntry"))
 					results.Items = append(results.Items, us)
 				}
 			}


### PR DESCRIPTION
The apis module should not have a dependency on controller-runtime, since CR is far too heavy and ties the apis to a specific Kube release, making re-use much harder than it has to be.

For this we need to undo some kubebuilder defaults, like relying on CR for scheme initialization and also later moving the webhook code out of the apis module.

This is the first step, harmonizing how the individual APIs are set up and not using CR for that anymore.