### PR TITLE
feat(gateway): Query and subscribe by category

### DIFF
--- a/services/kubernetes-graphql-gateway/gateway/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/config.go
@@ -47,9 +47,10 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 		GRPCAddress:        cfg.Options.GRPCListenerAddress,
 		GRPCMaxRecvMsgSize: cfg.Options.GRPCMaxRecvMsgSize,
 		GraphQL: gatewayconfig.GraphQL{
-			Pretty:            true,
-			PlaygroundEnabled: cfg.Options.PlaygroundEnabled,
-			GraphiQL:          cfg.Options.PlaygroundEnabled,
+			Pretty:                     true,
+			PlaygroundEnabled:          cfg.Options.PlaygroundEnabled,
+			ResourcesByCategoryEnabled: cfg.Options.ResourcesByCategoryEnabled,
+			GraphiQL:                   cfg.Options.PlaygroundEnabled,
 		},
 		Limits: gatewayconfig.Limits{
 			MaxQueryDepth:      cfg.Options.MaxQueryDepth,

--- a/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
@@ -69,9 +69,10 @@ type Gateway struct {
 
 // GraphQL holds GraphQL handler configuration.
 type GraphQL struct {
-	Pretty            bool
-	PlaygroundEnabled bool
-	GraphiQL          bool
+	Pretty                     bool
+	ResourcesByCategoryEnabled bool
+	PlaygroundEnabled          bool
+	GraphiQL                   bool
 }
 
 // Limits holds query validation limits enforced at the GraphQL layer.

--- a/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
@@ -102,7 +102,7 @@ func New(
 		return nil, fmt.Errorf("failed to create custom subscription generator: %w", err)
 	}
 
-	schemaProvider, err := schema.New(ctx, schemaData.Components.Schemas, resolverProvider, customSubGen)
+	schemaProvider, err := schema.New(ctx, schemaData.Components.Schemas, resolverProvider, customSubGen, graphqlCfg.ResourcesByCategoryEnabled)
 	if err != nil {
 		validatorCancel()
 		return nil, fmt.Errorf("failed to create GraphQL schema: %w", err)

--- a/services/kubernetes-graphql-gateway/gateway/gateway/metrics/metrics.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/metrics/metrics.go
@@ -123,8 +123,10 @@ func (m *EndpointMetrics) Record(cluster, operation string, d time.Duration, res
 
 // ResolverMetrics tracks Kubernetes API calls made by GraphQL resolvers.
 type ResolverMetrics struct {
-	RequestsTotal   *prometheus.CounterVec
-	RequestDuration *prometheus.HistogramVec
+	RequestsTotal         *prometheus.CounterVec
+	RequestDuration       *prometheus.HistogramVec
+	CategoryWatchesActive *prometheus.GaugeVec
+	WatchInitialItems     *prometheus.HistogramVec
 }
 
 func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
@@ -138,8 +140,18 @@ func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
 			Help:    "Duration of Kubernetes API calls in seconds by operation and kind.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"operation", "kind"}),
+		CategoryWatchesActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "kubernetes_graphql_gateway_category_watches_active",
+			Help: "Current number of open resource watches held by category subscriptions.",
+		}, []string{"category"}),
+		WatchInitialItems: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "kubernetes_graphql_gateway_watch_initial_items",
+			Help:    "Number of objects returned during a subscription's list phase.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 8),
+		}, []string{"kind"}),
 	}
-	reg.MustRegister(m.RequestsTotal, m.RequestDuration)
+	reg.MustRegister(
+		m.RequestsTotal, m.RequestDuration, m.CategoryWatchesActive, m.WatchInitialItems)
 	return m
 }
 
@@ -147,6 +159,16 @@ func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
 func (m *ResolverMetrics) Record(operation, kind string, d time.Duration, result string) {
 	m.RequestsTotal.WithLabelValues(operation, kind, result).Inc()
 	m.RequestDuration.WithLabelValues(operation, kind).Observe(d.Seconds())
+}
+
+// UpdateCategoryWatches adds or subtracts the delta and updates the gauge.
+func (m *ResolverMetrics) UpdateCategoryWatches(category string, delta int) {
+	m.CategoryWatchesActive.WithLabelValues(category).Add(float64(delta))
+}
+
+// ObserveWatchInitialItems records the item count during the initial list, labelled by kind.
+func (m *ResolverMetrics) ObserveWatchInitialItems(kind string, n int) {
+	m.WatchInitialItems.WithLabelValues(kind).Observe(float64(n))
 }
 
 // AuthMetrics tracks token authentication attempts.

--- a/services/kubernetes-graphql-gateway/gateway/gateway/metrics/metrics.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/metrics/metrics.go
@@ -123,10 +123,12 @@ func (m *EndpointMetrics) Record(cluster, operation string, d time.Duration, res
 
 // ResolverMetrics tracks Kubernetes API calls made by GraphQL resolvers.
 type ResolverMetrics struct {
-	RequestsTotal         *prometheus.CounterVec
-	RequestDuration       *prometheus.HistogramVec
-	CategoryWatchesActive *prometheus.GaugeVec
-	WatchInitialItems     *prometheus.HistogramVec
+	RequestsTotal           *prometheus.CounterVec
+	RequestDuration         *prometheus.HistogramVec
+	CategoryFanoutTypes     *prometheus.HistogramVec
+	CategoryObjectsReturned *prometheus.HistogramVec
+	CategoryWatchesActive   *prometheus.GaugeVec
+	WatchInitialItems       *prometheus.HistogramVec
 }
 
 func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
@@ -140,6 +142,16 @@ func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
 			Help:    "Duration of Kubernetes API calls in seconds by operation and kind.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"operation", "kind"}),
+		CategoryFanoutTypes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "kubernetes_graphql_gateway_category_fanout_types",
+			Help:    "Number of resource types a category query expanded out to, by category.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 8),
+		}, []string{"category"}),
+		CategoryObjectsReturned: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "kubernetes_graphql_gateway_category_objects_returned",
+			Help:    "Total objects returned across all types in a category query, by category.",
+			Buckets: prometheus.ExponentialBuckets(1, 4, 8),
+		}, []string{"category"}),
 		CategoryWatchesActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "kubernetes_graphql_gateway_category_watches_active",
 			Help: "Current number of open resource watches held by category subscriptions.",
@@ -151,7 +163,13 @@ func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
 		}, []string{"kind"}),
 	}
 	reg.MustRegister(
-		m.RequestsTotal, m.RequestDuration, m.CategoryWatchesActive, m.WatchInitialItems)
+		m.RequestsTotal,
+		m.RequestDuration,
+		m.CategoryFanoutTypes,
+		m.CategoryObjectsReturned,
+		m.CategoryWatchesActive,
+		m.WatchInitialItems,
+	)
 	return m
 }
 
@@ -159,6 +177,12 @@ func NewResolverMetrics(reg prometheus.Registerer) *ResolverMetrics {
 func (m *ResolverMetrics) Record(operation, kind string, d time.Duration, result string) {
 	m.RequestsTotal.WithLabelValues(operation, kind, result).Inc()
 	m.RequestDuration.WithLabelValues(operation, kind).Observe(d.Seconds())
+}
+
+// RecordCategoryFanout records the resource types and individual object counts a category query expanded to.
+func (m *ResolverMetrics) RecordCategoryFanout(category string, types, objects int) {
+	m.CategoryFanoutTypes.WithLabelValues(category).Observe(float64(types))
+	m.CategoryObjectsReturned.WithLabelValues(category).Observe(float64(objects))
 }
 
 // UpdateCategoryWatches adds or subtracts the delta and updates the gauge.

--- a/services/kubernetes-graphql-gateway/gateway/options/options.go
+++ b/services/kubernetes-graphql-gateway/gateway/options/options.go
@@ -49,6 +49,8 @@ type ExtraOptions struct {
 	ServerBindPort int
 	// PlaygroundEnabled indicates whether to enable the GraphQL playground.
 	PlaygroundEnabled bool
+	// ResourcesByCategoryEnabled is the feature gate for the resourcesByCategory query and subscription.
+	ResourcesByCategoryEnabled bool
 	// CORSAllowedOrigins is the list of allowed origins for CORS.
 	CORSAllowedOrigins []string
 	// CORSAllowedHeaders is the list of allowed headers for CORS.
@@ -98,27 +100,28 @@ func NewOptions() *Options {
 		Logs: logs,
 
 		ExtraOptions: ExtraOptions{
-			SchemasDir:               "_output/schemas",
-			SchemaHandler:            "file",
-			GRPCListenerAddress:      "localhost:50051",
-			GRPCMaxRecvMsgSize:       defaults.DefaultGRPCMaxMsgSize,
-			ServerBindAddress:        "0.0.0.0",
-			ServerBindPort:           8080,
-			PlaygroundEnabled:        false,
-			CORSAllowedOrigins:       []string{},
-			CORSAllowedHeaders:       []string{},
-			TokenReviewCacheTTL:      30 * time.Second,
-			RequestTimeout:           60 * time.Second,
-			SubscriptionTimeout:      30 * time.Minute,
-			MaxRequestBodyBytes:      3 * 1024 * 1024,
-			MaxInFlightRequests:      400,
-			MaxInFlightSubscriptions: 50,
-			MaxQueryDepth:            10,
-			MaxQueryComplexity:       1000,
-			MaxQueryBatchSize:        10,
-			ReadHeaderTimeout:        32 * time.Second,
-			IdleTimeout:              90 * time.Second,
-			EndpointSuffix:           "/graphql",
+			SchemasDir:                 "_output/schemas",
+			SchemaHandler:              "file",
+			GRPCListenerAddress:        "localhost:50051",
+			GRPCMaxRecvMsgSize:         defaults.DefaultGRPCMaxMsgSize,
+			ServerBindAddress:          "0.0.0.0",
+			ServerBindPort:             8080,
+			PlaygroundEnabled:          false,
+			ResourcesByCategoryEnabled: false,
+			CORSAllowedOrigins:         []string{},
+			CORSAllowedHeaders:         []string{},
+			TokenReviewCacheTTL:        30 * time.Second,
+			RequestTimeout:             60 * time.Second,
+			SubscriptionTimeout:        30 * time.Minute,
+			MaxRequestBodyBytes:        3 * 1024 * 1024,
+			MaxInFlightRequests:        400,
+			MaxInFlightSubscriptions:   50,
+			MaxQueryDepth:              10,
+			MaxQueryComplexity:         1000,
+			MaxQueryBatchSize:          10,
+			ReadHeaderTimeout:          32 * time.Second,
+			IdleTimeout:                90 * time.Second,
+			EndpointSuffix:             "/graphql",
 		},
 	}
 	return opts
@@ -134,6 +137,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.ServerBindPort, "gateway-port", options.ServerBindPort, "port for the GraphQL gateway server")
 	fs.StringVar(&options.ServerBindAddress, "gateway-address", options.ServerBindAddress, "address for the GraphQL gateway server")
 	fs.BoolVar(&options.PlaygroundEnabled, "enable-playground", options.PlaygroundEnabled, "enable the GraphQL playground (allows unauthenticated GET requests to serve the playground UI)")
+	fs.BoolVar(&options.ResourcesByCategoryEnabled, "enable-resources-by-category", options.ResourcesByCategoryEnabled, "enable the resourcesByCategory query and subscription")
 	fs.StringSliceVar(&options.CORSAllowedOrigins, "cors-allowed-origins", options.CORSAllowedOrigins, "list of allowed origins for CORS")
 	fs.StringSliceVar(&options.CORSAllowedHeaders, "cors-allowed-headers", options.CORSAllowedHeaders, "list of allowed headers for CORS")
 	fs.DurationVar(&options.TokenReviewCacheTTL, "token-review-cache-ttl", options.TokenReviewCacheTTL, "TTL for cached TokenReview results (0 to disable caching)")

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -24,7 +24,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type TypeByCategory struct {
@@ -72,6 +74,10 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 				scope := apiextensionsv1.ResourceScope(v.Scope)
 				items, err := r.ListItems(gvk, scope)(p)
 				if err != nil {
+					if apierrors.IsForbidden(err) {
+						log.FromContext(ctx).V(4).Info("skipping forbidden type in category", "category", name, "gvk", gvk, "err", err)
+						return nil
+					}
 					return fmt.Errorf("getting items for gvk %s: %w", gvk, err)
 				}
 
@@ -119,6 +125,8 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 			r.metrics.UpdateCategoryWatches(category, categoryTypesCount)
 		}
 
+		logger := log.FromContext(p.Context)
+
 		var wg sync.WaitGroup
 		for _, cType := range categoryTypes {
 			gvk := schema.GroupVersionKind{Group: cType.Group, Version: cType.Version, Kind: cType.Kind}
@@ -126,12 +134,12 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 
 			sub, err := r.SubscribeItems(gvk, scope)(p)
 			if err != nil {
-				// TODO: only ignore RBAC errors
+				logger.Error(err, "subscribing to type in category", "category", category, "gvk", gvk)
 				continue
 			}
 			srcChan, ok := sub.(chan any)
 			if !ok {
-				// TODO: error log
+				logger.Error(nil, "subscription source is not a channel", "type", fmt.Sprintf("%T", sub))
 				continue
 			}
 
@@ -141,6 +149,16 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 					case event, ok := <-srcChan:
 						if !ok {
 							return
+						}
+
+						if watchErr, isErr := event.(error); isErr {
+							if apierrors.IsForbidden(watchErr) {
+								logger.V(4).Info(
+									"skipping watch on forbidden type in category", "gvk", gvk, "err", watchErr)
+
+								// return without cancel is safe, srcChan is closed once an error is written
+								return
+							}
 						}
 						select {
 						case outCh <- event:

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -17,7 +17,13 @@ limitations under the License.
 package resolver
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/graphql-go/graphql"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type TypeByCategory struct {
@@ -35,5 +41,36 @@ func (r *Service) TypeByCategory(m map[string][]TypeByCategory) graphql.FieldRes
 		}
 
 		return m[name], nil
+	}
+}
+
+func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		name, err := GetArg[string](p.Args, NameArg, true)
+		if err != nil {
+			return nil, err
+		}
+
+		members := m[name]
+		result := make([]map[string]any, 0)
+
+		for _, v := range members {
+			gvk := schema.GroupVersionKind{Group: v.Group, Version: v.Version, Kind: v.Kind}
+			scope := apiextensionsv1.ResourceScope(v.Scope)
+			items, err := r.ListItems(gvk, scope)(p)
+			if err != nil {
+				return nil, fmt.Errorf("getting items: %w", err)
+			}
+
+			listresult, ok := items.(*ListResult)
+			if !ok {
+				return nil, errors.New("ListItems returned wrong type: was not *ListResult")
+			}
+
+			result = append(result, listresult.Items...)
+
+		}
+
+		return result, nil
 	}
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -87,9 +87,9 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 		categoryTypes := m[category]
 
 		var wg sync.WaitGroup
-		for _, cat := range categoryTypes {
-			gvk := schema.GroupVersionKind{Group: cat.Group, Version: cat.Version, Kind: cat.Kind}
-			scope := apiextensionsv1.ResourceScope(cat.Scope)
+		for _, cType := range categoryTypes {
+			gvk := schema.GroupVersionKind{Group: cType.Group, Version: cType.Version, Kind: cType.Kind}
+			scope := apiextensionsv1.ResourceScope(cType.Scope)
 
 			sub, err := r.SubscribeItems(gvk, scope)(p)
 			if err != nil {

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -82,9 +82,8 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 			return nil, fmt.Errorf("no name arg in %v; %w", p.Args, err)
 		}
 
-		outCh := make(chan any, 100)
-
 		categoryTypes := m[category]
+		outCh := make(chan any, len(categoryTypes))
 
 		var wg sync.WaitGroup
 		for _, cType := range categoryTypes {

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -19,6 +19,7 @@ package resolver
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/graphql-go/graphql"
 
@@ -68,9 +69,63 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 			}
 
 			result = append(result, listresult.Items...)
-
 		}
 
 		return result, nil
+	}
+}
+
+func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		category, err := GetArg[string](p.Args, NameArg, true)
+		if err != nil {
+			return nil, fmt.Errorf("no name arg in %v; %w", p.Args, err)
+		}
+
+		outCh := make(chan any, 100)
+
+		categoryTypes := m[category]
+
+		var wg sync.WaitGroup
+		for _, cat := range categoryTypes {
+			gvk := schema.GroupVersionKind{Group: cat.Group, Version: cat.Version, Kind: cat.Kind}
+			scope := apiextensionsv1.ResourceScope(cat.Scope)
+
+			sub, err := r.SubscribeItems(gvk, scope)(p)
+			if err != nil {
+				// ignore (eg rbac?) or cancel everything?
+				continue
+			}
+			srcChan, ok := sub.(chan any)
+			if !ok {
+				continue
+			}
+
+			wg.Go(func() {
+				for {
+					// can cut some corners here?
+					select {
+					case blap, ok := <-srcChan:
+						if !ok {
+							return
+						}
+						select {
+						case outCh <- blap:
+						case <-p.Context.Done():
+							return
+						}
+					case <-p.Context.Done():
+						return
+					}
+				}
+			})
+		}
+
+		go func() {
+			wg.Wait()
+			close(outCh)
+		}()
+
+		return outCh, nil
 	}
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -104,7 +104,12 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 		}
 
 		categoryTypes := m[category]
-		outCh := make(chan any, len(categoryTypes))
+		categoryTypesCount := len(categoryTypes)
+		outCh := make(chan any, categoryTypesCount)
+
+		if r.metrics != nil {
+			r.metrics.UpdateCategoryWatches(category, categoryTypesCount)
+		}
 
 		var wg sync.WaitGroup
 		for _, cType := range categoryTypes {
@@ -143,6 +148,9 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 
 		go func() {
 			wg.Wait()
+			if r.metrics != nil {
+				r.metrics.UpdateCategoryWatches(category, -categoryTypesCount)
+			}
 			close(outCh)
 		}()
 

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -34,6 +34,11 @@ type TypeByCategory struct {
 	Scope   string
 }
 
+// CategoryListResult is the response type for resourcesByCategory.
+type CategoryListResult struct {
+	Items []map[string]any `json:"items"`
+}
+
 func (r *Service) TypeByCategory(m map[string][]TypeByCategory) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
 		name, err := GetArg[string](p.Args, NameArg, true)
@@ -93,7 +98,9 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 		if r.metrics != nil {
 			r.metrics.RecordCategoryFanout(name, len(members), len(result))
 		}
-		return result, nil
+		return &CategoryListResult{
+			Items: result,
+		}, nil
 	}
 }
 

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 
 	"github.com/graphql-go/graphql"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -43,25 +46,28 @@ type CategoryListResult struct {
 
 func (r *Service) TypeByCategory(m map[string][]TypeByCategory) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
-		name, err := GetArg[string](p.Args, NameArg, true)
+		category, err := GetArg[string](p.Args, NameArg, true)
 		if err != nil {
 			return nil, err
 		}
 
-		return m[name], nil
+		return m[category], nil
 	}
 }
 
 func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
-		name, err := GetArg[string](p.Args, NameArg, true)
+		category, err := GetArg[string](p.Args, NameArg, true)
 		if err != nil {
 			return nil, err
 		}
 
-		members := m[name]
+		members := m[category]
 
-		grp, ctx := errgroup.WithContext(p.Context)
+		spanCtx, span := otel.Tracer("").Start(p.Context, "ResourcesByCategory", trace.WithAttributes(attribute.String("category", category)))
+		defer span.End()
+
+		grp, ctx := errgroup.WithContext(spanCtx)
 		p.Context = ctx
 		// revisit after poc: floor(members, maxParallel)
 		grp.SetLimit(len(members))
@@ -75,7 +81,7 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 				items, err := r.ListItems(gvk, scope)(p)
 				if err != nil {
 					if apierrors.IsForbidden(err) {
-						log.FromContext(ctx).V(4).Info("skipping forbidden type in category", "category", name, "gvk", gvk, "err", err)
+						log.FromContext(ctx).V(4).Info("skipping forbidden type in category", "category", category, "gvk", gvk, "err", err)
 						return nil
 					}
 					return fmt.Errorf("getting items for gvk %s: %w", gvk, err)
@@ -102,7 +108,7 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 		}
 
 		if r.metrics != nil {
-			r.metrics.RecordCategoryFanout(name, len(members), len(result))
+			r.metrics.RecordCategoryFanout(category, len(members), len(result))
 		}
 		return &CategoryListResult{
 			Items: result,
@@ -114,7 +120,7 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 	return func(p graphql.ResolveParams) (any, error) {
 		category, err := GetArg[string](p.Args, NameArg, true)
 		if err != nil {
-			return nil, fmt.Errorf("no name arg in %v; %w", p.Args, err)
+			return nil, fmt.Errorf("no name arg in %v: %w", p.Args, err)
 		}
 
 		categoryTypes := m[category]
@@ -153,8 +159,8 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 
 						if watchErr, isErr := event.(error); isErr {
 							if apierrors.IsForbidden(watchErr) {
-								logger.V(4).Info(
-									"skipping watch on forbidden type in category", "gvk", gvk, "err", watchErr)
+								logger.V(4).Info("skipping watch on forbidden type in category",
+									"err", watchErr, "category", category, "gvk", gvk)
 
 								// return without cancel is safe, srcChan is closed once an error is written
 								return

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -54,8 +54,6 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 
 		members := m[name]
 
-		// parallel := len(members)
-
 		grp, ctx := errgroup.WithContext(p.Context)
 		p.Context = ctx
 		// revisit after poc: floor(members, maxParallel)
@@ -92,6 +90,9 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 			result = append(result, v...)
 		}
 
+		if r.metrics != nil {
+			r.metrics.RecordCategoryFanout(name, len(members), len(result))
+		}
 		return result, nil
 	}
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -17,11 +17,11 @@ limitations under the License.
 package resolver
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/graphql-go/graphql"
+	"golang.org/x/sync/errgroup"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,22 +53,43 @@ func (r *Service) ResourcesByCategory(m map[string][]TypeByCategory) graphql.Fie
 		}
 
 		members := m[name]
-		result := make([]map[string]any, 0)
 
-		for _, v := range members {
-			gvk := schema.GroupVersionKind{Group: v.Group, Version: v.Version, Kind: v.Kind}
-			scope := apiextensionsv1.ResourceScope(v.Scope)
-			items, err := r.ListItems(gvk, scope)(p)
-			if err != nil {
-				return nil, fmt.Errorf("getting items: %w", err)
-			}
+		// parallel := len(members)
 
-			listresult, ok := items.(*ListResult)
-			if !ok {
-				return nil, errors.New("ListItems returned wrong type: was not *ListResult")
-			}
+		grp, ctx := errgroup.WithContext(p.Context)
+		p.Context = ctx
+		// revisit after poc: floor(members, maxParallel)
+		grp.SetLimit(len(members))
 
-			result = append(result, listresult.Items...)
+		gather := make([][]map[string]any, len(members))
+
+		for i, v := range members {
+			grp.Go(func() error {
+				gvk := schema.GroupVersionKind{Group: v.Group, Version: v.Version, Kind: v.Kind}
+				scope := apiextensionsv1.ResourceScope(v.Scope)
+				items, err := r.ListItems(gvk, scope)(p)
+				if err != nil {
+					return fmt.Errorf("getting items for gvk %s: %w", gvk, err)
+				}
+
+				listresult, ok := items.(*ListResult)
+				if !ok {
+					return fmt.Errorf("ListItems returned wrong type: expected *ListResult got %T", items)
+				}
+
+				gather[i] = listresult.Items
+				return nil
+			})
+		}
+
+		err = grp.Wait()
+		if err != nil {
+			return nil, err
+		}
+
+		var result []map[string]any
+		for _, v := range gather {
+			result = append(result, v...)
 		}
 
 		return result, nil
@@ -92,11 +113,12 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 
 			sub, err := r.SubscribeItems(gvk, scope)(p)
 			if err != nil {
-				// ignore (eg rbac?) or cancel everything?
+				// TODO: only ignore RBAC errors
 				continue
 			}
 			srcChan, ok := sub.(chan any)
 			if !ok {
+				// TODO: error log
 				continue
 			}
 

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries.go
@@ -103,14 +103,13 @@ func (r *Service) SubscribeResourcesByCategory(m map[string][]TypeByCategory) gr
 
 			wg.Go(func() {
 				for {
-					// can cut some corners here?
 					select {
-					case blap, ok := <-srcChan:
+					case event, ok := <-srcChan:
 						if !ok {
 							return
 						}
 						select {
-						case outCh <- blap:
+						case outCh <- event:
 						case <-p.Context.Done():
 							return
 						}

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -64,7 +64,7 @@ func TestResourcesByCategory(t *testing.T) {
 		result, ok := raw.(*CategoryListResult)
 		require.True(t, ok, "unexpected result type")
 
-		require.Len(t, result, 2)
+		require.Len(t, result.Items, 2)
 
 		receivedNames := make([]string, len(result.Items))
 		for i, v := range result.Items {

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -3,7 +3,10 @@ package resolver
 import (
 	"context"
 	"errors"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/graphql-go/graphql"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,7 +16,9 @@ import (
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/metrics"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -127,6 +132,249 @@ func TestResourcesByCategory(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+func TestResourcesByCategory_Permissions(t *testing.T) {
+	foo := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resolver.bar/v1",
+			"kind":       "Foo",
+			"metadata": map[string]any{
+				"name": "first",
+			},
+		},
+	}
+	bar := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resolver.bar/v1",
+			"kind":       "Bar",
+			"metadata": map[string]any{
+				"name": "second",
+			},
+		},
+	}
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "resolver.bar", Resource: "bars"}, "",
+		errors.New("no access"))
+
+	tests := []struct {
+		name          string
+		deniedKinds   []string
+		listErr       error
+		expectedNames []string
+		expectError   bool
+	}{
+		{
+			name:          "all types allowed",
+			expectedNames: []string{"first", "second"},
+			expectError:   false,
+		},
+		{
+			name:          "one of two types forbidden",
+			deniedKinds:   []string{"Bar"},
+			listErr:       forbidden,
+			expectedNames: []string{"first"},
+			expectError:   false,
+		},
+		{
+			name:          "every type forbidden returns empty result",
+			deniedKinds:   []string{"Foo", "Bar"},
+			listErr:       forbidden,
+			expectedNames: nil,
+			expectError:   false,
+		},
+		{
+			name:        "unauthorized is not suppressed",
+			deniedKinds: []string{"Bar"},
+			listErr:     apierrors.NewUnauthorized("token expired"),
+			expectError: true,
+		},
+		{
+			name:        "internal error is not suppressed",
+			deniedKinds: []string{"Bar"},
+			listErr:     apierrors.NewInternalError(errors.New("etcd unreachable")),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := testfakes.NewClient(
+				listErrForKinds(tt.listErr, tt.deniedKinds, foo, bar), nil)
+			svc := New(client, nil)
+
+			categoryName := "the-category"
+			typeByCat := map[string][]TypeByCategory{
+				categoryName: {
+					TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Foo"},
+					TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Bar"},
+				},
+			}
+
+			resolve := svc.ResourcesByCategory(typeByCat)
+
+			raw, err := resolve(graphql.ResolveParams{
+				Context: t.Context(),
+				Args:    map[string]any{"name": categoryName},
+			})
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, raw)
+				return
+			}
+			require.NoError(t, err)
+
+			result, ok := raw.(*CategoryListResult)
+			require.True(t, ok, "unexpected result type")
+
+			receivedNames := make([]string, len(result.Items))
+			for i, v := range result.Items {
+				receivedNames[i], _, _ = unstructured.NestedString(v, "metadata", "name")
+			}
+			assert.ElementsMatch(t, tt.expectedNames, receivedNames)
+		})
+	}
+}
+
+func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
+	foo := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resolver.bar/v1",
+			"kind":       "Foo",
+			"metadata": map[string]any{
+				"name": "first",
+			},
+		},
+	}
+	bar := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resolver.bar/v1",
+			"kind":       "Bar",
+			"metadata": map[string]any{
+				"name": "second",
+			},
+		},
+	}
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "resolver.bar", Resource: "bars"}, "",
+		errors.New("no access"))
+
+	tests := []struct {
+		name          string
+		deniedKinds   []string
+		listErr       error
+		expectedNames []string
+		expectError   bool
+	}{
+		{
+			name:          "all types allowed",
+			expectedNames: []string{"first", "second"},
+			expectError:   false,
+		},
+		{
+			name:          "one of two types forbidden",
+			deniedKinds:   []string{"Bar"},
+			listErr:       forbidden,
+			expectedNames: []string{"first"},
+			expectError:   false,
+		},
+		{
+			name:          "all types forbidden",
+			deniedKinds:   []string{"Foo", "Bar"},
+			listErr:       forbidden,
+			expectedNames: nil,
+			expectError:   false,
+		},
+		{
+			name:          "unauthorized is not suppressed",
+			deniedKinds:   []string{"Bar"},
+			listErr:       apierrors.NewUnauthorized("token expired"),
+			expectedNames: []string{"first"},
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			client := testfakes.NewClient(
+				listErrForKinds(tt.listErr, tt.deniedKinds, foo, bar), nil)
+			svc := New(client, nil)
+
+			categoryName := "the-category"
+			typeByCat := map[string][]TypeByCategory{
+				categoryName: {
+					TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Foo"},
+					TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Bar"},
+				},
+			}
+
+			subscribe := svc.SubscribeResourcesByCategory(typeByCat)
+
+			raw, err := subscribe(graphql.ResolveParams{
+				Context: ctx,
+				Args:    map[string]any{"name": categoryName},
+			})
+			require.NoError(t, err)
+
+			outCh, ok := raw.(chan any)
+			require.True(t, ok, "unexpected result type")
+
+			receivedNames, receivedErr := drainEvents(t, outCh)
+			assert.ElementsMatch(t, tt.expectedNames, receivedNames)
+
+			if tt.expectError {
+				assert.Error(t, receivedErr)
+				return
+			}
+			assert.NoError(t, receivedErr)
+		})
+	}
+}
+
+// drainEvents collects the names of all objects, as well as the last error.
+func drainEvents(t *testing.T, outCh <-chan any) (names []string, err error) {
+	t.Helper()
+	for {
+		select {
+		case event, ok := <-outCh:
+			if !ok {
+				return names, err
+			}
+			switch v := event.(type) {
+			case error:
+				err = v
+			case SubscriptionEnvelope:
+				obj, _ := v.Object.(map[string]any)
+				name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+				names = append(names, name)
+			default:
+				t.Fatalf("unexpected event type %T", event)
+			}
+		case <-time.After(200 * time.Millisecond):
+			return names, err
+		}
+	}
+}
+
+// listErrForKinds returns a List function which fails with listErr for deniedKinds.
+func listErrForKinds(
+	listErr error,
+	deniedKinds []string,
+	objs ...unstructured.Unstructured,
+) func(context.Context, ctrlruntimeclient.ObjectList, ...ctrlruntimeclient.ListOption) error {
+	serve := testfakes.ListItems(objs...)
+	return func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+		kind := strings.TrimSuffix(list.GetObjectKind().GroupVersionKind().Kind, "List")
+		if slices.Contains(deniedKinds, kind) {
+			return listErr
+		}
+		return serve(ctx, list, opts...)
+	}
 }
 
 // histObservation returns the sample count and the total sum for a given histogram.

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -55,19 +55,19 @@ func TestResourcesByCategory(t *testing.T) {
 
 		resolve := svc.ResourcesByCategory(typeByCat)
 
-		result, err := resolve(graphql.ResolveParams{
+		raw, err := resolve(graphql.ResolveParams{
 			Context: t.Context(),
 			Args:    map[string]any{"name": categoryName},
 		})
 		require.NoError(t, err)
 
-		records, ok := result.([]map[string]any)
+		result, ok := raw.(*CategoryListResult)
 		require.True(t, ok, "unexpected result type")
 
-		require.Len(t, records, 2)
+		require.Len(t, result, 2)
 
-		receivedNames := make([]string, len(records))
-		for i, v := range records {
+		receivedNames := make([]string, len(result.Items))
+		for i, v := range result.Items {
 			receivedNames[i], _, _ = unstructured.NestedString(v, "metadata", "name")
 		}
 		assert.ElementsMatch(t, []string{"first", "second"}, receivedNames)
@@ -99,10 +99,9 @@ func TestResourcesByCategory(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		records, ok := result.([]map[string]any)
+		records, ok := result.(*CategoryListResult)
 		require.True(t, ok, "unexpected result type")
-
-		assert.Empty(t, records)
+		assert.Empty(t, records.Items)
 	})
 	t.Run("error on List", func(t *testing.T) {
 		client := testfakes.NewClient(

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -1,0 +1,116 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestResourcesByCategory(t *testing.T) {
+	t.Run("fan-out query for two types", func(t *testing.T) {
+		foo := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "resolver.bar/v1",
+				"kind":       "Foo",
+				"metadata": map[string]any{
+					"name": "first",
+				},
+			},
+		}
+		bar := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "resolver.bar/v1",
+				"kind":       "Bar",
+				"metadata": map[string]any{
+					"name": "second",
+				},
+			},
+		}
+
+		client := testfakes.NewClient(
+			testfakes.ListItems(foo, bar), nil)
+		svc := New(client, nil)
+
+		categoryName := "the-category"
+		typeByCat := map[string][]TypeByCategory{
+			categoryName: {
+				TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Foo"},
+				TypeByCategory{Group: "resolver.bar", Version: "v1", Kind: "Bar"},
+			},
+		}
+
+		resolve := svc.ResourcesByCategory(typeByCat)
+
+		result, err := resolve(graphql.ResolveParams{
+			Context: t.Context(),
+			Args:    map[string]any{"name": categoryName},
+		})
+		require.NoError(t, err)
+
+		records, ok := result.([]map[string]any)
+		require.True(t, ok, "unexpected result type")
+
+		require.Len(t, records, 2)
+
+		receivedNames := make([]string, len(records))
+		for i, v := range records {
+			receivedNames[i], _, _ = unstructured.NestedString(v, "metadata", "name")
+		}
+		assert.ElementsMatch(t, []string{"first", "second"}, receivedNames)
+	})
+	t.Run("zero types in category", func(t *testing.T) {
+		client := testfakes.NewClient(testfakes.ListItems(), nil)
+		svc := New(client, nil)
+
+		categoryName := "emptycat"
+		typeByCat := map[string][]TypeByCategory{
+			categoryName: {},
+		}
+
+		resolve := svc.ResourcesByCategory(typeByCat)
+
+		result, err := resolve(graphql.ResolveParams{
+			Context: t.Context(),
+			Args:    map[string]any{"name": categoryName},
+		})
+		require.NoError(t, err)
+
+		records, ok := result.([]map[string]any)
+		require.True(t, ok, "unexpected result type")
+
+		assert.Empty(t, records)
+	})
+	t.Run("error on List", func(t *testing.T) {
+		client := testfakes.NewClient(
+			func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+				return errors.New("could not list baz")
+			},
+			nil)
+		svc := New(client, nil)
+
+		categoryName := "baz-category"
+		typeByCat := map[string][]TypeByCategory{
+			categoryName: {
+				TypeByCategory{Group: "resolver.baz", Version: "v1", Kind: "Blap"},
+			},
+		}
+
+		resolve := svc.ResourcesByCategory(typeByCat)
+
+		result, err := resolve(graphql.ResolveParams{
+			Context: t.Context(),
+			Args:    map[string]any{"name": categoryName},
+		})
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -267,11 +267,13 @@ func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
 		listErr       error
 		expectedNames []string
 		expectError   bool
+		wantEvents    int
 	}{
 		{
 			name:          "all types allowed",
 			expectedNames: []string{"first", "second"},
 			expectError:   false,
+			wantEvents:    2,
 		},
 		{
 			name:          "one of two types forbidden",
@@ -279,6 +281,7 @@ func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
 			listErr:       forbidden,
 			expectedNames: []string{"first"},
 			expectError:   false,
+			wantEvents:    1,
 		},
 		{
 			name:          "all types forbidden",
@@ -286,6 +289,7 @@ func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
 			listErr:       forbidden,
 			expectedNames: nil,
 			expectError:   false,
+			wantEvents:    0,
 		},
 		{
 			name:          "unauthorized is not suppressed",
@@ -293,6 +297,7 @@ func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
 			listErr:       apierrors.NewUnauthorized("token expired"),
 			expectedNames: []string{"first"},
 			expectError:   true,
+			wantEvents:    2,
 		},
 	}
 
@@ -324,26 +329,40 @@ func TestSubscribeResourcesByCategory_Permissions(t *testing.T) {
 			outCh, ok := raw.(chan any)
 			require.True(t, ok, "unexpected result type")
 
-			receivedNames, receivedErr := drainEvents(t, outCh)
+			receivedNames, receivedErr := readEvents(t, outCh, tt.wantEvents)
 			assert.ElementsMatch(t, tt.expectedNames, receivedNames)
-
 			if tt.expectError {
 				assert.Error(t, receivedErr)
-				return
+			} else {
+				assert.NoError(t, receivedErr)
 			}
-			assert.NoError(t, receivedErr)
+
+			cancel()
+			for open := true; open; {
+				select {
+				case _, ok := <-outCh:
+					open = ok
+				case <-time.After(drainTimeout):
+					t.Fatal("subscription did not end after context cancel")
+				}
+			}
 		})
 	}
 }
 
-// drainEvents collects the names of all objects, as well as the last error.
-func drainEvents(t *testing.T, outCh <-chan any) (names []string, err error) {
+// drainTimeout is a fallback for the subscription wait in tests.
+const drainTimeout = 2 * time.Second
+
+// readEvents reads exactly expected number of events or errors from outCh.
+// Returns the collected metadata.name values and any received error.
+func readEvents(t *testing.T, outCh <-chan any, expected int) (names []string, err error) {
 	t.Helper()
-	for {
+	var result []string
+	for got := range expected {
 		select {
 		case event, ok := <-outCh:
 			if !ok {
-				return names, err
+				t.Fatalf("channel closed after %d events, want %d", got, expected)
 			}
 			switch v := event.(type) {
 			case error:
@@ -351,14 +370,15 @@ func drainEvents(t *testing.T, outCh <-chan any) (names []string, err error) {
 			case SubscriptionEnvelope:
 				obj, _ := v.Object.(map[string]any)
 				name, _, _ := unstructured.NestedString(obj, "metadata", "name")
-				names = append(names, name)
+				result = append(result, name)
 			default:
 				t.Fatalf("unexpected event type %T", event)
 			}
-		case <-time.After(200 * time.Millisecond):
-			return names, err
+		case <-time.After(drainTimeout):
+			t.Fatalf("timed out waiting for events: got %d, want %d", got, expected)
 		}
 	}
+	return result, err
 }
 
 // listErrForKinds returns a List function which fails with listErr for deniedKinds.

--- a/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/custom_queries_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/graphql-go/graphql"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/metrics"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,7 +40,10 @@ func TestResourcesByCategory(t *testing.T) {
 
 		client := testfakes.NewClient(
 			testfakes.ListItems(foo, bar), nil)
-		svc := New(client, nil)
+
+		metricsReg := prometheus.NewRegistry()
+		m := metrics.NewResolverMetrics(metricsReg)
+		svc := New(client, m)
 
 		categoryName := "the-category"
 		typeByCat := map[string][]TypeByCategory{
@@ -66,6 +71,16 @@ func TestResourcesByCategory(t *testing.T) {
 			receivedNames[i], _, _ = unstructured.NestedString(v, "metadata", "name")
 		}
 		assert.ElementsMatch(t, []string{"first", "second"}, receivedNames)
+
+		found, count, sum := histObservation(t, metricsReg, "kubernetes_graphql_gateway_category_fanout_types", "category", categoryName)
+		require.True(t, found, "fanout_types not recorded")
+		assert.Equal(t, uint64(1), count)
+		assert.Equal(t, float64(2), sum)
+
+		found, count, sum = histObservation(t, metricsReg, "kubernetes_graphql_gateway_category_objects_returned", "category", categoryName)
+		require.True(t, found, "objects_returned not recorded")
+		assert.Equal(t, uint64(1), count)
+		assert.Equal(t, float64(2), sum)
 	})
 	t.Run("zero types in category", func(t *testing.T) {
 		client := testfakes.NewClient(testfakes.ListItems(), nil)
@@ -113,4 +128,25 @@ func TestResourcesByCategory(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+// histObservation returns the sample count and the total sum for a given histogram.
+func histObservation(t *testing.T, reg *prometheus.Registry, name, labelName, labelValue string) (found bool, count uint64, sum float64) {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == labelName && l.GetValue() == labelValue {
+					h := m.GetHistogram()
+					return true, h.GetSampleCount(), h.GetSampleSum()
+				}
+			}
+		}
+	}
+	return false, 0, 0
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription.go
@@ -239,6 +239,9 @@ func (r *Service) runWatch(
 			}
 
 			lastRV = list.GetResourceVersion()
+			if r.metrics != nil {
+				r.metrics.ObserveWatchInitialItems(gvk.Kind, len(list.Items))
+			}
 		}
 
 		// --- WATCH phase ---

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription.go
@@ -383,7 +383,7 @@ func extractRequestedFields(info graphql.ResolveInfo) []string {
 		for _, sel := range fieldAST.SelectionSet.Selections {
 			if f, ok := sel.(*ast.Field); ok {
 				if f.Name.Value == "object" {
-					fields = append(fields, parseSelectionSet(f.SelectionSet, "")...)
+					fields = append(fields, parseSelectionSet(f.SelectionSet, "", info.Fragments)...)
 				}
 			}
 		}
@@ -393,7 +393,11 @@ func extractRequestedFields(info graphql.ResolveInfo) []string {
 
 // parseSelectionSet recursively extracts field paths from a selection set.
 // If `prefix` is non-empty, it prefixes subfields with `prefix + "."`.
-func parseSelectionSet(selectionSet *ast.SelectionSet, prefix string) []string {
+func parseSelectionSet(
+	selectionSet *ast.SelectionSet,
+	prefix string,
+	fragments map[string]ast.Definition,
+) []string {
 	var result []string
 	if selectionSet == nil {
 		return result
@@ -410,12 +414,20 @@ func parseSelectionSet(selectionSet *ast.SelectionSet, prefix string) []string {
 
 			// If this field has a sub-selection set, recurse
 			if sel.SelectionSet != nil && len(sel.SelectionSet.Selections) > 0 {
-				subFields := parseSelectionSet(sel.SelectionSet, fullPath)
+				subFields := parseSelectionSet(sel.SelectionSet, fullPath, fragments)
 				result = append(result, subFields...)
 			} else {
 				// Leaf field
 				result = append(result, fullPath)
 			}
+		case *ast.InlineFragment:
+			result = append(result, parseSelectionSet(sel.SelectionSet, prefix, fragments)...)
+		case *ast.FragmentSpread:
+			def, ok := fragments[sel.Name.Value].(*ast.FragmentDefinition)
+			if !ok {
+				continue
+			}
+			result = append(result, parseSelectionSet(def.SelectionSet, prefix, fragments)...)
 		}
 	}
 	return result

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_fields_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_fields_test.go
@@ -1,0 +1,162 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// A per-type subscription selects fields directly on a concrete object type.
+const perTypeSubscription = `
+subscription {
+  pods {
+    type
+    object {
+      metadata { name }
+      spec { nodeName }
+    }
+  }
+}`
+
+// A category subscription selects on a union, so the only way to reach a field
+// is through an inline fragment.
+const categorySubscription = `
+subscription {
+  resourcesByCategory(name: "cert-manager") {
+    type
+    object {
+      ... on Certificate {
+        metadata { name }
+        spec { dnsNames }
+      }
+    }
+  }
+}`
+
+const categorySubscriptionTwoMembers = `
+subscription {
+  resourcesByCategory(name: "cert-manager") {
+    type
+    object {
+      ... on Certificate {
+        spec { dnsNames }
+      }
+      ... on Issuer {
+        status { conditions }
+      }
+    }
+  }
+}`
+
+// A named fragment reaches the same fields by a different AST node: the body
+// lives in a FragmentDefinition, not in the spread.
+const categorySubscriptionNamedFragment = `
+subscription {
+  resourcesByCategory(name: "cert-manager") {
+    type
+    object {
+      ...certFields
+    }
+  }
+}
+
+fragment certFields on Certificate {
+  metadata { name }
+  spec { dnsNames }
+}`
+
+func TestExtractRequestedFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		expectedFields []string
+	}{
+		{
+			name:           "concrete object type",
+			query:          perTypeSubscription,
+			expectedFields: []string{"metadata.name", "spec.nodeName"},
+		},
+		{
+			name:           "inline fragment on one union member",
+			query:          categorySubscription,
+			expectedFields: []string{"metadata.name", "spec.dnsNames"},
+		},
+		{
+			name:           "inline fragments on two union members",
+			query:          categorySubscriptionTwoMembers,
+			expectedFields: []string{"spec.dnsNames", "status.conditions"},
+		},
+		{
+			name:           "named fragment spread on a union member",
+			query:          categorySubscriptionNamedFragment,
+			expectedFields: []string{"metadata.name", "spec.dnsNames"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := extractRequestedFields(resolveInfo(t, tt.query))
+
+			assert.ElementsMatch(t, tt.expectedFields, fields)
+		})
+	}
+}
+
+func TestDetermineFieldChanged_FieldSelectedThroughInlineFragment(t *testing.T) {
+	before := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "cert"},
+			"spec":     map[string]any{"dnsNames": []any{"a.example.com"}},
+		},
+	}
+	after := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "cert"},
+			"spec":     map[string]any{"dnsNames": []any{"b.example.com"}},
+		},
+	}
+
+	watched := extractRequestedFields(resolveInfo(t, categorySubscription))
+
+	changed, err := determineFieldChanged(before, after, watched)
+	require.NoError(t, err)
+
+	assert.True(t, changed, "spec.dnsNames changed but was reported unchanged")
+}
+
+// resolveInfo parses query and returns the ResolveInfo runWatch would see for
+// its single root subscription field.
+func resolveInfo(t *testing.T, query string) graphql.ResolveInfo {
+	t.Helper()
+
+	doc, err := parser.Parse(parser.ParseParams{Source: query})
+	require.NoError(t, err)
+
+	var operation *ast.OperationDefinition
+	fragments := map[string]ast.Definition{}
+
+	for _, definition := range doc.Definitions {
+		switch def := definition.(type) {
+		case *ast.OperationDefinition:
+			require.Nil(t, operation, "query has more than one operation")
+			operation = def
+		case *ast.FragmentDefinition:
+			fragments[def.Name.Value] = def
+		default:
+			t.Fatalf("unexpected definition %T", def)
+		}
+	}
+	require.NotNil(t, operation, "query has no operation")
+	require.Len(t, operation.SelectionSet.Selections, 1)
+
+	field, ok := operation.SelectionSet.Selections[0].(*ast.Field)
+	require.True(t, ok, "root selection is not a field")
+
+	return graphql.ResolveInfo{FieldASTs: []*ast.Field{field}, Fragments: fragments}
+}

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
@@ -27,9 +27,12 @@ import (
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/metrics"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -543,10 +546,14 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 			},
 		)
 
-		svc := New(client, nil)
+		metricsReg := prometheus.NewRegistry()
+		m := metrics.NewResolverMetrics(metricsReg)
+		svc := New(client, m)
+
+		const categoryName = "cert-manager"
 
 		typemap := map[string][]TypeByCategory{
-			"cert-manager": {
+			categoryName: {
 				{
 					Group:   firstGroup,
 					Version: firstVersion,
@@ -559,18 +566,19 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 				},
 			},
 		}
+		resolver := svc.SubscribeResourcesByCategory(typemap)
 
-		rFn := svc.SubscribeResourcesByCategory(typemap)
-		chObj, err := rFn(graphql.ResolveParams{
+		// act
+		resolveResult, err := resolver(graphql.ResolveParams{
 			Context: ctx,
 			Args: map[string]any{
-				NameArg: "cert-manager",
+				NameArg: categoryName,
 			},
 		})
 
 		require.NoError(t, err)
 
-		resultChan, ok := chObj.(chan any)
+		resultChan, ok := resolveResult.(chan any)
 		require.True(t, ok)
 
 		result := collectNResults(resultChan, 2)
@@ -598,6 +606,11 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 			}
 		}
 
+		series, _ := testutil.GatherAndCount(metricsReg, "kubernetes_graphql_gateway_category_watches_active")
+		assert.Equal(t, 1, series, "gauge should have exactly one series with category as label")
+		gaugeVal := testutil.ToFloat64(m.CategoryWatchesActive.WithLabelValues(categoryName))
+		assert.Equal(t, float64(2), gaugeVal, "expected metric to report two GVK subscriptions")
+
 		cancel()
 
 		select {
@@ -606,6 +619,9 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("fan-in channel did not close on context cancel")
 		}
+
+		gaugeAfter := testutil.ToFloat64(m.CategoryWatchesActive.WithLabelValues(categoryName))
+		assert.Equal(t, float64(0), gaugeAfter, "should be zero after cancellation")
 	})
 }
 

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -148,6 +149,26 @@ func collectResults(ch chan any, timeout time.Duration) []any {
 			return results
 		}
 	}
+}
+
+// collectNResults drains ch until a specific item count has been received.
+func collectNResults(ch chan any, count int) []any {
+	out := make([]any, 0, count)
+	timeout := 5 * time.Second
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for len(out) < count {
+		select {
+		case v, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, v)
+		case <-timer.C:
+			return out
+		}
+	}
+	return out
 }
 
 func TestRunWatch_WatchErrorGone_TriggersReconnection(t *testing.T) {
@@ -524,4 +545,124 @@ func TestRunWatch_410OnWatchCreation_ClearsRVAndRelists(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, addedCount, 2, "expected ADDED events from re-list after 410")
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&listCalls), int32(2), "expected re-list after 410")
+}
+
+func TestSubscribeResourcesByCategory(t *testing.T) {
+	t.Run("merges all input streams", func(t *testing.T) {
+		makeObjKind := func(kind, name, namespace, rv string) *unstructured.Unstructured {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       kind,
+					"metadata": map[string]any{
+						"name":            name,
+						"namespace":       namespace,
+						"resourceVersion": rv,
+					},
+				},
+			}
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		firstGroup := "foomanager.io"
+		firstVersion := "v1"
+		firstKind := "Issuer"
+
+		secondGroup := "foomanager.io"
+		secondVersion := "v1"
+		secondKind := "CertificateRequest"
+
+		client := fakeClient{
+			listFn: listWithItems(),
+			watchFn: func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+				gvk := list.GetObjectKind().GroupVersionKind()
+				kind := strings.TrimSuffix(gvk.Kind, "List")
+				w := newFakeWatcher()
+
+				go func() {
+					obj := makeObjKind(kind, "blapper", "system", "baz")
+					w.events <- watch.Event{Type: watch.Added, Object: obj}
+					<-ctx.Done()
+					close(w.events)
+				}()
+				return w, nil
+			},
+		}
+
+		svc := New(&client, nil)
+
+		typemap := map[string][]TypeByCategory{
+			"cert-manager": {
+				{
+					Group:   firstGroup,
+					Version: firstVersion,
+					Kind:    firstKind,
+				},
+				{
+					Group:   secondGroup,
+					Version: secondVersion,
+					Kind:    secondKind,
+				},
+			},
+		}
+
+		rFn := svc.SubscribeResourcesByCategory(typemap)
+		chObj, err := rFn(graphql.ResolveParams{
+			Context: ctx,
+			Args: map[string]any{
+				NameArg: "cert-manager",
+			},
+		})
+
+		require.NoError(t, err)
+
+		resultChan, ok := chObj.(chan any)
+		require.True(t, ok)
+
+		result := collectNResults(resultChan, 2)
+
+		// verify
+		require.Len(t, result, 2) // might break with List?
+
+		// assert
+		seenKinds := make(map[string]struct{})
+		for _, v := range result {
+			envelope, ok := v.(SubscriptionEnvelope)
+			require.True(t, ok)
+			assert.Equal(t, EventTypeAdded, envelope.Type)
+
+			fieldVals, ok := envelope.Object.(map[string]any)
+			require.True(t, ok)
+
+			kind := fieldVals["kind"]
+			seenKinds[kind.(string)] = struct{}{}
+		}
+
+		for _, kind := range []string{firstKind, secondKind} {
+			if _, got := seenKinds[kind]; !got {
+				t.Errorf("expected kind %q got none in %v", kind, seenKinds)
+			}
+		}
+
+		cancel()
+
+		select {
+		case _, open := <-resultChan:
+			assert.False(t, open, "fan-in channel should be closed")
+		case <-time.After(time.Second):
+			t.Fatal("fan-in channel did not close on context cancel")
+		}
+	})
+}
+
+// listWithItems returns a listFn returning items for the List operation.
+func listWithItems(items ...unstructured.Unstructured) func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	return func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+		ul := list.(*unstructured.UnstructuredList)
+		ul.SetResourceVersion("100")
+		ul.Items = items
+		return nil
+	}
 }

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +30,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,55 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// fakeWatcher implements watch.Interface for testing.
-type fakeWatcher struct {
-	events chan watch.Event
-	done   chan struct{}
-	once   sync.Once
-}
-
-func newFakeWatcher() *fakeWatcher {
-	return &fakeWatcher{
-		events: make(chan watch.Event, 10),
-		done:   make(chan struct{}),
-	}
-}
-
-func (f *fakeWatcher) ResultChan() <-chan watch.Event {
-	return f.events
-}
-
-func (f *fakeWatcher) Stop() {
-	f.once.Do(func() {
-		close(f.done)
-	})
-}
-
-// fakeClient implements client.WithWatch with controllable List and Watch behavior.
-type fakeClient struct {
-	ctrlruntimeclient.WithWatch
-	watchCalls int32
-	listCalls  int32
-	watchFn    func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error)
-	listFn     func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error
-}
-
-func (f *fakeClient) Watch(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
-	atomic.AddInt32(&f.watchCalls, 1)
-	if f.watchFn != nil {
-		return f.watchFn(ctx, obj, opts...)
-	}
-	return newFakeWatcher(), nil
-}
-
-func (f *fakeClient) List(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
-	atomic.AddInt32(&f.listCalls, 1)
-	if f.listFn != nil {
-		return f.listFn(ctx, obj, opts...)
-	}
-	return nil
-}
 
 func makeResolveParams(ctx context.Context) graphql.ResolveParams {
 	return graphql.ResolveParams{
@@ -176,32 +128,32 @@ func TestRunWatch_WatchErrorGone_TriggersReconnection(t *testing.T) {
 	defer cancel()
 
 	var watchCall int32
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 			call := atomic.AddInt32(&watchCall, 1)
-			w := newFakeWatcher()
+			w := testfakes.NewWatcher()
 			if call == 1 {
 				go func() {
-					w.events <- makeStatusEvent(http.StatusGone, metav1.StatusReasonExpired, "resource version too old")
-					close(w.events)
+					w.WriteChan() <- makeStatusEvent(http.StatusGone, metav1.StatusReasonExpired, "resource version too old")
+					close(w.WriteChan())
 				}()
 			} else {
 				go func() {
 					obj := makeUnstructuredObj("test", "default", "200")
-					w.events <- watch.Event{Type: watch.Added, Object: obj}
+					w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj}
 					<-ctx.Done()
-					close(w.events)
+					close(w.WriteChan())
 				}()
 			}
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -226,32 +178,32 @@ func TestRunWatch_WatchError500_TriggersReconnection(t *testing.T) {
 	defer cancel()
 
 	var watchCall int32
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 			call := atomic.AddInt32(&watchCall, 1)
-			w := newFakeWatcher()
+			w := testfakes.NewWatcher()
 			if call == 1 {
 				go func() {
-					w.events <- makeStatusEvent(http.StatusInternalServerError, metav1.StatusReasonInternalError, "internal error")
-					close(w.events)
+					w.WriteChan() <- makeStatusEvent(http.StatusInternalServerError, metav1.StatusReasonInternalError, "internal error")
+					close(w.WriteChan())
 				}()
 			} else {
 				go func() {
 					obj := makeUnstructuredObj("test", "default", "200")
-					w.events <- watch.Event{Type: watch.Added, Object: obj}
+					w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj}
 					<-ctx.Done()
-					close(w.events)
+					close(w.WriteChan())
 				}()
 			}
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -275,22 +227,22 @@ func TestRunWatch_WatchError403_IsTerminal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
-			w := newFakeWatcher()
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+			w := testfakes.NewWatcher()
 			go func() {
-				w.events <- makeStatusEvent(http.StatusForbidden, metav1.StatusReasonForbidden, "forbidden")
-				close(w.events)
+				w.WriteChan() <- makeStatusEvent(http.StatusForbidden, metav1.StatusReasonForbidden, "forbidden")
+				close(w.WriteChan())
 			}()
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -306,7 +258,7 @@ func TestRunWatch_WatchError403_IsTerminal(t *testing.T) {
 		}
 	}
 	assert.True(t, foundErr, "expected error sent to client for 403")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&fc.watchCalls), "should not retry on 403")
+	assert.Equal(t, int32(1), fc.WatchCalls(), "should not retry on 403")
 }
 
 func TestRunWatch_ChannelClose_TriggersReconnection(t *testing.T) {
@@ -314,31 +266,31 @@ func TestRunWatch_ChannelClose_TriggersReconnection(t *testing.T) {
 	defer cancel()
 
 	var watchCall int32
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 			call := atomic.AddInt32(&watchCall, 1)
-			w := newFakeWatcher()
+			w := testfakes.NewWatcher()
 			if call == 1 {
 				go func() {
-					close(w.events)
+					close(w.WriteChan())
 				}()
 			} else {
 				go func() {
 					obj := makeUnstructuredObj("test", "default", "200")
-					w.events <- watch.Event{Type: watch.Added, Object: obj}
+					w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj}
 					<-ctx.Done()
-					close(w.events)
+					close(w.WriteChan())
 				}()
 			}
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -361,22 +313,22 @@ func TestRunWatch_ChannelClose_TriggersReconnection(t *testing.T) {
 func TestRunWatch_ContextCancellation_StopsRetryLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
-			w := newFakeWatcher()
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+			w := testfakes.NewWatcher()
 			go func() {
-				w.events <- makeStatusEvent(http.StatusInternalServerError, metav1.StatusReasonInternalError, "error")
-				close(w.events)
+				w.WriteChan() <- makeStatusEvent(http.StatusInternalServerError, metav1.StatusReasonInternalError, "error")
+				close(w.WriteChan())
 			}()
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -408,28 +360,28 @@ func TestRunWatch_WatchCreationFailure_Retries(t *testing.T) {
 	defer cancel()
 
 	var watchCall int32
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("100")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 			call := atomic.AddInt32(&watchCall, 1)
 			if call == 1 {
 				return nil, fmt.Errorf("connection refused")
 			}
-			w := newFakeWatcher()
+			w := testfakes.NewWatcher()
 			go func() {
 				obj := makeUnstructuredObj("test", "default", "200")
-				w.events <- watch.Event{Type: watch.Added, Object: obj}
+				w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj}
 				<-ctx.Done()
-				close(w.events)
+				close(w.WriteChan())
 			}()
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -456,25 +408,25 @@ func TestRunWatch_NormalEvents_DeliveredCorrectly(t *testing.T) {
 	obj1 := makeUnstructuredObj("obj1", "default", "100")
 	obj2 := makeUnstructuredObj("obj1", "default", "101")
 
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			ul := list.(*unstructured.UnstructuredList)
 			ul.SetResourceVersion("99")
 			ul.Items = nil
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
-			w := newFakeWatcher()
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+			w := testfakes.NewWatcher()
 			go func() {
-				w.events <- watch.Event{Type: watch.Added, Object: obj1}
-				w.events <- watch.Event{Type: watch.Modified, Object: obj2}
-				w.events <- watch.Event{Type: watch.Deleted, Object: obj2}
+				w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj1}
+				w.WriteChan() <- watch.Event{Type: watch.Modified, Object: obj2}
+				w.WriteChan() <- watch.Event{Type: watch.Deleted, Object: obj2}
 				time.Sleep(100 * time.Millisecond)
 				cancel()
 			}()
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -501,8 +453,8 @@ func TestRunWatch_410OnWatchCreation_ClearsRVAndRelists(t *testing.T) {
 
 	var watchCall int32
 	var listCalls int32
-	fc := &fakeClient{
-		listFn: func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	fc := testfakes.NewClient(
+		func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
 			call := atomic.AddInt32(&listCalls, 1)
 			ul := list.(*unstructured.UnstructuredList)
 			if call == 1 {
@@ -514,19 +466,19 @@ func TestRunWatch_410OnWatchCreation_ClearsRVAndRelists(t *testing.T) {
 			}
 			return nil
 		},
-		watchFn: func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		func(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 			call := atomic.AddInt32(&watchCall, 1)
 			if call == 1 {
 				return nil, apierrors.NewResourceExpired("resource version too old")
 			}
-			w := newFakeWatcher()
+			w := testfakes.NewWatcher()
 			go func() {
 				<-ctx.Done()
-				close(w.events)
+				close(w.WriteChan())
 			}()
 			return w, nil
 		},
-	}
+	)
 
 	svc := &Service{runtimeClient: fc}
 	resultChannel := make(chan any, 10)
@@ -574,24 +526,24 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 		secondVersion := "v1"
 		secondKind := "CertificateRequest"
 
-		client := fakeClient{
-			listFn: listWithItems(),
-			watchFn: func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+		client := testfakes.NewClient(
+			listWithItems(),
+			func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
 				gvk := list.GetObjectKind().GroupVersionKind()
 				kind := strings.TrimSuffix(gvk.Kind, "List")
-				w := newFakeWatcher()
+				w := testfakes.NewWatcher()
 
 				go func() {
 					obj := makeObjKind(kind, "blapper", "system", "baz")
-					w.events <- watch.Event{Type: watch.Added, Object: obj}
+					w.WriteChan() <- watch.Event{Type: watch.Added, Object: obj}
 					<-ctx.Done()
-					close(w.events)
+					close(w.WriteChan())
 				}()
 				return w, nil
 			},
-		}
+		)
 
-		svc := New(&client, nil)
+		svc := New(client, nil)
 
 		typemap := map[string][]TypeByCategory{
 			"cert-manager": {

--- a/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/resolver/subscription_watch_test.go
@@ -576,7 +576,7 @@ func TestSubscribeResourcesByCategory(t *testing.T) {
 		result := collectNResults(resultChan, 2)
 
 		// verify
-		require.Len(t, result, 2) // might break with List?
+		require.Len(t, result, 2)
 
 		// assert
 		seenKinds := make(map[string]struct{})

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -20,21 +20,31 @@ import (
 	"github.com/graphql-go/graphql"
 
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/resolver"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/types"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
-	typeByCategoryFieldName = "typeByCategory"
+	typeByCategoryFieldName      = "typeByCategory"
+	resourcesByCategoryFieldName = "resourcesByCategory"
 )
 
 type CustomQueryGenerator struct {
 	resolver        *resolver.Service
 	categoryManager *CategoryManager
+	registry        *types.Registry
 }
 
-func NewCustomQueryGenerator(resolver *resolver.Service, categoryManager *CategoryManager) *CustomQueryGenerator {
+func NewCustomQueryGenerator(
+	resolver *resolver.Service,
+	categoryManager *CategoryManager,
+	registry *types.Registry,
+) *CustomQueryGenerator {
 	return &CustomQueryGenerator{
 		resolver:        resolver,
 		categoryManager: categoryManager,
+		registry:        registry,
 	}
 }
 
@@ -58,8 +68,81 @@ func (g *CustomQueryGenerator) AddTypeByCategoryQuery(rootQueryType *graphql.Obj
 	})
 }
 
+func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(rootQueryType *graphql.Object) {
+
+	typesByGVK := make(map[schema.GroupVersionKind]*graphql.Object)
+	for _, v := range g.categoryManager.AllCategories() {
+		for _, t := range v {
+			gvk := schema.GroupVersionKind{
+				Group:   t.Group,
+				Version: t.Version,
+				Kind:    t.Kind,
+			}
+			gObj, _ := g.registry.Get(g.registry.GetUniqueTypeName(&gvk))
+			if gObj == nil {
+				continue
+			}
+			typesByGVK[gvk] = gObj
+		}
+	}
+
+	unionTypes := make([]*graphql.Object, 0, len(typesByGVK))
+	for _, gObj := range typesByGVK {
+		unionTypes = append(unionTypes, gObj)
+	}
+
+	uType := graphql.NewUnion(graphql.UnionConfig{
+		Name:  "CategoryResource",
+		Types: unionTypes,
+		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+			rawObj, ok := p.Value.(map[string]any)
+			if !ok {
+				return nil
+			}
+
+			apiVersion, ok := getField(rawObj, "apiVersion")
+			if !ok {
+				return nil
+			}
+			kind, ok := getField(rawObj, "kind")
+			if !ok {
+				return nil
+			}
+			gv, err := schema.ParseGroupVersion(apiVersion)
+			if err != nil {
+				return nil
+			}
+
+			gvk := gv.WithKind(kind)
+
+			return typesByGVK[gvk]
+		},
+	})
+
+	rootQueryType.AddFieldConfig(resourcesByCategoryFieldName, &graphql.Field{
+		Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(uType))),
+		Args: graphql.FieldConfigArgument{
+			resolver.NameArg:          resolver.NameArgConfig,
+			resolver.NamespaceArg:     resolver.NamespaceArgConfig,
+			resolver.LabelSelectorArg: resolver.LabelSelectorArgConfig,
+		},
+		Resolve: g.resolver.ResourcesByCategory(g.categoryManager.AllCategories()),
+	})
+
+}
+
 func graphqlStringField() *graphql.Field {
 	return &graphql.Field{
 		Type: graphql.NewNonNull(graphql.String),
 	}
+}
+
+func getField(source map[string]any, field string) (string, bool) {
+	v, got := source[field]
+	if !got {
+		return "", got
+	}
+
+	s, ok := v.(string)
+	return s, ok
 }

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -106,9 +106,10 @@ func (g *CustomQueryGenerator) AddResourcesByCategorySubscription(
 		&graphql.Field{
 			Type: graphql.NewNonNull(eventType),
 			Args: graphql.FieldConfigArgument{
-				resolver.NameArg:          resolver.NameArgConfig,
-				resolver.NamespaceArg:     resolver.NamespaceArgConfig,
-				resolver.LabelSelectorArg: resolver.LabelSelectorArgConfig,
+				resolver.NameArg:           resolver.NameArgConfig,
+				resolver.NamespaceArg:      resolver.NamespaceArgConfig,
+				resolver.LabelSelectorArg:  resolver.LabelSelectorArgConfig,
+				resolver.SubscribeToAllArg: resolver.SubscribeToAllArgConfig,
 			},
 			Resolve:   resolver.CreateSubscriptionResolver(),
 			Subscribe: g.resolver.SubscribeResourcesByCategory(g.categoryManager.AllCategories()),

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -23,7 +23,9 @@ import (
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/fields"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/types"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -145,19 +147,31 @@ func BuildResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union
 		Name:  "CategoryResource",
 		Types: unionTypes,
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+			logger := log.FromContext(p.Context)
+
 			rawObj, ok := p.Value.(map[string]any)
 			if !ok {
 				return nil
 			}
 
-			apiVersion, ok := getField(rawObj, "apiVersion")
+			apiVersion, ok, err := unstructured.NestedString(rawObj, "apiVersion")
+			if err != nil {
+				logger.Error(err, "reading field on resolve", "field", "apiVersion")
+				return nil
+			}
 			if !ok {
 				return nil
 			}
-			kind, ok := getField(rawObj, "kind")
+
+			kind, ok, err := unstructured.NestedString(rawObj, "kind")
+			if err != nil {
+				logger.Error(err, "reading field on resolve: not a string", "field", "kind")
+				return nil
+			}
 			if !ok {
 				return nil
 			}
+
 			gv, err := schema.ParseGroupVersion(apiVersion)
 			if err != nil {
 				return nil
@@ -170,14 +184,4 @@ func BuildResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union
 	})
 
 	return uType
-}
-
-func getField(source map[string]any, field string) (string, bool) {
-	v, got := source[field]
-	if !got {
-		return "", got
-	}
-
-	s, ok := v.(string)
-	return s, ok
 }

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -20,6 +20,7 @@ import (
 	"github.com/graphql-go/graphql"
 
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/resolver"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/fields"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/types"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -68,17 +69,66 @@ func (g *CustomQueryGenerator) AddTypeByCategoryQuery(rootQueryType *graphql.Obj
 	})
 }
 
-func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(rootQueryType *graphql.Object) {
+func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(
+	rootQueryType *graphql.Object,
+	resourceUnion *graphql.Union,
+) {
+	rootQueryType.AddFieldConfig(resourcesByCategoryFieldName, &graphql.Field{
+		Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(resourceUnion))),
+		Args: graphql.FieldConfigArgument{
+			resolver.NameArg:          resolver.NameArgConfig,
+			resolver.NamespaceArg:     resolver.NamespaceArgConfig,
+			resolver.LabelSelectorArg: resolver.LabelSelectorArgConfig,
+		},
+		Resolve: g.resolver.ResourcesByCategory(g.categoryManager.AllCategories()),
+	})
+}
 
+func (g *CustomQueryGenerator) AddResourcesByCategorySubscription(
+	rootSubscription *graphql.Object,
+	resourceUnion *graphql.Union,
+) {
+	eventType := graphql.NewObject(
+		graphql.ObjectConfig{
+			Name: resourceUnion.Name() + "Event",
+			Fields: graphql.Fields{
+				"type": &graphql.Field{Type: graphql.NewNonNull(fields.WatchEventTypeEnum)},
+				// must be nullable for delete events?
+				"object": &graphql.Field{Type: resourceUnion},
+			},
+		},
+	)
+
+	rootSubscription.AddFieldConfig(resourcesByCategoryFieldName,
+		&graphql.Field{
+			Type: graphql.NewNonNull(eventType),
+			Args: graphql.FieldConfigArgument{
+				resolver.NameArg:          resolver.NameArgConfig,
+				resolver.NamespaceArg:     resolver.NamespaceArgConfig,
+				resolver.LabelSelectorArg: resolver.LabelSelectorArgConfig,
+			},
+			Resolve:   resolver.CreateSubscriptionResolver(),
+			Subscribe: g.resolver.SubscribeResourcesByCategory(g.categoryManager.AllCategories()),
+		})
+}
+
+func graphqlStringField() *graphql.Field {
+	return &graphql.Field{
+		Type: graphql.NewNonNull(graphql.String),
+	}
+}
+
+// BuildResourceUnion returns a union of all registered resource types.
+func BuildResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union {
 	typesByGVK := make(map[schema.GroupVersionKind]*graphql.Object)
-	for _, v := range g.categoryManager.AllCategories() {
+	for _, v := range cm.AllCategories() {
 		for _, t := range v {
 			gvk := schema.GroupVersionKind{
 				Group:   t.Group,
 				Version: t.Version,
 				Kind:    t.Kind,
 			}
-			gObj, _ := g.registry.Get(g.registry.GetUniqueTypeName(&gvk))
+			gObj, _ := reg.Get(reg.GetUniqueTypeName(&gvk))
 			if gObj == nil {
 				continue
 			}
@@ -119,22 +169,7 @@ func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(rootQueryType *graphq
 		},
 	})
 
-	rootQueryType.AddFieldConfig(resourcesByCategoryFieldName, &graphql.Field{
-		Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(uType))),
-		Args: graphql.FieldConfigArgument{
-			resolver.NameArg:          resolver.NameArgConfig,
-			resolver.NamespaceArg:     resolver.NamespaceArgConfig,
-			resolver.LabelSelectorArg: resolver.LabelSelectorArgConfig,
-		},
-		Resolve: g.resolver.ResourcesByCategory(g.categoryManager.AllCategories()),
-	})
-
-}
-
-func graphqlStringField() *graphql.Field {
-	return &graphql.Field{
-		Type: graphql.NewNonNull(graphql.String),
-	}
+	return uType
 }
 
 func getField(source map[string]any, field string) (string, bool) {

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -87,7 +87,7 @@ func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(
 	})
 
 	rootQueryType.AddFieldConfig(resourcesByCategoryFieldName, &graphql.Field{
-		Type: listType,
+		Type: graphql.NewNonNull(listType),
 		Args: graphql.FieldConfigArgument{
 			resolver.NameArg:          resolver.NameArgConfig,
 			resolver.NamespaceArg:     resolver.NamespaceArgConfig,
@@ -105,8 +105,7 @@ func (g *CustomQueryGenerator) AddResourcesByCategorySubscription(
 		graphql.ObjectConfig{
 			Name: resourceUnion.Name() + "Event",
 			Fields: graphql.Fields{
-				"type": &graphql.Field{Type: graphql.NewNonNull(fields.WatchEventTypeEnum)},
-				// must be nullable for delete events?
+				"type":   &graphql.Field{Type: graphql.NewNonNull(fields.WatchEventTypeEnum)},
 				"object": &graphql.Field{Type: resourceUnion},
 			},
 		},
@@ -114,7 +113,7 @@ func (g *CustomQueryGenerator) AddResourcesByCategorySubscription(
 
 	rootSubscription.AddFieldConfig(resourcesByCategoryFieldName,
 		&graphql.Field{
-			Type: graphql.NewNonNull(eventType),
+			Type: eventType,
 			Args: graphql.FieldConfigArgument{
 				resolver.NameArg:           resolver.NameArgConfig,
 				resolver.NamespaceArg:      resolver.NamespaceArgConfig,

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -31,6 +31,7 @@ import (
 const (
 	typeByCategoryFieldName      = "typeByCategory"
 	resourcesByCategoryFieldName = "resourcesByCategory"
+	unionTypeName                = "CategoryResource"
 )
 
 type CustomQueryGenerator struct {
@@ -120,8 +121,10 @@ func graphqlStringField() *graphql.Field {
 	}
 }
 
-// BuildResourceUnion returns a union of all registered resource types.
-func BuildResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union {
+// BuildCategoryResourceUnion builds a union of the resource types in at least one category set.
+// Category members with no type in the registry are skipped.
+// Returns nil when no registered resource types with a category remain.
+func BuildCategoryResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union {
 	typesByGVK := make(map[schema.GroupVersionKind]*graphql.Object)
 	for _, v := range cm.AllCategories() {
 		for _, t := range v {
@@ -143,8 +146,12 @@ func BuildResourceUnion(cm *CategoryManager, reg *types.Registry) *graphql.Union
 		unionTypes = append(unionTypes, gObj)
 	}
 
+	if len(unionTypes) == 0 {
+		return nil
+	}
+
 	uType := graphql.NewUnion(graphql.UnionConfig{
-		Name:  "CategoryResource",
+		Name:  unionTypeName,
 		Types: unionTypes,
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			logger := log.FromContext(p.Context)

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries.go
@@ -32,6 +32,7 @@ const (
 	typeByCategoryFieldName      = "typeByCategory"
 	resourcesByCategoryFieldName = "resourcesByCategory"
 	unionTypeName                = "CategoryResource"
+	categoryListTypeName         = "CategoryResourceList"
 )
 
 type CustomQueryGenerator struct {
@@ -76,8 +77,17 @@ func (g *CustomQueryGenerator) AddResourcesByCategoryQuery(
 	rootQueryType *graphql.Object,
 	resourceUnion *graphql.Union,
 ) {
+	listType := graphql.NewObject(graphql.ObjectConfig{
+		Name: categoryListTypeName,
+		Fields: graphql.Fields{
+			"items": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(resourceUnion))),
+			},
+		},
+	})
+
 	rootQueryType.AddFieldConfig(resourcesByCategoryFieldName, &graphql.Field{
-		Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(resourceUnion))),
+		Type: listType,
 		Args: graphql.FieldConfigArgument{
 			resolver.NameArg:          resolver.NameArgConfig,
 			resolver.NamespaceArg:     resolver.NamespaceArgConfig,

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/resolver"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/types"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestUnionFoo(t *testing.T) {
+	r := types.NewRegistry()
+
+	first := schema.GroupVersionKind{
+		Group:   "blappers.deploy.once",
+		Version: "v1",
+		Kind:    "Certificate",
+	}
+	second := schema.GroupVersionKind{
+		Group:   "blappers.deploy.once",
+		Version: "v1beta1",
+		Kind:    "Issuer",
+	}
+
+	key := r.GetUniqueTypeName(&first)
+
+	r.Register(key, graphql.NewObject(graphql.ObjectConfig{
+		Name: "First",
+		Fields: graphql.Fields{
+			"apiVersion": &graphql.Field{
+				Type: graphql.String,
+			},
+		},
+	}), nil)
+	r.Register(
+		r.GetUniqueTypeName(&second),
+		graphql.NewObject(graphql.ObjectConfig{
+			Name: "Another",
+			Fields: graphql.Fields{
+				"apiVersion": &graphql.Field{
+					Type: graphql.String,
+				},
+			},
+		}), nil)
+
+	typesByCat := map[string][]resolver.TypeByCategory{
+		"cert-manager": {
+			{
+				Group:   first.Group,
+				Version: first.Version,
+				Kind:    first.Kind,
+			},
+			{
+				Group:   second.Group,
+				Version: second.Version,
+				Kind:    second.Kind,
+			},
+		},
+	}
+
+	g := CustomQueryGenerator{
+		registry: r,
+		categoryManager: &CategoryManager{
+			typeByCategory: typesByCat,
+		}}
+
+	root := graphql.NewObject(
+		graphql.ObjectConfig{
+			Name:   "Query",
+			Fields: graphql.Fields{},
+		},
+	)
+
+	g.AddResourcesByCategoryQuery(root)
+
+	field := root.Fields()["resourcesByCategory"]
+	require.NotNil(t, field)
+
+	x, ok := field.Type.(*graphql.NonNull)
+	require.True(t, ok)
+
+	foo, ok := x.OfType.(*graphql.List)
+	require.True(t, ok)
+
+	bar, ok := foo.OfType.(*graphql.NonNull)
+	require.True(t, ok)
+
+	baz, ok := bar.OfType.(*graphql.Union)
+	require.True(t, ok)
+
+	require.Len(t, baz.Types(), 2)
+	assert.Equal(t, "CategoryResource", baz.Name())
+}

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -29,88 +29,69 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestUnionFoo(t *testing.T) {
-	r := types.NewRegistry()
-
-	first := schema.GroupVersionKind{
-		Group:   "blappers.deploy.once",
-		Version: "v1",
-		Kind:    "Certificate",
-	}
-	second := schema.GroupVersionKind{
-		Group:   "blappers.deploy.once",
-		Version: "v1beta1",
-		Kind:    "Issuer",
-	}
-
-	key := r.GetUniqueTypeName(&first)
-
-	r.Register(key, graphql.NewObject(graphql.ObjectConfig{
-		Name: "First",
-		Fields: graphql.Fields{
-			"apiVersion": &graphql.Field{
-				Type: graphql.String,
-			},
-		},
+// registerMember adds a resource type under the given GVK in the registry.
+func registerMember(r *types.Registry, group, version, kind string) schema.GroupVersionKind {
+	gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
+	r.Register(r.GetUniqueTypeName(&gvk), graphql.NewObject(graphql.ObjectConfig{
+		Name:   r.GetUniqueTypeName(&gvk),
+		Fields: graphql.Fields{"apiVersion": {Type: graphql.String}},
 	}), nil)
-	r.Register(
-		r.GetUniqueTypeName(&second),
-		graphql.NewObject(graphql.ObjectConfig{
-			Name: "Another",
-			Fields: graphql.Fields{
-				"apiVersion": &graphql.Field{
-					Type: graphql.String,
+	return gvk
+}
+
+func TestBuildResourceUnion(t *testing.T) {
+	r := types.NewRegistry()
+	cert := registerMember(r, "blappers.deploy.once", "v1", "Certificate")
+	issuer := registerMember(r, "blappers.deploy.once", "v1", "Issuer")
+
+	categoryName := "cert-manager"
+
+	cm := CategoryManager{typeByCategory: map[string][]resolver.TypeByCategory{
+		categoryName: {
+			resolver.TypeByCategory{Group: cert.Group, Version: cert.Version, Kind: cert.Kind},
+			resolver.TypeByCategory{Group: issuer.Group, Version: issuer.Version, Kind: issuer.Kind},
+		},
+	}}
+
+	union := BuildResourceUnion(&cm, r)
+
+	root := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"testfield": &graphql.Field{
+				Type: graphql.NewList(union),
+				Resolve: func(p graphql.ResolveParams) (any, error) {
+					return []any{
+							map[string]any{"apiVersion": "blappers.deploy.once/v1", "kind": "Certificate"},
+							map[string]any{"apiVersion": "blappers.deploy.once/v1", "kind": "Issuer"},
+						},
+						nil
 				},
 			},
-		}), nil)
-
-	typesByCat := map[string][]resolver.TypeByCategory{
-		"cert-manager": {
-			{
-				Group:   first.Group,
-				Version: first.Version,
-				Kind:    first.Kind,
-			},
-			{
-				Group:   second.Group,
-				Version: second.Version,
-				Kind:    second.Kind,
-			},
 		},
+	})
+
+	sch, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
+	require.NoError(t, err)
+
+	response := graphql.Do(graphql.Params{
+		Schema:        sch,
+		Context:       t.Context(),
+		RequestString: `{ testfield { __typename } }`,
+	})
+	require.Empty(t, response.Errors, "query should not err")
+
+	items := response.Data.(map[string]any)["testfield"].([]any)
+	_ = items
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		typeName := item.(map[string]any)["__typename"]
+		result = append(result, typeName.(string))
 	}
 
-	cm := CategoryManager{
-		typeByCategory: typesByCat,
-	}
-	g := CustomQueryGenerator{
-		registry:        r,
-		categoryManager: &cm}
-
-	root := graphql.NewObject(
-		graphql.ObjectConfig{
-			Name:   "Query",
-			Fields: graphql.Fields{},
-		},
-	)
-
-	resources := BuildResourceUnion(&cm, g.registry)
-	g.AddResourcesByCategoryQuery(root, resources)
-
-	field := root.Fields()["resourcesByCategory"]
-	require.NotNil(t, field)
-
-	x, ok := field.Type.(*graphql.NonNull)
-	require.True(t, ok)
-
-	foo, ok := x.OfType.(*graphql.List)
-	require.True(t, ok)
-
-	bar, ok := foo.OfType.(*graphql.NonNull)
-	require.True(t, ok)
-
-	baz, ok := bar.OfType.(*graphql.Union)
-	require.True(t, ok)
-
-	require.Len(t, baz.Types(), 2)
-	assert.Equal(t, "CategoryResource", baz.Name())
+	assert.ElementsMatch(t, []string{
+		r.GetUniqueTypeName(&cert),
+		r.GetUniqueTypeName(&issuer),
+	}, result)
 }

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -71,11 +71,11 @@ func TestBuildResourceUnion(t *testing.T) {
 		},
 	})
 
-	sch, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
 	require.NoError(t, err)
 
 	response := graphql.Do(graphql.Params{
-		Schema:        sch,
+		Schema:        schema,
 		Context:       t.Context(),
 		RequestString: `{ testfield { __typename } }`,
 	})
@@ -94,4 +94,47 @@ func TestBuildResourceUnion(t *testing.T) {
 		r.GetUniqueTypeName(&cert),
 		r.GetUniqueTypeName(&issuer),
 	}, result)
+}
+
+func TestBuildResourceUnion_MalformedAPIVersion(t *testing.T) {
+	r := types.NewRegistry()
+	cert := registerMember(r, "foo.cluster.bar", "v1", "Bucket")
+	issuer := registerMember(r, "foo.cluster.bar", "v1", "Secret")
+
+	categoryName := "foo-category"
+
+	cm := CategoryManager{typeByCategory: map[string][]resolver.TypeByCategory{
+		categoryName: {
+			resolver.TypeByCategory{Group: cert.Group, Version: cert.Version, Kind: cert.Kind},
+			resolver.TypeByCategory{Group: issuer.Group, Version: issuer.Version, Kind: issuer.Kind},
+		},
+	}}
+
+	union := BuildResourceUnion(&cm, r)
+
+	root := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"testfield": &graphql.Field{
+				Type: graphql.NewList(union),
+				Resolve: func(p graphql.ResolveParams) (any, error) {
+					return []any{
+							map[string]any{"apiVersion": "foo.cluster.bar/v1", "kind": "Bucket"},
+							map[string]any{"apiVersion": 123, "kind": "Secret"},
+						},
+						nil
+				},
+			},
+		},
+	})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
+	require.NoError(t, err)
+
+	response := graphql.Do(graphql.Params{
+		Schema:        schema,
+		Context:       t.Context(),
+		RequestString: `{ testfield { __typename } }`,
+	})
+	require.NotEmpty(t, response.Errors, "wrong type for apiVersion should result in an error")
 }

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -79,11 +79,12 @@ func TestUnionFoo(t *testing.T) {
 		},
 	}
 
+	cm := CategoryManager{
+		typeByCategory: typesByCat,
+	}
 	g := CustomQueryGenerator{
-		registry: r,
-		categoryManager: &CategoryManager{
-			typeByCategory: typesByCat,
-		}}
+		registry:        r,
+		categoryManager: &cm}
 
 	root := graphql.NewObject(
 		graphql.ObjectConfig{
@@ -92,7 +93,8 @@ func TestUnionFoo(t *testing.T) {
 		},
 	)
 
-	g.AddResourcesByCategoryQuery(root)
+	resources := BuildResourceUnion(&cm, g.registry)
+	g.AddResourcesByCategoryQuery(root, resources)
 
 	field := root.Fields()["resourcesByCategory"]
 	require.NotNil(t, field)

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -39,7 +39,7 @@ func registerMember(r *types.Registry, group, version, kind string) schema.Group
 	return gvk
 }
 
-func TestBuildResourceUnion(t *testing.T) {
+func TestBuildCategoryResourceUnion(t *testing.T) {
 	r := types.NewRegistry()
 	cert := registerMember(r, "blappers.deploy.once", "v1", "Certificate")
 	issuer := registerMember(r, "blappers.deploy.once", "v1", "Issuer")
@@ -53,7 +53,7 @@ func TestBuildResourceUnion(t *testing.T) {
 		},
 	}}
 
-	union := BuildResourceUnion(&cm, r)
+	union := BuildCategoryResourceUnion(&cm, r)
 
 	root := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
@@ -94,7 +94,7 @@ func TestBuildResourceUnion(t *testing.T) {
 	}, result)
 }
 
-func TestBuildResourceUnion_invalidAPIVersion(t *testing.T) {
+func TestBuildCategoryResourceUnion_invalidAPIVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		sources []any
@@ -130,7 +130,7 @@ func TestBuildResourceUnion_invalidAPIVersion(t *testing.T) {
 				},
 			}}
 
-			union := BuildResourceUnion(&cm, r)
+			union := BuildCategoryResourceUnion(&cm, r)
 
 			root := graphql.NewObject(graphql.ObjectConfig{
 				Name: "Query",

--- a/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/extensions/custom_queries_test.go
@@ -82,8 +82,6 @@ func TestBuildResourceUnion(t *testing.T) {
 	require.Empty(t, response.Errors, "query should not err")
 
 	items := response.Data.(map[string]any)["testfield"].([]any)
-	_ = items
-
 	result := make([]string, 0, len(items))
 	for _, item := range items {
 		typeName := item.(map[string]any)["__typename"]
@@ -96,45 +94,65 @@ func TestBuildResourceUnion(t *testing.T) {
 	}, result)
 }
 
-func TestBuildResourceUnion_MalformedAPIVersion(t *testing.T) {
-	r := types.NewRegistry()
-	cert := registerMember(r, "foo.cluster.bar", "v1", "Bucket")
-	issuer := registerMember(r, "foo.cluster.bar", "v1", "Secret")
-
-	categoryName := "foo-category"
-
-	cm := CategoryManager{typeByCategory: map[string][]resolver.TypeByCategory{
-		categoryName: {
-			resolver.TypeByCategory{Group: cert.Group, Version: cert.Version, Kind: cert.Kind},
-			resolver.TypeByCategory{Group: issuer.Group, Version: issuer.Version, Kind: issuer.Kind},
-		},
-	}}
-
-	union := BuildResourceUnion(&cm, r)
-
-	root := graphql.NewObject(graphql.ObjectConfig{
-		Name: "Query",
-		Fields: graphql.Fields{
-			"testfield": &graphql.Field{
-				Type: graphql.NewList(union),
-				Resolve: func(p graphql.ResolveParams) (any, error) {
-					return []any{
-							map[string]any{"apiVersion": "foo.cluster.bar/v1", "kind": "Bucket"},
-							map[string]any{"apiVersion": 123, "kind": "Secret"},
-						},
-						nil
-				},
+func TestBuildResourceUnion_invalidAPIVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []any
+	}{
+		{
+			name: "apiVersion is not a string",
+			sources: []any{
+				map[string]any{"apiVersion": "foo.cluster.bar/v1", "kind": "Bucket"},
+				map[string]any{"apiVersion": 123, "kind": "Secret"},
 			},
 		},
-	})
+		{
+			name: "apiVersion is malformed",
+			sources: []any{
+				map[string]any{"apiVersion": "foo.cluster.bar/v1", "kind": "Bucket"},
+				map[string]any{"apiVersion": "a/b/c", "kind": "Secret"},
+			},
+		},
+	}
 
-	schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := types.NewRegistry()
+			cert := registerMember(r, "foo.cluster.bar", "v1", "Bucket")
+			issuer := registerMember(r, "foo.cluster.bar", "v1", "Secret")
 
-	response := graphql.Do(graphql.Params{
-		Schema:        schema,
-		Context:       t.Context(),
-		RequestString: `{ testfield { __typename } }`,
-	})
-	require.NotEmpty(t, response.Errors, "wrong type for apiVersion should result in an error")
+			categoryName := "foo-category"
+
+			cm := CategoryManager{typeByCategory: map[string][]resolver.TypeByCategory{
+				categoryName: {
+					resolver.TypeByCategory{Group: cert.Group, Version: cert.Version, Kind: cert.Kind},
+					resolver.TypeByCategory{Group: issuer.Group, Version: issuer.Version, Kind: issuer.Kind},
+				},
+			}}
+
+			union := BuildResourceUnion(&cm, r)
+
+			root := graphql.NewObject(graphql.ObjectConfig{
+				Name: "Query",
+				Fields: graphql.Fields{
+					"testfield": &graphql.Field{
+						Type: graphql.NewList(union),
+						Resolve: func(p graphql.ResolveParams) (any, error) {
+							return tt.sources, nil
+						},
+					},
+				},
+			})
+
+			schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: root})
+			require.NoError(t, err)
+
+			response := graphql.Do(graphql.Params{
+				Schema:        schema,
+				Context:       t.Context(),
+				RequestString: `{ testfield { __typename } }`,
+			})
+			require.NotEmpty(t, response.Errors, "invalid apiVersion should result in an error")
+		})
+	}
 }

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
@@ -78,8 +78,12 @@ func New(definitions map[string]*spec.Schema, resolverProvider *resolver.Service
 		mutationGen:     fields.NewMutationGenerator(resolverProvider),
 		subscriptionGen: fields.NewSubscriptionGenerator(resolverProvider),
 		categoryManager: categoryManager,
-		customQueryGen:  extensions.NewCustomQueryGenerator(resolverProvider, categoryManager),
-		customSubGen:    customSubGen,
+		customQueryGen: extensions.NewCustomQueryGenerator(
+			resolverProvider,
+			categoryManager,
+			registry,
+		),
+		customSubGen: customSubGen,
 	}
 }
 
@@ -105,6 +109,7 @@ func (g *SchemaGenerator) Generate(ctx context.Context) (*graphql.Schema, error)
 	}
 
 	g.customQueryGen.AddTypeByCategoryQuery(rootQuery)
+	g.customQueryGen.AddResourcesByCategoryQuery(rootQuery)
 	g.addApplyYamlMutation(rootMutation)
 
 	if g.customSubGen != nil {
@@ -292,6 +297,7 @@ func (g *SchemaGenerator) processResource(
 		Name:   uniqueTypeName + "_Input",
 		Fields: inputFields,
 	})
+	g.typeRegistry.Register(uniqueTypeName, resourceType, inputType)
 
 	rc := &fields.ResourceContext{
 		GVK:            r.GVK,

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
@@ -109,7 +109,10 @@ func (g *SchemaGenerator) Generate(ctx context.Context) (*graphql.Schema, error)
 	}
 
 	g.customQueryGen.AddTypeByCategoryQuery(rootQuery)
-	g.customQueryGen.AddResourcesByCategoryQuery(rootQuery)
+
+	resUnion := extensions.BuildResourceUnion(g.categoryManager, g.typeRegistry)
+	g.customQueryGen.AddResourcesByCategoryQuery(rootQuery, resUnion)
+	g.customQueryGen.AddResourcesByCategorySubscription(rootSubscription, resUnion)
 	g.addApplyYamlMutation(rootMutation)
 
 	if g.customSubGen != nil {

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
@@ -62,10 +62,18 @@ type SchemaGenerator struct {
 	categoryManager *extensions.CategoryManager
 	customQueryGen  *extensions.CustomQueryGenerator
 	customSubGen    *extensions.CustomSubscriptionGenerator
+
+	// resourcesByCategoryEnabled is a PoC feature flag which will be removed eventually.
+	resourcesByCategoryEnabled bool
 }
 
 // New creates a new schema generator.
-func New(definitions map[string]*spec.Schema, resolverProvider *resolver.Service, customSubGen *extensions.CustomSubscriptionGenerator) *SchemaGenerator {
+func New(
+	definitions map[string]*spec.Schema,
+	resolverProvider *resolver.Service,
+	customSubGen *extensions.CustomSubscriptionGenerator,
+	resourcesByCategoryEnabled bool,
+) *SchemaGenerator {
 	registry := types.NewRegistry()
 	categoryManager := extensions.NewCategoryManager(definitions)
 
@@ -83,7 +91,8 @@ func New(definitions map[string]*spec.Schema, resolverProvider *resolver.Service
 			categoryManager,
 			registry,
 		),
-		customSubGen: customSubGen,
+		customSubGen:               customSubGen,
+		resourcesByCategoryEnabled: resourcesByCategoryEnabled,
 	}
 }
 
@@ -110,10 +119,12 @@ func (g *SchemaGenerator) Generate(ctx context.Context) (*graphql.Schema, error)
 
 	g.customQueryGen.AddTypeByCategoryQuery(rootQuery)
 
-	resourceWithCategory := extensions.BuildCategoryResourceUnion(g.categoryManager, g.typeRegistry)
-	if resourceWithCategory != nil {
-		g.customQueryGen.AddResourcesByCategoryQuery(rootQuery, resourceWithCategory)
-		g.customQueryGen.AddResourcesByCategorySubscription(rootSubscription, resourceWithCategory)
+	if g.resourcesByCategoryEnabled {
+		resourceWithCategory := extensions.BuildCategoryResourceUnion(g.categoryManager, g.typeRegistry)
+		if resourceWithCategory != nil {
+			g.customQueryGen.AddResourcesByCategoryQuery(rootQuery, resourceWithCategory)
+			g.customQueryGen.AddResourcesByCategorySubscription(rootSubscription, resourceWithCategory)
+		}
 	}
 
 	g.addApplyYamlMutation(rootMutation)

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator.go
@@ -110,9 +110,12 @@ func (g *SchemaGenerator) Generate(ctx context.Context) (*graphql.Schema, error)
 
 	g.customQueryGen.AddTypeByCategoryQuery(rootQuery)
 
-	resUnion := extensions.BuildResourceUnion(g.categoryManager, g.typeRegistry)
-	g.customQueryGen.AddResourcesByCategoryQuery(rootQuery, resUnion)
-	g.customQueryGen.AddResourcesByCategorySubscription(rootSubscription, resUnion)
+	resourceWithCategory := extensions.BuildCategoryResourceUnion(g.categoryManager, g.typeRegistry)
+	if resourceWithCategory != nil {
+		g.customQueryGen.AddResourcesByCategoryQuery(rootQuery, resourceWithCategory)
+		g.customQueryGen.AddResourcesByCategorySubscription(rootSubscription, resourceWithCategory)
+	}
+
 	g.addApplyYamlMutation(rootMutation)
 
 	if g.customSubGen != nil {

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -17,17 +17,129 @@ limitations under the License.
 package generator
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/graphql-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pmgateway "go.platform-mesh.io/apis/gateway"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/resolver"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/schema/types"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/internal/testfakes"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestGenerate_resourcesByCategory(t *testing.T) {
+	t.Run("result for objects in two gvks", func(t *testing.T) {
+		categoryName := "foo-managed"
+		first := schemaWithCategory(
+			"foo.tests.bar",
+			"v1beta1",
+			"Foo",
+			apiextensionsv1.NamespaceScoped,
+			categoryName,
+		)
+		second := schemaWithCategory(
+			"foo.tests.bar",
+			"v1",
+			"Bar",
+			apiextensionsv1.NamespaceScoped,
+			categoryName,
+		)
+
+		foo := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "foo.tests.bar/v1beta1",
+				"kind":       "Foo",
+				"metadata": map[string]any{
+					"name": "first",
+				},
+			},
+		}
+		bar := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "foo.tests.bar/v1",
+				"kind":       "Bar",
+				"metadata": map[string]any{
+					"name": "second",
+				},
+			},
+		}
+
+		client := testfakes.NewClient(
+			func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+				ul := list.(*unstructured.UnstructuredList)
+				ul.SetResourceVersion("100")
+
+				switch strings.TrimSuffix(ul.GetObjectKind().GroupVersionKind().Kind, "List") {
+				case "Foo":
+					ul.Items = []unstructured.Unstructured{foo}
+				case "Bar":
+					ul.Items = []unstructured.Unstructured{bar}
+				}
+				return nil
+			},
+			nil,
+		)
+
+		resolver := resolver.New(client, nil)
+		sut := New(
+			map[string]*spec.Schema{
+				"foo/key":    first,
+				"foo/second": second,
+			},
+			resolver,
+			nil, // happens to be safe
+		)
+
+		schemagen, err := sut.Generate(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, schemagen)
+
+		reg := types.NewRegistry()
+		fooType := reg.GetUniqueTypeName(&schema.GroupVersionKind{Group: "foo.tests.bar", Version: "v1beta1", Kind: "Foo"})
+		barType := reg.GetUniqueTypeName(&schema.GroupVersionKind{Group: "foo.tests.bar", Version: "v1", Kind: "Bar"})
+
+		query := fmt.Sprintf(`{
+	resourcesByCategory(name: "%s") {
+    __typename
+    ... on %s { metadata { name } }
+    ... on %s { metadata { name } }
+  }
+	}`, categoryName, fooType, barType)
+
+		result := graphql.Do(graphql.Params{
+			Schema:        *schemagen,
+			Context:       t.Context(),
+			RequestString: query,
+		})
+
+		require.Empty(t, result.Errors)
+
+		queryResults := result.Data.(map[string]any)["resourcesByCategory"].([]any)
+		assert.Len(t, queryResults, 2)
+
+		byType := map[string]string{}
+		for _, v := range queryResults {
+			data := v.(map[string]any)
+			meta := data["metadata"].(map[string]any)
+			typeName := data["__typename"].(string)
+			byType[typeName] = meta["name"].(string)
+		}
+
+		assert.Equal(t, "first", byType[fooType])
+		assert.Equal(t, "second", byType[barType])
+	})
+}
 
 func TestGroupByAPIGroup(t *testing.T) {
 	tests := []struct {
@@ -316,6 +428,44 @@ func schemaWithGVKAndScope(group, version, kind string, scope apiextensionsv1.Re
 			Extensions: spec.Extensions{
 				pmgateway.GVKExtensionKey:   []any{map[string]any{"group": group, "version": version, "kind": kind}},
 				pmgateway.ScopeExtensionKey: string(scope),
+			},
+		},
+	}
+}
+
+func schemaWithCategory(
+	group, version, kind string,
+	scope apiextensionsv1.ResourceScope,
+	categories ...string,
+) *spec.Schema {
+	cat := make([]any, 0, len(categories))
+	for _, v := range categories {
+		cat = append(cat, v)
+	}
+
+	return &spec.Schema{
+		VendorExtensible: spec.VendorExtensible{
+			Extensions: spec.Extensions{
+				pmgateway.GVKExtensionKey:        []any{map[string]any{"group": group, "version": version, "kind": kind}},
+				pmgateway.ScopeExtensionKey:      scope,
+				pmgateway.CategoriesExtensionKey: cat,
+			},
+		},
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"metadata": {
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"object"},
+						Properties: map[string]spec.Schema{
+							"name": {
+								SchemaProps: spec.SchemaProps{
+									Type: spec.StringOrArray{"string"},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -207,6 +207,7 @@ func setup(
 		definitions,
 		resolver,
 		nil,
+		true,
 	)
 }
 

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -114,6 +114,27 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 		assert.Equal(t, "first", byType[fooType])
 		assert.Equal(t, "second", byType[barType])
 	})
+	t.Run("exposes subscribeToAll arg", func(t *testing.T) {
+		schemaDef := schemaWithCategory("a.b.c", "v1", "Fooer", apiextensionsv1.NamespaceScoped, "cat")
+		sut := setup(listItems(), schemaDef)
+
+		sch, err := sut.Generate(t.Context())
+		require.NoError(t, err)
+
+		field := sch.SubscriptionType().Fields()["resourcesByCategory"]
+		require.NotNil(t, field)
+
+		var argFound bool
+		for _, v := range field.Args {
+			if v.Name() == "subscribeToAll" {
+				argFound = true
+				break
+			}
+		}
+
+		assert.True(t, argFound, "subscribeToAll arg should be on the query")
+	})
+
 	t.Run("resources have no category", func(t *testing.T) {
 		uncategorized := schemaWithCategory(
 			"pm.io",

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -19,6 +19,7 @@ package generator
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -114,7 +115,7 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 		assert.Equal(t, "first", byType[fooType])
 		assert.Equal(t, "second", byType[barType])
 	})
-	t.Run("exposes subscribeToAll arg", func(t *testing.T) {
+	t.Run("subscription exposes only subscribeToAll", func(t *testing.T) {
 		schemaDef := schemaWithCategory("a.b.c", "v1", "Fooer", apiextensionsv1.NamespaceScoped, "cat")
 		sut := setup(listItems(), schemaDef)
 
@@ -124,15 +125,12 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 		field := sch.SubscriptionType().Fields()["resourcesByCategory"]
 		require.NotNil(t, field)
 
-		var argFound bool
-		for _, v := range field.Args {
-			if v.Name() == "subscribeToAll" {
-				argFound = true
-				break
-			}
+		hasArg := func(argName string) bool {
+			return slices.ContainsFunc(field.Args, func(a *graphql.Argument) bool { return a.Name() == argName })
 		}
 
-		assert.True(t, argFound, "subscribeToAll arg should be on the query")
+		assert.True(t, hasArg("subscribeToAll"), "subscribeToAll arg should be on the subscription")
+		assert.False(t, hasArg("resourceVersion"), "resourceVersion is not supported in resourcesByCategory")
 	})
 
 	t.Run("resources have no category", func(t *testing.T) {

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -74,32 +74,7 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 				},
 			},
 		}
-
-		client := testfakes.NewClient(
-			func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
-				ul := list.(*unstructured.UnstructuredList)
-				ul.SetResourceVersion("100")
-
-				switch strings.TrimSuffix(ul.GetObjectKind().GroupVersionKind().Kind, "List") {
-				case "Foo":
-					ul.Items = []unstructured.Unstructured{foo}
-				case "Bar":
-					ul.Items = []unstructured.Unstructured{bar}
-				}
-				return nil
-			},
-			nil,
-		)
-
-		resolver := resolver.New(client, nil)
-		sut := New(
-			map[string]*spec.Schema{
-				"foo/key":    first,
-				"foo/second": second,
-			},
-			resolver,
-			nil, // happens to be safe
-		)
+		sut := setup(listItems(foo, bar), first, second)
 
 		schemagen, err := sut.Generate(t.Context())
 		require.NoError(t, err)
@@ -139,6 +114,79 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 		assert.Equal(t, "first", byType[fooType])
 		assert.Equal(t, "second", byType[barType])
 	})
+	t.Run("resources have no category", func(t *testing.T) {
+		uncategorized := schemaWithCategory(
+			"pm.io",
+			"v1",
+			"Workload",
+			apiextensionsv1.NamespaceScoped,
+		)
+		instance := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "pm.io/v1",
+				"kind":       "Workload",
+				"metadata": map[string]any{
+					"name": "foo",
+				},
+			},
+		}
+
+		sut := setup(listItems(instance), uncategorized)
+		sch, err := sut.Generate(t.Context())
+		require.NoError(t, err)
+
+		reg := types.NewRegistry()
+		workloadType := reg.GetUniqueTypeName(&schema.GroupVersionKind{Group: "pm.io", Version: "v1", Kind: "Workload"})
+
+		schemaType := sch.Type(workloadType)
+		require.NotNil(t, schemaType, "resource with no category should be in the schema")
+	})
+}
+
+// listItems returns a client List function returning objs filtered by GVK.
+func listItems(
+	objs ...unstructured.Unstructured,
+) func(context.Context, ctrlruntimeclient.ObjectList, ...ctrlruntimeclient.ListOption) error {
+	byGVK := map[schema.GroupVersionKind][]unstructured.Unstructured{}
+	for _, v := range objs {
+		gvk := v.GroupVersionKind()
+		byGVK[gvk] = append(byGVK[gvk], v)
+	}
+
+	return func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+		ul := list.(*unstructured.UnstructuredList)
+		ul.SetResourceVersion("100")
+
+		gvk := ul.GetObjectKind().GroupVersionKind()
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+		ul.Items = byGVK[gvk]
+		return nil
+	}
+}
+
+// setup initializes the Generator with schemas and a fake client
+// returning objects through the provided list function.
+func setup(
+	listFn func(context.Context, ctrlruntimeclient.ObjectList, ...ctrlruntimeclient.ListOption) error,
+	schemas ...*spec.Schema,
+) *SchemaGenerator {
+	client := testfakes.NewClient(
+		listFn,
+		nil,
+	)
+
+	resolver := resolver.New(client, nil)
+	definitions := make(map[string]*spec.Schema)
+	for i, v := range schemas {
+		key := fmt.Sprintf("def-%d", i)
+		definitions[key] = v
+	}
+
+	return New(
+		definitions,
+		resolver,
+		nil,
+	)
 }
 
 func TestGroupByAPIGroup(t *testing.T) {

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -86,9 +86,11 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 
 		query := fmt.Sprintf(`{
 	resourcesByCategory(name: "%s") {
-    __typename
-    ... on %s { metadata { name } }
-    ... on %s { metadata { name } }
+		items {
+			__typename
+			... on %s { metadata { name } }
+			... on %s { metadata { name } }
+		}
   }
 	}`, categoryName, fooType, barType)
 
@@ -100,7 +102,8 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 
 		require.Empty(t, result.Errors)
 
-		queryResults := result.Data.(map[string]any)["resourcesByCategory"].([]any)
+		data := result.Data.(map[string]any)["resourcesByCategory"].(map[string]any)
+		queryResults := data["items"].([]any)
 		assert.Len(t, queryResults, 2)
 
 		byType := map[string]string{}

--- a/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/generator/generator_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/graphql-go/graphql"
@@ -75,7 +74,7 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 				},
 			},
 		}
-		sut := setup(listItems(foo, bar), first, second)
+		sut := setup(testfakes.ListItems(foo, bar), first, second)
 
 		schemagen, err := sut.Generate(t.Context())
 		require.NoError(t, err)
@@ -117,7 +116,7 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 	})
 	t.Run("subscription exposes only subscribeToAll", func(t *testing.T) {
 		schemaDef := schemaWithCategory("a.b.c", "v1", "Fooer", apiextensionsv1.NamespaceScoped, "cat")
-		sut := setup(listItems(), schemaDef)
+		sut := setup(testfakes.ListItems(), schemaDef)
 
 		sch, err := sut.Generate(t.Context())
 		require.NoError(t, err)
@@ -150,7 +149,7 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 			},
 		}
 
-		sut := setup(listItems(instance), uncategorized)
+		sut := setup(testfakes.ListItems(instance), uncategorized)
 		sch, err := sut.Generate(t.Context())
 		require.NoError(t, err)
 
@@ -160,27 +159,6 @@ func TestGenerate_resourcesByCategory(t *testing.T) {
 		schemaType := sch.Type(workloadType)
 		require.NotNil(t, schemaType, "resource with no category should be in the schema")
 	})
-}
-
-// listItems returns a client List function returning objs filtered by GVK.
-func listItems(
-	objs ...unstructured.Unstructured,
-) func(context.Context, ctrlruntimeclient.ObjectList, ...ctrlruntimeclient.ListOption) error {
-	byGVK := map[schema.GroupVersionKind][]unstructured.Unstructured{}
-	for _, v := range objs {
-		gvk := v.GroupVersionKind()
-		byGVK[gvk] = append(byGVK[gvk], v)
-	}
-
-	return func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
-		ul := list.(*unstructured.UnstructuredList)
-		ul.SetResourceVersion("100")
-
-		gvk := ul.GetObjectKind().GroupVersionKind()
-		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
-		ul.Items = byGVK[gvk]
-		return nil
-	}
 }
 
 // setup initializes the Generator with schemas and a fake client

--- a/services/kubernetes-graphql-gateway/gateway/schema/provider.go
+++ b/services/kubernetes-graphql-gateway/gateway/schema/provider.go
@@ -35,8 +35,15 @@ type Provider struct {
 }
 
 // New creates a new Provider with a GraphQL schema built from OpenAPI definitions.
-func New(ctx context.Context, definitions map[string]*spec.Schema, resolverProvider *resolver.Service, customSubGen *extensions.CustomSubscriptionGenerator) (*Provider, error) {
-	schema, err := generator.New(definitions, resolverProvider, customSubGen).Generate(ctx)
+func New(
+	ctx context.Context,
+	definitions map[string]*spec.Schema,
+	resolverProvider *resolver.Service,
+	customSubGen *extensions.CustomSubscriptionGenerator,
+	resourcesByCategoryEnabled bool,
+) (*Provider, error) {
+	schema, err := generator.New(definitions, resolverProvider, customSubGen, resourcesByCategoryEnabled).
+		Generate(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/services/kubernetes-graphql-gateway/internal/testfakes/client.go
+++ b/services/kubernetes-graphql-gateway/internal/testfakes/client.go
@@ -1,0 +1,82 @@
+package testfakes
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/watch"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FakeClient implements client.WithWatch with controllable List and Watch behavior.
+type FakeClient struct {
+	ctrlruntimeclient.WithWatch
+	watchCalls int32
+	listCalls  int32
+	watchFn    func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error)
+	listFn     func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error
+}
+
+func NewClient(
+	listFn func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error,
+	watchFn func(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error),
+) *FakeClient {
+	return &FakeClient{
+		listFn:  listFn,
+		watchFn: watchFn,
+	}
+}
+
+func (f *FakeClient) Watch(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+	atomic.AddInt32(&f.watchCalls, 1)
+	if f.watchFn != nil {
+		return f.watchFn(ctx, obj, opts...)
+	}
+	return NewWatcher(), nil
+}
+
+func (f *FakeClient) List(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	atomic.AddInt32(&f.listCalls, 1)
+	if f.listFn != nil {
+		return f.listFn(ctx, obj, opts...)
+	}
+	return nil
+}
+
+func (f *FakeClient) ListCalls() int32 {
+	return atomic.LoadInt32(&f.listCalls)
+}
+
+func (f *FakeClient) WatchCalls() int32 {
+	return atomic.LoadInt32(&f.watchCalls)
+}
+
+// FakeWatcher implements watch.Interface for testing.
+type FakeWatcher struct {
+	events chan watch.Event
+	done   chan struct{}
+	once   sync.Once
+}
+
+func NewWatcher() *FakeWatcher {
+	return &FakeWatcher{
+		events: make(chan watch.Event, 10),
+		done:   make(chan struct{}),
+	}
+}
+
+func (f *FakeWatcher) ResultChan() <-chan watch.Event {
+	return f.events
+}
+
+func (f *FakeWatcher) Stop() {
+	f.once.Do(func() {
+		close(f.done)
+	})
+}
+
+// WriteChan returns the producer-side Event channel.
+func (f *FakeWatcher) WriteChan() chan<- watch.Event {
+	return f.events
+}

--- a/services/kubernetes-graphql-gateway/internal/testfakes/client.go
+++ b/services/kubernetes-graphql-gateway/internal/testfakes/client.go
@@ -2,12 +2,36 @@ package testfakes
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ListItems returns a client List function returning objs filtered by GVK.
+func ListItems(
+	objs ...unstructured.Unstructured,
+) func(context.Context, ctrlruntimeclient.ObjectList, ...ctrlruntimeclient.ListOption) error {
+	byGVK := map[schema.GroupVersionKind][]unstructured.Unstructured{}
+	for _, v := range objs {
+		gvk := v.GroupVersionKind()
+		byGVK[gvk] = append(byGVK[gvk], v)
+	}
+
+	return func(_ context.Context, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+		ul := list.(*unstructured.UnstructuredList)
+		ul.SetResourceVersion("100")
+
+		gvk := ul.GetObjectKind().GroupVersionKind()
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+		ul.Items = byGVK[gvk]
+		return nil
+	}
+}
 
 // FakeClient implements client.WithWatch with controllable List and Watch behavior.
 type FakeClient struct {


### PR DESCRIPTION
This PR adds two new operations for a custom query and a subscription by category, both named `resourcesByCategory`. 
A graphql union type `CategoryResource` is generated from the categorized resources. Resources not in a category are excluded.

During the PoC and test phase `resourcesByCategory` **requires a new feature flag** to be passed via CLI args: 
`--enable-resources-by-category`

Metrics added to the fan-out list and watch:
- Query:
  - `kubernetes_graphql_gateway_category_fanout_types_bucket`
  - `kubernetes_graphql_gateway_category_objects_returned_bucket`
- Subscribe:
  - `kubernetes_graphql_gateway_category_watches_active`
  - `kubernetes_graphql_gateway_watch_initial_items_bucket`

No new limits with defaults are added yet. We need feedback from a live system and the aforementioned metrics to make a better judgement call on that.

Related to #128 
