### PR TITLE
fix(search-service): treat empty query as match-all instead of rejecting with 400

### DIFF
--- a/services/search-service/internal/service/search/service.go
+++ b/services/search-service/internal/service/search/service.go
@@ -85,7 +85,7 @@ func (s *Service) Search(ctx context.Context, req SearchRequest) (SearchResponse
 
 	query := strings.TrimSpace(req.Query)
 	if query == "" {
-		return SearchResponse{}, fmt.Errorf("%w: q is required", ErrInvalidRequest)
+		query = "*"
 	}
 	org := strings.TrimSpace(req.Organization)
 	if org == "" {

--- a/services/search-service/internal/service/search/service_test.go
+++ b/services/search-service/internal/service/search/service_test.go
@@ -127,11 +127,21 @@ func TestSearchInvalidCursor(t *testing.T) {
 	}
 }
 
-func TestSearchRejectsMissingQuery(t *testing.T) {
-	svc := NewService(fakeResolver{}, &fakeSearcher{}, &fakeAuthorizer{}, nil, ServiceConfig{})
-	_, err := svc.Search(context.Background(), SearchRequest{Organization: "acme", User: "alice@example.com", Query: "  "})
-	if !errors.Is(err, ErrInvalidRequest) {
-		t.Fatalf("expected ErrInvalidRequest, got %v", err)
+func TestSearchEmptyQueryMatchesAll(t *testing.T) {
+	hit := OpenSearchHit{ID: "1", Score: 1, Sort: []any{1.0, "1"}, Source: map[string]any{"id": "1"}}
+	svc := NewService(
+		fakeResolver{index: SearchIndexRef{IndexName: "idx-acme", Resource: "accounts"}},
+		&fakeSearcher{pages: []OpenSearchPage{{Hits: []OpenSearchHit{hit}}}},
+		&fakeAuthorizer{results: []AuthorizationResult{{Allowed: []bool{true}, Calls: 1}}},
+		nil,
+		ServiceConfig{},
+	)
+	resp, err := svc.Search(t.Context(), SearchRequest{Organization: "acme", User: "alice@example.com", Query: "  "})
+	if err != nil {
+		t.Fatalf("expected no error for empty query, got %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results for empty query (match-all)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- An empty or whitespace-only `q` parameter now maps to a wildcard (`*`) query instead of returning a 400 error
- This aligns with standard OpenSearch/Elasticsearch conventions where an empty search returns all results
- Updated `TestSearchRejectsMissingQuery` → `TestSearchEmptyQueryMatchesAll` to verify the new behavior

## Motivation

The frontend sends `q=` on initial page load (before the user types anything). The previous behavior of returning a 400 forced callers to special-case empty queries. The fix makes the service consistent with OpenSearch's own behavior where an empty query string is equivalent to `*` (match-all).

## Test plan

- [x] `TestSearchEmptyQueryMatchesAll` verifies whitespace-only query returns results
- [x] All existing tests pass: `go test ./internal/service/search/...`