### PR TITLE
fix wrong parent workspace in account-operator e2e tests

### DIFF
--- a/operators/account-operator/internal/controller/account_controller_test.go
+++ b/operators/account-operator/internal/controller/account_controller_test.go
@@ -145,11 +145,11 @@ func (s *AccountTestSuite) TestAddingFinalizer() {
 		},
 	}
 
-	s.Require().NoError(s.rootOrgsDefaultClient.Create(testContext, account))
+	s.Require().NoError(s.rootOrgsClient.Create(testContext, account))
 
 	createdAccount := pmcorev1alpha1.Account{}
 	s.Assert().Eventually(func() bool {
-		err := s.rootOrgsDefaultClient.Get(testContext, types.NamespacedName{Name: accountName, Namespace: defaultNamespace}, &createdAccount)
+		err := s.rootOrgsClient.Get(testContext, types.NamespacedName{Name: accountName, Namespace: defaultNamespace}, &createdAccount)
 
 		return err == nil && len(createdAccount.Finalizers) == 2
 	}, defaultTestTimeout*2, defaultTickInterval)


### PR DESCRIPTION
While working on the sharded envtest, I noticed this error plop up in the logs:

> workspaces.tenancy.kcp.io \"test-account-finalizer\" is forbidden: [workspace type root:orgs:test-account-finalizer-org extends root:org, which only allows [root:orgs] parent workspaces, but parent type root:orgs:default-org only implements [root:org root:orgs:default-org], workspace type root:orgs:test-account-finalizer-org only allows [root:orgs] parent workspaces, but parent type root:orgs:default-org only implements [root:org root:orgs:default-org]]

After some debugging I finally found the cause: the tests were accidentally using a client into the `default-org`, but the account model in Platform Mesh forbids nesting orgs into each other. Since we are creating an Org in this test, we should place it in the `root:orgs` workspace, the only one that is allowed to host organization workspaces.

Apparently the failed creation of this workspace never influenced the finalizers on the Account object, so nobody ever noticed.