### PR TITLE
Add Tilt local dev environment (infra, kcp, account-operator)

### DIFF
--- a/contrib/tilt/.gitignore
+++ b/contrib/tilt/.gitignore
@@ -1,0 +1,3 @@
+bin/
+.cache/
+.secret/

--- a/contrib/tilt/README.md
+++ b/contrib/tilt/README.md
@@ -1,0 +1,83 @@
+# Platform Mesh — Tilt local development environment
+
+Tilt replaces the OCM/Flux/platform-mesh-operator delivery pipeline for the
+developer inner loop: static infrastructure is deployed once into kind, and the
+operators/services you are working on hot-reload in seconds.
+
+## What it deploys today
+
+- **Local infra** (`manifests/`): `platform-mesh-system` namespace, a
+  self-signed cert-manager `Issuer`, an envoy `Gateway` named `platform-mesh`,
+  and a dev etcd.
+- **Remote infra** (`infra_remote.Tiltfile`, skipped by `TILT_NO_INFRA=1`):
+  cert-manager, the envoy gateway controller, kcp-operator.
+- **kcp** (static): the upstream kcp Tilt module `deploy_kcp()`, parameterized
+  for our gateway, hostnames (`root.pm.localhost`), OIDC issuer and (in
+  `auth`/`full`) the ReBAC authorization webhook. kcp always runs a **pinned
+  released image** — it is never built from source here.
+
+## Prerequisites
+
+- docker or podman, `kind`, `kubectl`, `helm`, `tilt`, `git`
+- The kcp static-install module (`deploy_kcp`) is fetched automatically from the
+  kcp repo — **no local kcp checkout required**. Until the upstream PR merges it
+  comes from the in-flight branch (`load_kcp()` in `helpers.py`). Overrides:
+  - `KCP_TILT_DIR` — path to a local `kcp/contrib/tilt` checkout; skips the
+    fetch (use offline or when hacking on the module itself).
+  - `KCP_TILT_REPO` / `KCP_TILT_REF` — git URL / ref to fetch from.
+
+## Usage
+
+```sh
+# create the kind cluster first — it MUST be named platform-mesh.
+# The Tiltfile refuses any context other than kind-platform-mesh (guard against
+# a stray `tilt up` hitting a shared/other cluster). Override with
+# TILT_ALLOWED_CONTEXT if you must.
+kind create cluster --name platform-mesh
+tilt up -f contrib/tilt/Tiltfile -- --profile=core 
+
+HELM_CHARTS_DIR=/Users/mjudeikis/go/src/github.com/platform-mesh/helm-charts \
+KCP_TILT_DIR=/Users/mjudeikis/go/src/github.com/kcp-dev/kcp/contrib/tilt \
+tilt up -f contrib/tilt/Tiltfile -- --profile=core
+```
+
+### Validate manifests without a cluster
+
+`deploy_kcp()`'s output can be inspected offline — no cluster, no remote
+fetches:
+
+```sh
+TILT_NO_INFRA=1 tilt alpha tiltfile-result -f contrib/tilt/Tiltfile
+```
+
+This renders the local manifests and the kcp custom resources (RootShard,
+FrontProxy, TLSRoutes, Kubeconfigs) with all hooks applied, so you can confirm
+the gateway wiring, OIDC issuer and authorization webhook before deploying.
+
+## The kcp hooks
+
+The kcp static install lives upstream in
+`kcp-dev/kcp/contrib/tilt/kcp_static.Tiltfile` and exposes `deploy_kcp()`. This
+project owns its own infrastructure (gateway, etcd, cert issuer) and passes it
+in. Hooks exercised here:
+
+| Hook | Purpose |
+|---|---|
+| `gateway` + `route_version` | attach kcp TLSRoutes to our `platform-mesh` gateway (prod: traefik) |
+| `authorization_webhook_secret` | wire the ReBAC authz webhook (L3, `auth`/`full`) |
+| `oidc` | front kcp with dex/keycloak as the OIDC issuer |
+| `image_tag` / `image_repo` | pin the released kcp image |
+| `extra_shards` | opt-in extra shards (`--sharded`) |
+| `namespace`, `base_domain`, `etcd_endpoint`, `issuer_ref` | environment wiring |
+
+## Layout
+
+```
+contrib/tilt/
+  Tiltfile              # entrypoint: config, local infra, kcp, components
+  infra_remote.Tiltfile # ext:// + remote-chart infra (gated by TILT_NO_INFRA)
+  helpers.py            # chart_path(), component_build()
+  manifests/            # local, no-fetch infra manifests
+  runtime.Dockerfile    # thin image for hot-reloaded binaries
+  bin/ .cache/ .secret/ # gitignored working dirs
+```

--- a/contrib/tilt/Tiltfile
+++ b/contrib/tilt/Tiltfile
@@ -1,0 +1,243 @@
+# Copyright 2026 The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Platform Mesh — Tilt local development environment (SKELETON).
+#
+# See contrib/adr/adr-02-tilt-local-dev-environment.md for the full design.
+#
+# Status: proving the kcp static-install hooks. Infra beyond kcp (Keycloak,
+# OpenFGA, portal) and component hot-reload are stubbed and land in later PRs.
+#
+# Quick start:
+#   kind create cluster --name platform-mesh
+#   tilt up -f contrib/tilt/Tiltfile
+#
+# Render-only (no cluster, no remote fetches) for validating manifests:
+#   TILT_NO_INFRA=1 tilt alpha tiltfile-result -f contrib/tilt/Tiltfile
+
+# ---------------------------------------------------------------------------
+# config
+# ---------------------------------------------------------------------------
+
+# Profiles map onto RFC 008 shapes (see ADR). Skeleton implements `infra`.
+config.define_string('profile', args=False, usage='infra|core|auth|full (default: infra)')
+config.define_string_list('components', args=True, usage='monorepo components to hot-reload')
+cfg = config.parse()
+PROFILE = cfg.get('profile', 'infra')
+COMPONENTS = cfg.get('components', [])
+
+# Base domain + namespace shared by the whole environment.
+BASE_DOMAIN = 'pm.localhost'
+NAMESPACE = 'platform-mesh-system'
+
+# Skip remote-fetch infra (cert-manager, envoy gateway, kcp-operator) so the
+# Tiltfile evaluates offline — used for manifest validation. Local manifests and
+# the kcp CRs still render.
+NO_INFRA = os.getenv('TILT_NO_INFRA', '') not in ('', '0', 'false', 'no')
+
+print('Platform Mesh dev env — profile={} components={} no_infra={}'.format(PROFILE, COMPONENTS, NO_INFRA))
+
+# ---------------------------------------------------------------------------
+# context guard
+# ---------------------------------------------------------------------------
+
+# Refuse to deploy anywhere except the dedicated kind cluster. kind names its
+# context "kind-<clustername>", so the cluster from
+#   kind create cluster --name platform-mesh
+# is reached via context "kind-platform-mesh". This prevents an accidental
+# `tilt up` from applying to whatever kubeconfig context happens to be current
+# (a shared dev/staging cluster, another kind, docker-desktop, ...).
+#
+# Only enforced for real deploys (up/ci); `tilt alpha tiltfile-result` and other
+# subcommands evaluate without a cluster and are left alone. Override the target
+# with TILT_ALLOWED_CONTEXT if you named your cluster differently.
+ALLOWED_CONTEXT = os.getenv('TILT_ALLOWED_CONTEXT', 'kind-platform-mesh')
+allow_k8s_contexts(ALLOWED_CONTEXT)
+if config.tilt_subcommand in ('up', 'ci'):
+    _ctx = k8s_context()
+    if _ctx != ALLOWED_CONTEXT:
+        fail(
+            'refusing to run against kube context {!r}: this Tiltfile only targets {!r}.\n'.format(_ctx, ALLOWED_CONTEXT) +
+            'Create/select it with:\n' +
+            '  kind create cluster --name platform-mesh\n' +
+            '  kubectl config use-context {}\n'.format(ALLOWED_CONTEXT) +
+            '(or set TILT_ALLOWED_CONTEXT to override).'
+        )
+
+# ---------------------------------------------------------------------------
+# static infra owned by THIS project
+# ---------------------------------------------------------------------------
+
+# Local manifests (no remote fetch): system namespace, self-signed issuer, the
+# envoy Gateway the kcp routes attach to, and a dev etcd for the shards.
+#
+# The namespace is its own resource with NO CRD-dependent siblings, so it always
+# applies immediately. Everything scoped to platform-mesh-system waits on it
+# (resource_deps) — otherwise a resource bundled with the namespace that fails to
+# apply (e.g. the Issuer before cert-manager's CRD exists) would strand the
+# namespace and every namespaced resource would fail with "namespace not found".
+k8s_yaml('manifests/namespace.yaml')
+k8s_resource(
+    new_name='namespace',
+    objects=['platform-mesh-system:namespace'],
+    labels=['infra'],
+)
+
+# Issuer depends on the namespace; it also needs cert-manager's CRD, so Tilt
+# retries it until cert-manager (infra_remote) is up.
+k8s_yaml('manifests/issuer.yaml')
+k8s_resource(
+    new_name='cert-issuer',
+    objects=['selfsigned:issuer'],
+    labels=['infra'],
+    resource_deps=['namespace'],
+)
+
+# Gateway depends on the namespace; needs the envoy gateway CRDs (infra_remote).
+k8s_yaml('manifests/gateway.yaml')
+k8s_resource(
+    new_name='gateway',
+    objects=['platform-mesh:gatewayclass', 'platform-mesh:gateway'],
+    labels=['infra'],
+    resource_deps=['namespace'],
+)
+
+k8s_yaml('manifests/etcd.yaml')
+k8s_resource('etcd', labels=['infra'])
+
+# Dex — the OIDC issuer kcp authenticates against (RootShard spec.auth.oidc).
+# kcp always needs an issuer wired, and the kcp-operator won't create the shard
+# Deployment until the referenced CA secret (dex-ca) exists, so Dex ships in the
+# base `infra` profile. Terminates its own TLS and is routed by SNI through the
+# passthrough gateway (manifests/dex.yaml); the cert chain publishes `dex-ca`.
+k8s_yaml('manifests/dex.yaml')
+k8s_resource(
+    'dex',
+    objects=[
+        'dex-ca:certificate',
+        'dex-ca:issuer',
+        'dex-server:certificate',
+        'dex:configmap',
+        'dex:tlsroute',
+    ],
+    labels=['infra'],
+    resource_deps=['namespace', 'cert-issuer'],
+)
+
+# Remote-fetch infra (cert-manager, envoy gateway controller, kcp-operator).
+if not NO_INFRA:
+    include('./infra_remote.Tiltfile')
+
+# ---------------------------------------------------------------------------
+# kcp (static, via the upstream kcp Tilt module)
+# ---------------------------------------------------------------------------
+
+# The static-install logic lives upstream in the kcp repo
+# (contrib/tilt/kcp_static.Tiltfile), parameterized for our gateway, hostnames
+# and auth. load_kcp() fetches it from the in-flight branch by default; set
+# KCP_TILT_DIR to a local kcp/contrib/tilt checkout to work offline / hack on
+# the module. Once the upstream PR merges, bump KCP_TILT_REPO/KCP_TILT_REF
+# defaults in helpers.py to the tagged kcp release.
+load('./helpers.py', 'component_build', 'chart_path', 'load_kcp')
+deploy_kcp = load_kcp()
+
+deploy_kcp(
+    base_domain=BASE_DOMAIN,
+    namespace=NAMESPACE,
+    # Attach to OUR gateway instead of kcp's default envoy `eg`. Production wires
+    # the same shape against traefik via .Values.gatewayApi.name.
+    gateway={
+        'name': 'platform-mesh',
+        'namespace': None,
+        'group': 'gateway.networking.k8s.io',
+        'kind': 'Gateway',
+        'section': 'passthrough',
+    },
+    route_version='v1alpha2',
+    # etcd this project provides (manifests/etcd.yaml).
+    etcd_endpoint='http://etcd.kcp-etcd.svc.cluster.local:2379',
+
+    # kcp pods resolve *.pm.localhost only via hostAliases → the gateway IP.
+    # The module derives hostAliases from this list, so add dex alongside the
+    # base + shard names — otherwise the shard/front-proxy OIDC authenticator
+    # can't reach the issuer discovery endpoint (https://idp.pm.localhost:8443)
+    # and logs "lookup idp.pm.localhost ... no such host". Single-shard `infra`;
+    # revisit if extra_shards are added (their hostnames must stay in this list).
+    hostnames=[BASE_DOMAIN, 'root.' + BASE_DOMAIN, 'idp.' + BASE_DOMAIN],
+
+    # Pinned released kcp image (never built from source here).
+    image_tag=os.getenv('KCP_IMAGE_TAG', 'main'),
+
+    # L3 authorization: rebac-authz-webhook secret (auth/full profiles). Wired
+    # here to exercise the hook; the secret itself is created by the auth layer.
+    authorization_webhook_secret='kcp-webhook-secret' if PROFILE in ('auth', 'full') else None,
+    
+    # OIDC issuer: dex in the infra/core profiles (see ADR), served at the
+    # implementation-neutral host oidc.<base_domain> (manifests/dex.yaml).
+    oidc={
+        'issuerURL': 'https://idp.{}:8443'.format(BASE_DOMAIN),
+        'clientID': 'platform-mesh',
+        'groupsClaim': 'groups',
+        'usernameClaim': 'email',
+        'caFileRef': {'name': 'dex-ca', 'key': 'ca.crt'},
+    },
+    kubeconfig_dir='.secret/kcp',
+    # The kcp CRs live in platform-mesh-system; make them wait for the namespace
+    # resource so a fresh cluster doesn't race "namespace not found".
+    resource_deps=['namespace'],
+)
+
+# ---------------------------------------------------------------------------
+# component hot-reload (stub — off by default in the skeleton)
+# ---------------------------------------------------------------------------
+
+if COMPONENTS:
+    OCI = 'oci://ghcr.io/platform-mesh/helm-charts'
+    # Example wiring for the pilot component. Real deps/versions land with Phase 1.
+    if 'account-operator' in COMPONENTS:
+        # Pin a published chart version (the placeholder 0.0.0 was never pushed).
+        # Override with ACCOUNT_OPERATOR_CHART_VERSION to track a newer chart, or
+        # set HELM_CHARTS_DIR to a local helm-charts checkout to render the chart
+        # from source (see chart_path in helpers.py) — then this version is ignored.
+        component_build(
+            name='account-operator',
+            path='operators/account-operator',
+            deps=['apis', 'subroutines', 'golang-commons'],
+            # Match the image ref the chart renders so Tilt substitutes the
+            # locally-built image (it swaps by repository, keeping the chart's args).
+            image='ghcr.io/platform-mesh/platform-mesh/account-operator',
+            chart=chart_path('account-operator', os.getenv('ACCOUNT_OPERATOR_CHART_VERSION', '0.17.0'), OCI),
+            namespace=NAMESPACE,
+            # Skip the account-operator-crds subchart: it emits kcp APIExport/
+            # APIResourceSchema/APIExportEndpointSlice objects whose CRDs live in
+            # kcp workspaces, not the runtime kube cluster. Applying them here
+            # fails and drops the webhook cert with it, wedging the pod in
+            # ContainerCreating. The kcp API registration is wired separately.
+            helm_set=['crds.enabled=false'],
+            # Wait for the namespace so a fresh cluster doesn't race "namespace not found".
+            resource_deps=['namespace'],
+            # Fold the chart's non-workload objects into this resource (else Tilt's
+            # dependency-less "uncategorized" catch-all applies them before the
+            # namespace exists). The cluster-scoped ClusterRole/Binding are included
+            # for tidy grouping; the namespaced ones are what actually need the dep.
+            objects=[
+                'account-operator:serviceaccount',
+                'account-operator:clusterrole',
+                'account-operator:clusterrolebinding',
+                'account-operator-ca-cert:certificate',
+                'account-operator-serving-cert:certificate',
+                'account-operator-selfsigned-issuer:issuer',
+                'account-operator-ca-issuer:issuer',
+            ],
+        )

--- a/contrib/tilt/helpers.py
+++ b/contrib/tilt/helpers.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# helpers.py — chart resolution, kcp module loading, and component hot-reload
+# for the Platform Mesh Tilt dev environment.
+
+def load_kcp():
+    """Load deploy_kcp() from the kcp repo.
+
+    The static-install module lives upstream in the kcp repo (merged to main).
+    Overrides via env:
+      KCP_TILT_DIR  — path to a local kcp/contrib/tilt checkout; skips the
+                      git fetch entirely (use for offline work / hacking on the
+                      module itself).
+      KCP_TILT_REPO — git URL   (default: kcp-dev/kcp).
+      KCP_TILT_REF  — git ref   (default: main; pin to a tag/release for repro).
+
+    Returns the deploy_kcp function. Uses load_dynamic (not load()) because the
+    path is computed and the fetch must run before the load.
+    """
+    local_dir = os.getenv('KCP_TILT_DIR', '')
+    if local_dir:
+        path = os.path.join(local_dir, 'kcp_static.Tiltfile')
+    else:
+        repo = os.getenv('KCP_TILT_REPO', 'https://github.com/kcp-dev/kcp')
+        ref = os.getenv('KCP_TILT_REF', 'main')
+        dest = '.cache/kcp'
+        # Idempotent shallow checkout of the ref (clone first time, fetch after).
+        local(
+            'if [ -d {d}/.git ]; then git -C {d} fetch -q --depth 1 origin {r} && git -C {d} checkout -q FETCH_HEAD; else git clone -q --depth 1 --branch {r} {u} {d}; fi'.format(
+                d=dest, r=ref, u=repo,
+            ),
+            quiet=True,
+            echo_off=True,
+        )
+        path = os.path.join(dest, 'contrib/tilt/kcp_static.Tiltfile')
+    return load_dynamic(path)['deploy_kcp']
+
+def chart_path(name, version, oci_repo, cache_dir='.cache/charts'):
+    """Resolve a Platform Mesh Helm chart to a local directory path.
+
+    By default pulls the pinned version from the OCI registry into cache_dir,
+    so `tilt up` works from a clone of this monorepo alone (no helm-charts
+    checkout). Set HELM_CHARTS_DIR to a local helm-charts checkout to override
+    the source for chart development — then charts render from
+    $HELM_CHARTS_DIR/charts/<name> live.
+
+    Returns a path suitable for helm(...).
+    """
+    local_dir = os.getenv('HELM_CHARTS_DIR', '')
+    if local_dir:
+        return os.path.join(local_dir, 'charts', name)
+
+    dest = os.path.join(cache_dir, name)
+    # Idempotent pull: only fetch when the pinned version is not already cached.
+    local(
+        'test -d {dest} || (mkdir -p {cache} && helm pull {repo}/{name} --version {version} --untar --untardir {cache})'.format(
+            dest=dest, cache=cache_dir, repo=oci_repo, name=name, version=version,
+        ),
+        quiet=True,
+        echo_off=True,
+    )
+    return dest
+
+
+def component_build(name, path, deps, image, chart, namespace, values=[], helm_set=[], resource_deps=[], objects=[], workload=''):
+    """Hot-reload a monorepo operator/service.
+
+    1. compile the component to a linux binary on the host (fast, cached by go)
+    2. bake the binary into a thin runtime image, live_update-syncing the
+       binary on rebuild instead of a full docker build
+    3. deploy the component's production Helm chart with the image overridden
+       to the Tilt-built one
+
+    deps: extra source dirs that should trigger a rebuild (shared modules like
+    apis/, subroutines/, golang-commons/).
+    helm_set: list of "key=value" chart overrides passed as helm --set. Use to
+    drop parts of a production chart that don't belong on the local kube cluster
+    (e.g. crds.enabled=false to skip the kcp APIExport/APIResourceSchema objects,
+    whose CRDs only exist inside kcp workspaces, not the runtime cluster).
+    """
+    # Paths here resolve relative to THIS Tiltfile's directory (contrib/tilt), so
+    # the binary output and runtime image are addressed as ./bin and
+    # ./runtime.Dockerfile, while repo-root sources need a ../.. prefix.
+    bin_path = './bin/{}'.format(name)
+    local_resource(
+        'build:{}'.format(name),
+        # Build from the repo root so the go.work workspace (apis/, subroutines/,
+        # golang-commons/) is in scope, dropping the linux binary into ./bin.
+        cmd='cd ../.. && CGO_ENABLED=0 GOOS=linux GOARCH={arch} go build -o contrib/tilt/bin/{name} ./{path}'.format(
+            arch=os.getenv('GOARCH', 'arm64'), name=name, path=path,
+        ),
+        deps=['../../{}'.format(d) for d in [path] + deps],
+        labels=['components'],
+        allow_parallel=True,
+    )
+    docker_build(
+        ref=image,
+        context='./bin',
+        dockerfile='./runtime.Dockerfile',
+        build_args={'BIN': name},
+        only=[name],
+        live_update=[sync(bin_path, '/entrypoint')],
+    )
+    k8s_yaml(helm(
+        chart,
+        name=name,
+        namespace=namespace,
+        values=values,
+        set=helm_set,
+    ))
+    # Gate the deployed workload on any prerequisites (e.g. the namespace resource)
+    # so a fresh cluster doesn't race "namespace not found". `objects` folds the
+    # chart's non-workload objects (cert-manager PKI, ServiceAccount, RBAC) into
+    # this resource — otherwise Tilt drops them into its dependency-less catch-all
+    # ("uncategorized"), which applies before the namespace and fails on a fresh
+    # cluster. `workload` is the actual Deployment/Tilt resource name when the chart
+    # doesn't name it after the component (renamed back to `name` for the UI).
+    wl = workload if workload else name
+    if resource_deps or objects or wl != name:
+        if wl != name:
+            k8s_resource(wl, new_name=name, objects=objects, resource_deps=resource_deps)
+        else:
+            k8s_resource(name, objects=objects, resource_deps=resource_deps)

--- a/contrib/tilt/infra_remote.Tiltfile
+++ b/contrib/tilt/infra_remote.Tiltfile
@@ -1,0 +1,118 @@
+# Copyright 2026 The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# infra_remote.Tiltfile — infrastructure that requires fetching remote charts
+# and Tilt extensions. Split out of the main Tiltfile so `TILT_NO_INFRA=1` can
+# render the local manifests + kcp CRs entirely offline (the ext:// loads below
+# fetch at eval time).
+
+load('ext://cert_manager', 'deploy_cert_manager')
+load('ext://helm_remote', 'helm_remote')
+
+# cert-manager — issues the self-signed CA the kcp shards use.
+deploy_cert_manager(version='v1.19.2')
+
+# Envoy Gateway controller — programs the `platform-mesh` Gateway (Gateway CR in
+# manifests/gateway.yaml). Production uses traefik; envoy here keeps parity with
+# the kcp reference and is enough to prove the routing.
+namespace_yaml = 'apiVersion: v1\nkind: Namespace\nmetadata:\n  name: envoy-gateway-system\n'
+k8s_yaml(blob(namespace_yaml))
+helm_remote(
+    'gateway-helm',
+    repo_url='oci://registry-1.docker.io/envoyproxy',
+    repo_name='gateway-helm',
+    release_name='envoy',
+    namespace='envoy-gateway-system',
+    version='v1.7.0',
+)
+
+# kcp-operator — reconciles the RootShard/Shard/FrontProxy CRs that deploy_kcp
+# emits. Pinned to a released version.
+#
+# The operator's own config/manager kustomization pins `newTag: e2e` — a
+# floating CI tag, not a release (`:e2e` is not even a stable image). We pull the
+# base at the release ref and override the image tag to the same release via a
+# generated overlay, so we run a reproducible `:vX.Y.Z` image. `kubectl -k`
+# resolves the remote base natively; Tilt's builtin kustomize() does not fetch
+# remote URLs. Override the version with KCP_OPERATOR_VERSION.
+KCP_OPERATOR_VERSION = os.getenv('KCP_OPERATOR_VERSION', 'v0.8.2')
+local_resource(
+    'kcp-operator',
+    cmd='''set -eo pipefail
+tmp=$(mktemp -d)
+cat > "$tmp/kustomization.yaml" <<EOF
+resources:
+  - https://github.com/kcp-dev/kcp-operator/config/default?ref={v}
+images:
+  - name: ghcr.io/kcp-dev/kcp-operator
+    newTag: {v}
+EOF
+kubectl apply --server-side -k "$tmp"
+rm -rf "$tmp"'''.format(v=KCP_OPERATOR_VERSION),
+    labels=['infra'],
+    allow_parallel=True,
+)
+
+# ---------------------------------------------------------------------------
+# Delivery engines for the provider-operator's ManagedProvider deploy step
+# ---------------------------------------------------------------------------
+# ManagedProvider.Deploy emits Flux objects; the two RuntimeDeployment types are:
+#   - flux: source.toolkit.fluxcd.io (HelmRepository/OCIRepository) + a
+#           helm.toolkit.fluxcd.io/HelmRelease            → needs Flux only
+#   - ocm:  delivery.ocm.software (Repository/Component/Resource) resolved by the
+#           OCM controller, handed off to a Flux HelmRelease → needs OCM + Flux
+# Both are installed here so either RuntimeDeployment type works out of the box.
+# This is the deliberate ADR-02 divergence: a delivery engine lives in the dev
+# env so ManagedProvider can drive deploys (versions mirror helm-charts/local-setup).
+
+# Flux — source + helm (+ kustomize) controllers. Image-automation, reflection
+# and notification controllers are disabled (unused by ManagedProvider).
+k8s_yaml(blob('apiVersion: v1\nkind: Namespace\nmetadata:\n  name: flux-system\n'))
+helm_remote(
+    'flux2',
+    repo_url='oci://ghcr.io/fluxcd-community/charts',
+    repo_name='flux2',
+    release_name='flux',
+    namespace='flux-system',
+    version='2.17.2',
+    set=[
+        'imageAutomationController.create=false',
+        'imageReflectionController.create=false',
+        'notificationController.create=false',
+    ],
+)
+
+# OCM controller (ocm-k8s-toolkit) — reconciles delivery.ocm.software CRs for the
+# ManagedProvider `ocm` deploy type. Only needed for that type; the `flux` type
+# runs on Flux alone. The chart artifact is literally named `chart` at this OCI path.
+k8s_yaml(blob('apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ocm-system\n'))
+helm_remote(
+    'chart',
+    repo_url='oci://ghcr.io/open-component-model/kubernetes/controller',
+    repo_name='ocm-k8s-toolkit',
+    release_name='ocm-k8s-toolkit',
+    namespace='ocm-system',
+    version='0.3.0',
+)
+
+# Ingress port-forward to the gateway so root.pm.localhost:8443 is reachable
+# from the host. Mirrors the kcp reference port-forward loop.
+local_resource(
+    'ingress',
+    serve_cmd='kubectl -n envoy-gateway-system wait gateway/platform-mesh --for=condition=Programmed --timeout=5m 2>/dev/null; ' +
+              'while true; do svc=$(kubectl -n envoy-gateway-system get svc -l gateway.envoyproxy.io/owning-gateway-name=platform-mesh -o jsonpath="{.items[0].metadata.name}" 2>/dev/null); ' +
+              '[ -n "$svc" ] && kubectl -n envoy-gateway-system port-forward "svc/$svc" 8443:8443 || true; sleep 2; done',
+    labels=['infra'],
+    allow_parallel=True,
+)

--- a/contrib/tilt/manifests/dex.yaml
+++ b/contrib/tilt/manifests/dex.yaml
@@ -1,0 +1,185 @@
+# Dex — the OIDC issuer for the dev environment. In the RFC 008 `infra`/`core`
+# shapes Dex is *the* external issuer kcp authenticates against (see ADR-02), so
+# operator development runs without Keycloak/OpenFGA. kcp always needs an OIDC
+# issuer wired (spec.auth.oidc on the RootShard), and the kcp-operator refuses to
+# create the shard Deployment until the referenced CA secret (dex-ca) exists — so
+# Dex ships in the base `infra` profile.
+#
+# Topology mirrors kcp: the gateway (manifests/gateway.yaml) is TLS-passthrough on
+# :8443 and routes by SNI, so Dex terminates its own TLS with a cert valid for
+# idp.pm.localhost and is reached through the gateway via a TLSRoute. The public
+# issuer host is idp.pm.localhost (not dex.*) so the implementation stays swappable.
+# The signing CA is published as the `dex-ca` secret the RootShard's OIDC caFileRef mounts.
+#
+# Development-only: in-memory storage, a single static test user (dex/dex),
+# skipApprovalScreen. Do not use as a template for prod.
+
+# --- cert chain -------------------------------------------------------------
+# selfsigned (manifests/issuer.yaml) → dex-ca (root) → dex-server (leaf).
+# kcp trusts dex-ca's ca.crt; Dex serves dex-server, signed by dex-ca.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dex-ca
+  namespace: platform-mesh-system
+spec:
+  isCA: true
+  commonName: dex-ca
+  secretName: dex-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: dex-ca
+  namespace: platform-mesh-system
+spec:
+  ca:
+    secretName: dex-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dex-server
+  namespace: platform-mesh-system
+spec:
+  secretName: dex-server
+  dnsNames:
+    - idp.pm.localhost
+    - dex
+    - dex.platform-mesh-system
+    - dex.platform-mesh-system.svc
+    - dex.platform-mesh-system.svc.cluster.local
+  issuerRef:
+    name: dex-ca
+    kind: Issuer
+    group: cert-manager.io
+---
+# --- dex config -------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex
+  namespace: platform-mesh-system
+data:
+  config.yaml: |
+    issuer: https://idp.pm.localhost:8443
+    storage:
+      type: memory
+    web:
+      https: 0.0.0.0:5556
+      tlsCert: /etc/dex/tls/tls.crt
+      tlsKey: /etc/dex/tls/tls.key
+    telemetry:
+      http: 0.0.0.0:5558
+    oauth2:
+      skipApprovalScreen: true
+    staticClients:
+      - id: platform-mesh
+        name: Platform Mesh
+        public: true
+        redirectURIs:
+          - http://localhost:8000
+          - http://127.0.0.1:8000
+    enablePasswordDB: true
+    staticPasswords:
+      # Test user — email: dex@pm.localhost, password: dex
+      - email: dex@pm.localhost
+        username: dex
+        userID: "00000000-0000-0000-0000-000000000001"
+        hash: "$2a$10$AuO2zT4bk2xn1RXP23XqhO5BMo5PoJFs6tv4MUrKk/mtv97DSNoAC"
+---
+# --- dex deployment ---------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: platform-mesh-system
+  labels:
+    app: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.44.0
+          command: ["dex", "serve", "/etc/dex/config/config.yaml"]
+          ports:
+            - name: https
+              containerPort: 5556
+            - name: telemetry
+              containerPort: 5558
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex/config
+              readOnly: true
+            - name: tls
+              mountPath: /etc/dex/tls
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: telemetry
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: telemetry
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: dex
+        - name: tls
+          secret:
+            secretName: dex-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: platform-mesh-system
+  labels:
+    app: dex
+spec:
+  selector:
+    app: dex
+  ports:
+    - name: https
+      port: 5556
+      targetPort: https
+---
+# --- gateway route (SNI idp.pm.localhost → dex, TLS passthrough) ------------
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: dex
+  namespace: platform-mesh-system
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: platform-mesh
+      namespace: platform-mesh-system
+      sectionName: passthrough
+  hostnames:
+    - idp.pm.localhost
+  rules:
+    - backendRefs:
+        - name: dex
+          port: 5556

--- a/contrib/tilt/manifests/etcd.yaml
+++ b/contrib/tilt/manifests/etcd.yaml
@@ -1,0 +1,64 @@
+# Minimal single-member etcd for the dev environment. kcp shards connect here
+# and isolate their keyspace with --etcd-prefix (see deploy_kcp()). This is a
+# development-only, non-HA, ephemeral etcd — do not use as a template for prod.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-etcd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd
+  namespace: kcp-etcd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+        - name: etcd
+          image: gcr.io/etcd-development/etcd:v3.5.16
+          command:
+            - /usr/local/bin/etcd
+            - --name=etcd-0
+            - --data-dir=/var/run/etcd/default.etcd
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://etcd.kcp-etcd.svc.cluster.local:2379
+            - --listen-peer-urls=http://0.0.0.0:2380
+            # Single member only peers with itself. Pin the advertised peer URL to
+            # loopback and match it in --initial-cluster. Leaving the advertise URL
+            # unset makes etcd auto-detect the pod IP for it while --initial-cluster
+            # keeps the literal value, and the mismatch is fatal at startup.
+            - --initial-advertise-peer-urls=http://127.0.0.1:2380
+            - --initial-cluster=etcd-0=http://127.0.0.1:2380
+            - --auto-compaction-mode=periodic
+            - --auto-compaction-retention=5m
+            - --quota-backend-bytes=8589934592
+          ports:
+            - containerPort: 2379
+              name: client
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 2379
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  namespace: kcp-etcd
+spec:
+  selector:
+    app: etcd
+  ports:
+    - name: client
+      port: 2379
+      targetPort: 2379

--- a/contrib/tilt/manifests/gateway.yaml
+++ b/contrib/tilt/manifests/gateway.yaml
@@ -1,0 +1,34 @@
+# Envoy Gateway (Gateway API) for the dev environment. Named "platform-mesh" so
+# the kcp TLSRoutes attach to it via deploy_kcp(gateway={'name':'platform-mesh'})
+# — this is what production does with traefik + .Values.gatewayApi.name. Using a
+# non-default gateway name here is deliberate: it exercises the deploy_kcp gateway
+# hook end to end.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: platform-mesh
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: platform-mesh
+  namespace: platform-mesh-system
+spec:
+  # fake IP so envoy readies the gateway without a cloud LB (kind)
+  addresses:
+    - type: IPAddress
+      value: 10.96.2.2
+  hostnames:
+    - "*.pm.localhost"
+  gatewayClassName: platform-mesh
+  listeners:
+    - name: passthrough
+      protocol: TLS
+      port: 8443
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/contrib/tilt/manifests/issuer.yaml
+++ b/contrib/tilt/manifests/issuer.yaml
@@ -1,0 +1,11 @@
+# Self-signed cert-manager Issuer the kcp shards reference (deploy_kcp default
+# issuer_ref). Separate from the namespace so a not-yet-installed cert-manager
+# CRD only delays the Issuer (Tilt retries it), never the namespace. Replaces
+# mkcert + the local-setup cert scripts.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: platform-mesh-system
+spec:
+  selfSigned: {}

--- a/contrib/tilt/manifests/namespace.yaml
+++ b/contrib/tilt/manifests/namespace.yaml
@@ -1,0 +1,8 @@
+# The Platform Mesh system namespace. Kept in its own manifest / Tilt resource
+# with no CRD-dependent siblings so it always applies immediately — everything
+# scoped to platform-mesh-system (issuer, gateway, kcp CRs) depends on it
+# existing first.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-mesh-system

--- a/contrib/tilt/runtime.Dockerfile
+++ b/contrib/tilt/runtime.Dockerfile
@@ -1,0 +1,11 @@
+# Thin runtime image for hot-reloaded components. The host builds the linux
+# binary (see component_build in helpers.py); Tilt live_update-syncs it into
+# this image, so a code change never triggers a full docker build.
+FROM gcr.io/distroless/static:nonroot
+ARG BIN
+# Land the binary at a fixed path with a fixed entrypoint. The production charts
+# set container args only and rely on the image's entrypoint to be the operator,
+# so a per-component path (ARG can't be used in an exec-form ENTRYPOINT) wouldn't
+# be invoked. live_update syncs the rebuilt binary to the same /entrypoint.
+COPY ${BIN} /entrypoint
+ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
Local-dev Tilt setup per : cert-manager, envoy gateway, etcd, dex, kcp-operator + static kcp (RootShard/FrontProxy), Flux + OCM delivery engines, and account-operator as a hot-reloadable L1 component. Profiles map to RFC 008 layers (infra/core/auth/full).

Further split is not possible for too much interconnections between platfrom-mesh-operator, bootstrap processes(es) and individual components. To move this further we need to make every component self sustainable, and independent as much as they can be. First thing first - split core.platfrom-mesh.io so it does not contain multiple component apis.