### PR TITLE
fix(gateway): outdated task definitions expect main under cmd

### DIFF
--- a/services/kubernetes-graphql-gateway/Taskfile.yaml
+++ b/services/kubernetes-graphql-gateway/Taskfile.yaml
@@ -138,14 +138,14 @@ tasks:
           kill $PID 2>/dev/null || true
           sleep 2
         fi
-      - go run ./cmd/gateway/gateway.go --enable-playground
+      - go run main.go gateway --enable-playground
 
   listener:
     desc: "Start the listener server (kills existing process on port 8090 if needed)"
     cmds:
-      - go run ./cmd/listener/listener.go
+      - go run main.go listener
 
   listener-kcp:
     desc: "Start the listener server (kills existing process on port 8090 if needed)"
     cmds:
-      - go run ./cmd/listener/listener.go --apiexport-endpoint-slice-name gateway.platform-mesh.io --multicluster-runtime-provider kcp --kubeconfig=.secret/cc-d2-kcp.yaml
+      - go run main.go listener --apiexport-endpoint-slice-name gateway.platform-mesh.io --multicluster-runtime-provider kcp --kubeconfig=.secret/cc-d2-kcp.yaml


### PR DESCRIPTION
This has been broken for a while probably. Main is now at gateway root. 

Side note: the exported non-main packages in `cmd/< >/` kind of break convention. Judging by the package path, I expected to see main there and was confused why that is not the case. Maybe we can move them under `internal/cmd` or something similar?