### PR TITLE
fix test teardown in account-operator

### DIFF
--- a/operators/account-operator/internal/controller/account_controller_setup_test.go
+++ b/operators/account-operator/internal/controller/account_controller_setup_test.go
@@ -95,6 +95,12 @@ func (s *AccountTestSuite) setupKCP() {
 	s.kcpConfig, err = s.env.Start()
 	s.Require().NoError(err)
 
+	s.T().Cleanup(func() {
+		if err := s.env.Stop(); err != nil {
+			s.T().Logf("Error stopping kcp environment: %v", err)
+		}
+	})
+
 	s.kcpClient, err = mcc.New(s.kcpConfig, ctrlruntimeclient.Options{
 		Scheme: s.scheme,
 	})

--- a/operators/account-operator/internal/controller/account_controller_test.go
+++ b/operators/account-operator/internal/controller/account_controller_test.go
@@ -80,7 +80,6 @@ type AccountTestSuite struct {
 
 	logger *logger.Logger
 	ctx    context.Context
-	cancel context.CancelCauseFunc
 }
 
 func TestAccountTestSuite(t *testing.T) {
@@ -97,7 +96,16 @@ func (s *AccountTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	ctrl.SetLogger(logger.Logr())
 	s.logger = logger
-	s.ctx, s.cancel, _ = platformmeshcontext.StartContext(logger, nil, 0)
+
+	var cancel context.CancelCauseFunc
+	s.ctx, cancel, _ = platformmeshcontext.StartContext(logger, nil, 0)
+
+	// Do not use the Suite's teardown to stop kcp, since this would happen
+	// before the test's Cleanup functions are called. Since we use the envtest's
+	// workspace fixture, we have to keep kcp alive until that fixture can clean up.
+	s.T().Cleanup(func() {
+		cancel(fmt.Errorf("tearing down test suite"))
+	})
 
 	s.scheme = runtime.NewScheme()
 	utilruntime.Must(pmcorev1alpha1.AddToScheme(s.scheme))
@@ -123,13 +131,6 @@ func (s *AccountTestSuite) SetupSuite() {
 	s.startManager()
 
 	s.setupDefaultOrg()
-}
-
-func (s *AccountTestSuite) TearDownSuite() {
-	if err := s.env.Stop(); err != nil {
-		s.T().Logf("Error stopping kcp environment: %v", err)
-	}
-	s.cancel(fmt.Errorf("tearing down test suite"))
 }
 
 func (s *AccountTestSuite) TestAddingFinalizer() {


### PR DESCRIPTION
Using the test suite's TearDown functionality means that kcp is stopped before all the Cleanup functions had a chance to run. If you run `ADDITIONAL_COMMAND_ARGS="-v" task test-e2e` you could see the errors being generated during the shutdown.

> 2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery@v0.0.0-20260602065202-e006560fc76a/pkg/util/runtime/runtime.go:252 > Failed to watch error="an error on the server (\"Internal Server Error: \\\"/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/%2A/apis/core.platform-mesh.io/v1alpha1/accountinfos?allowWatchBookmarks=true&amp;resourceVersion=1121&amp;timeoutSeconds=492&amp;watch=true\\\": error authorizing RBAC in API export \\\"core.platform-mesh.io\\\", workspace \\\"21kco8wgjr5lj8k8\\\": Post \\\"https://127.0.0.1:33837/clusters/21kco8wgjr5lj8k8/apis/authorization.k8s.io/v1/subjectaccessreviews\\\": dial tcp 127.0.0.1:33837: connect: connection refused\") has prevented the request from succeeding (get accountinfos.core.platform-mesh.io)" logger=controller-runtime/cache/UnhandledError reflector=pkg/mod/github.com/kcp-dev/apimachinery/v2@v2.32.3/third_party/reflector/reflector.go:327 service=AccountTestSuite type=*v1alpha1.AccountInfo
2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery@v0.0.0-20260602065202-e006560fc76a/pkg/util/runtime/runtime.go:252 > Failed to watch error="an error on the server (\"Internal Server Error: \\\"/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/%2A/apis/tenancy.kcp.io/v1alpha1/workspaces?allowWatchBookmarks=true&amp;resourceVersion=1138&amp;timeoutSeconds=348&amp;watch=true\\\": error authorizing RBAC in API export \\\"core.platform-mesh.io\\\", workspace \\\"21kco8wgjr5lj8k8\\\": Post \\\"https://127.0.0.1:33837/clusters/21kco8wgjr5lj8k8/apis/authorization.k8s.io/v1/subjectaccessreviews\\\": dial tcp 127.0.0.1:33837: connect: connection refused\") has prevented the request from succeeding (get workspaces.tenancy.kcp.io)" logger=controller-runtime/cache/UnhandledError reflector=pkg/mod/github.com/kcp-dev/apimachinery/v2@v2.32.3/third_party/reflector/reflector.go:327 service=AccountTestSuite type=*v1alpha1.Workspace
2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery@v0.0.0-20260602065202-e006560fc76a/pkg/util/runtime/runtime.go:252 > Failed to watch error="an error on the server (\"Internal Server Error: \\\"/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/%2A/apis/core.platform-mesh.io/v1alpha1/accounts?allowWatchBookmarks=true&amp;resourceVersion=1114&amp;timeoutSeconds=529&amp;watch=true\\\": error authorizing RBAC in API export \\\"core.platform-mesh.io\\\", workspace \\\"21kco8wgjr5lj8k8\\\": Post \\\"https://127.0.0.1:33837/clusters/21kco8wgjr5lj8k8/apis/authorization.k8s.io/v1/subjectaccessreviews\\\": dial tcp 127.0.0.1:33837: connect: connection refused\") has prevented the request from succeeding (get accounts.core.platform-mesh.io)" logger=controller-runtime/cache/UnhandledError reflector=pkg/mod/github.com/kcp-dev/apimachinery/v2@v2.32.3/third_party/reflector/reflector.go:327 service=AccountTestSuite type=*v1alpha1.Account
2026-07-09T17:03:55+02:00 DBG ../../../../subroutines/lifecycle/lifecycle.go:452 > patching object cluster=1vyxa0tua8ll60yx controller=AccountReconciler controllerGroup=core.platform-mesh.io controllerKind=Account generation=2 name=test-workspace-finalizer namespace= reconcileID=afd85938-9f07-4fee-b972-a97d1ed3f088 service=AccountTestSuite v=1
2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494 > Reconciler error error="patching object: Patch \"https://127.0.0.1:33837/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/1vyxa0tua8ll60yx/apis/core.platform-mesh.io/v1alpha1/accounts/test-workspace-finalizer\": dial tcp 127.0.0.1:33837: connect: connection refused" controller=AccountReconciler controllerGroup=core.platform-mesh.io controllerKind=Account reconcileID=afd85938-9f07-4fee-b972-a97d1ed3f088 service=AccountTestSuite
2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery@v0.0.0-20260602065202-e006560fc76a/pkg/util/runtime/runtime.go:252 > Failed to watch error="an error on the server (\"Internal Server Error: \\\"/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/%2A/apis/apis.kcp.io/v1alpha1/apibindings?allowWatchBookmarks=true&amp;resourceVersion=1132&amp;timeoutSeconds=328&amp;watch=true\\\": error authorizing RBAC in API export \\\"core.platform-mesh.io\\\", workspace \\\"21kco8wgjr5lj8k8\\\": Post \\\"https://127.0.0.1:33837/clusters/21kco8wgjr5lj8k8/apis/authorization.k8s.io/v1/subjectaccessreviews\\\": dial tcp 127.0.0.1:33837: connect: connection refused\") has prevented the request from succeeding (get apibindings.apis.kcp.io)" logger=controller-runtime/cache/UnhandledError reflector=pkg/mod/github.com/kcp-dev/apimachinery/v2@v2.32.3/third_party/reflector/reflector.go:327 service=AccountTestSuite type=*v1alpha1.APIBinding
2026-07-09T17:03:55+02:00 ERR ../../../../../../../../../pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery@v0.0.0-20260602065202-e006560fc76a/pkg/util/runtime/runtime.go:252 > Failed to watch error="an error on the server (\"Internal Server Error: \\\"/services/apiexport/21kco8wgjr5lj8k8/core.platform-mesh.io/clusters/%2A/apis/tenancy.kcp.io/v1alpha1/workspacetypes?allowWatchBookmarks=true&amp;resourceVersion=946&amp;timeoutSeconds=346&amp;watch=true\\\": error authorizing RBAC in API export \\\"core.platform-mesh.io\\\", workspace \\\"21kco8wgjr5lj8k8\\\": Post \\\"https://127.0.0.1:33837/clusters/21kco8wgjr5lj8k8/apis/authorization.k8s.io/v1/subjectaccessreviews\\\": dial tcp 127.0.0.1:33837: connect: connection refused\") has prevented the request from succeeding (get workspacetypes.tenancy.kcp.io)" logger=controller-runtime/cache/UnhandledError reflector=pkg/mod/github.com/kcp-dev/apimachinery/v2@v2.32.3/third_party/reflector/reflector.go:327 service=AccountTestSuite type=*v1alpha1.WorkspaceType

On single-sharded tests these errors would not be a problem, but I am having issues after switching to the sharded envtest. Fixing the shutdown also made the sharded issues go away.