### PR TITLE
fix: clustercache engage problems

### DIFF
--- a/services/rebac-authz-webhook/pkg/clustercache/clustercache.go
+++ b/services/rebac-authz-webhook/pkg/clustercache/clustercache.go
@@ -51,22 +51,52 @@ type Provider interface {
 	Get(clusterName multicluster.ClusterName) (ClusterInfo, bool)
 }
 
-type clusterCache struct {
-	lock  sync.RWMutex
-	cache map[multicluster.ClusterName]ClusterInfo
-	mgr   mcmanager.Manager
+var defaultBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Steps:    9,
+	Cap:      5 * time.Minute,
 }
 
-func New(mgr mcmanager.Manager) (*clusterCache, error) {
-	return &clusterCache{
-		cache: make(map[multicluster.ClusterName]ClusterInfo),
-		mgr:   mgr,
-	}, nil
+type resolver struct {
+	cl     cluster.Cluster
+	cancel context.CancelFunc
+}
+
+type clusterCache struct {
+	cacheLock sync.RWMutex
+	cache     map[multicluster.ClusterName]ClusterInfo
+
+	resolversLock sync.Mutex
+	resolvers     map[multicluster.ClusterName]*resolver
+
+	mgr     mcmanager.Manager
+	backoff wait.Backoff
+}
+
+type Option func(*clusterCache)
+
+func WithBackoff(b wait.Backoff) Option {
+	return func(c *clusterCache) { c.backoff = b }
+}
+
+func New(mgr mcmanager.Manager, opts ...Option) (*clusterCache, error) {
+	c := &clusterCache{
+		cache:     make(map[multicluster.ClusterName]ClusterInfo),
+		resolvers: make(map[multicluster.ClusterName]*resolver),
+		mgr:       mgr,
+		backoff:   defaultBackoff,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
 }
 
 func (c *clusterCache) Get(clusterName multicluster.ClusterName) (ClusterInfo, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
 	val, ok := c.cache[clusterName]
 	return val, ok
 }
@@ -74,23 +104,70 @@ func (c *clusterCache) Get(clusterName multicluster.ClusterName) (ClusterInfo, b
 func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName, cl cluster.Cluster) error {
 	klog.V(5).InfoS("Engaging cluster", "clusterName", name)
 
-	var lc unstructured.Unstructured
-	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		lc = unstructured.Unstructured{}
-		lc.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "core.kcp.io",
-			Version: "v1alpha1",
-			Kind:    "LogicalCluster",
-		})
-		if err := cl.GetClient().Get(ctx, types.NamespacedName{Name: "cluster"}, &lc); err != nil {
-			klog.V(5).ErrorS(err, "Failed to get LogicalCluster, will retry", "clusterName", name)
-			return false, nil
+	c.resolversLock.Lock()
+	defer c.resolversLock.Unlock()
+
+	if old, ok := c.resolvers[name]; ok {
+		if old.cl == cl {
+			return nil
 		}
-		return true, nil
+		old.cancel()
+		delete(c.resolvers, name)
+	}
+
+	resolveCtx, cancel := context.WithCancel(ctx)
+	r := &resolver{cl: cl, cancel: cancel}
+	c.resolvers[name] = r
+
+	// Always return nil: Clusters.Add removes the cluster if Engage errors, and
+	// nothing re-drives it afterwards. Resolve in the background instead.
+	go func() {
+		defer func() {
+			c.resolversLock.Lock()
+			if cur, ok := c.resolvers[name]; ok && cur == r {
+				delete(c.resolvers, name)
+			}
+			c.resolversLock.Unlock()
+		}()
+		c.resolve(resolveCtx, name, cl)
+	}()
+
+	return nil
+}
+
+// resolve retries until it succeeds or ctx is cancelled. It loops by hand rather
+// than via wait.ExponentialBackoffWithContext, which stops after Backoff.Steps;
+// DelayFunc caps at Backoff.Cap and keeps returning it.
+func (c *clusterCache) resolve(ctx context.Context, name multicluster.ClusterName, cl cluster.Cluster) {
+	delay := c.backoff.DelayFunc()
+	for {
+		done, err := c.tryResolve(ctx, name, cl)
+		if done {
+			return
+		}
+		if err != nil {
+			klog.V(5).ErrorS(err, "Failed to resolve cluster, will retry", "clusterName", name)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay()):
+		}
+	}
+}
+
+// tryResolve returns done=true when the cluster was cached or intentionally
+// skipped, and (false, err) when it should be retried.
+func (c *clusterCache) tryResolve(ctx context.Context, name multicluster.ClusterName, cl cluster.Cluster) (bool, error) {
+	lc := unstructured.Unstructured{}
+	lc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "core.kcp.io",
+		Version: "v1alpha1",
+		Kind:    "LogicalCluster",
 	})
-	if err != nil {
-		klog.ErrorS(err, "Failed to get LogicalCluster, context cancelled", "clusterName", name)
-		return err
+	if err := cl.GetClient().Get(ctx, types.NamespacedName{Name: "cluster"}, &lc); err != nil {
+		return false, err
 	}
 
 	annotationPath := lc.GetAnnotations()["kcp.io/path"]
@@ -99,7 +176,7 @@ func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName
 	const orgsPrefix = "root:orgs:"
 	if !strings.HasPrefix(annotationPath, orgsPrefix) {
 		klog.V(5).InfoS("Cluster path does not have orgs prefix, skipping", "clusterName", name, "path", annotationPath)
-		return nil
+		return true, nil
 	}
 
 	orgName, _, _ := strings.Cut(annotationPath[len(orgsPrefix):], ":")
@@ -107,60 +184,44 @@ func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName
 
 	parentClusterID, found, err := unstructured.NestedString(lc.Object, "spec", "owner", "cluster")
 	if err != nil {
-		klog.ErrorS(err, "Failed to get owner.cluster from LogicalCluster spec", "clusterName", name)
-		return err
+		return false, err
 	}
 	if !found {
-		klog.Error("No owner.cluster found in LogicalCluster spec", "clusterName", name)
-		return errors.New("owner.cluster not found in LogicalCluster spec")
+		return false, errors.New("owner.cluster not found in LogicalCluster spec")
 	}
 
-	var store unstructured.Unstructured
-	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		store = unstructured.Unstructured{}
-		store.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "core.platform-mesh.io",
-			Version: "v1alpha1",
-			Kind:    "Store",
-		})
-
-		orgsCluster, err := c.mgr.GetCluster(ctx, "root:orgs")
-		if err != nil {
-			return false, err
-		}
-		orgsClient := orgsCluster.GetClient()
-
-		if err := orgsClient.Get(ctx, types.NamespacedName{Name: orgName}, &store); err != nil {
-			klog.V(5).ErrorS(err, "Failed to get Store for org, will retry", "clusterName", name, "orgName", orgName)
-			return false, nil
-		}
-		return true, nil
+	store := unstructured.Unstructured{}
+	store.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "core.platform-mesh.io",
+		Version: "v1alpha1",
+		Kind:    "Store",
 	})
+	orgsCluster, err := c.mgr.GetCluster(ctx, "root:orgs")
 	if err != nil {
-		klog.ErrorS(err, "Failed to get Store for org", "clusterName", name, "orgName", orgName)
-		return err
+		return false, err
+	}
+	if err := orgsCluster.GetClient().Get(ctx, types.NamespacedName{Name: orgName}, &store); err != nil {
+		return false, err
 	}
 
 	storeID, found, err := unstructured.NestedString(store.Object, "status", "storeId")
 	if err != nil {
-		klog.ErrorS(err, "Failed to get storeId from Store status", "clusterName", name, "orgName", orgName)
-		return err
+		return false, err
 	}
 	if !found {
-		klog.V(5).InfoS("storeId not found in Store status", "clusterName", name, "orgName", orgName)
-		return errors.New("storeId not found in Store status")
+		return false, errors.New("storeId not found in Store status")
 	}
 
 	cfg := rest.CopyConfig(cl.GetConfig())
 
 	parsed, err := url.Parse(cfg.Host)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	path, err := url.JoinPath("clusters", name.String())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	parsed.Path = path
@@ -168,22 +229,22 @@ func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName
 
 	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	restMapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	c.lock.Lock()
+	c.cacheLock.Lock()
 	c.cache[name] = ClusterInfo{
 		StoreID:         storeID,
 		RESTMapper:      restMapper,
 		AccountName:     accountName,
 		ParentClusterID: parentClusterID,
 	}
-	c.lock.Unlock()
+	c.cacheLock.Unlock()
 
 	klog.V(5).InfoS("Cached cluster info",
 		"clusterName", name,
@@ -191,7 +252,7 @@ func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName
 		"accountName", accountName,
 		"parentClusterID", parentClusterID)
 
-	return nil
+	return true, nil
 }
 
 func (c *clusterCache) Start(_ context.Context) error { // coverage-ignore

--- a/services/rebac-authz-webhook/pkg/clustercache/clustercache.go
+++ b/services/rebac-authz-webhook/pkg/clustercache/clustercache.go
@@ -119,17 +119,21 @@ func (c *clusterCache) Engage(ctx context.Context, name multicluster.ClusterName
 	r := &resolver{cl: cl, cancel: cancel}
 	c.resolvers[name] = r
 
+	// Handle cluster discovery asynchronously in order to not block Engage() calls on
+	// clusters with (hopefully just temporarily) missing permission claims.
+	//
 	// Always return nil: Clusters.Add removes the cluster if Engage errors, and
 	// nothing re-drives it afterwards. Resolve in the background instead.
 	go func() {
-		defer func() {
-			c.resolversLock.Lock()
-			if cur, ok := c.resolvers[name]; ok && cur == r {
-				delete(c.resolvers, name)
-			}
-			c.resolversLock.Unlock()
-		}()
 		c.resolve(resolveCtx, name, cl)
+
+		c.resolversLock.Lock()
+		defer c.resolversLock.Unlock()
+
+		// cleanup if we're still active and have not been replaced by another Engage() call
+		if c.resolvers[name] == r {
+			delete(c.resolvers, name)
+		}
 	}()
 
 	return nil

--- a/services/rebac-authz-webhook/pkg/clustercache/clustercache_test.go
+++ b/services/rebac-authz-webhook/pkg/clustercache/clustercache_test.go
@@ -19,7 +19,9 @@ package clustercache_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -29,154 +31,233 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 )
 
-func TestNew(t *testing.T) {
+const testCluster = multicluster.ClusterName("test-cluster")
+
+// fastBackoff makes the resolver retry almost immediately so tests don't wait
+// on the production cadence.
+var fastBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: 100, Cap: time.Millisecond}
+
+// waitStopped blocks until the resolver's call counter stops climbing, so a
+// late Get call can't race the testify mock's AssertExpectations at cleanup.
+func waitStopped(t *testing.T, gets *atomic.Int32) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		before := gets.Load()
+		time.Sleep(40 * time.Millisecond)
+		return gets.Load() == before
+	}, 2*time.Second, 20*time.Millisecond, "resolver did not stop after cancel")
+}
+
+type fixture struct {
+	cc clustercache.Provider
+}
+
+// spec describes one resolution scenario for newFixture.
+type spec struct {
+	path       string       // kcp.io/path annotation on the LogicalCluster
+	owner      string       // spec.owner.cluster; "" => omitted
+	storeID    string       // Store status.storeId; "" => Store returns without storeId
+	withStore  bool         // wire the orgs Store lookup
+	failFirstN int32        // fail the LogicalCluster Get this many times first
+	lcGetErr   error        // permanent LogicalCluster Get error (never resolves)
+	backoff    wait.Backoff // resolver cadence; zero value => fastBackoff
+}
+
+// newFixture wires the mocks the resolver touches and Engages one cluster: the
+// LogicalCluster Get fails its first failFirstN calls, then returns an object at
+// path/owner; withStore adds the orgs Store lookup returning storeID.
+func newFixture(t *testing.T, s spec) fixture {
+	t.Helper()
+
+	cl := mocks.NewCluster(t)
+	k8sClient := mocks.NewClient(t)
 	mgr := mocks.NewManager(t)
 
-	cc, err := clustercache.New(mgr)
+	cl.EXPECT().GetClient().Return(k8sClient)
+	if s.storeID != "" {
+		// GetConfig is only reached on the full success path (after storeId).
+		cl.EXPECT().GetConfig().Return(&rest.Config{Host: "https://example.com"})
+	}
+
+	var gets atomic.Int32
+	k8sClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "cluster"}, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, _ ...ctrlruntimeclient.GetOption) error {
+			defer gets.Add(1) // increment last so waitStopped's barrier orders the obj writes below
+			if s.lcGetErr != nil {
+				return s.lcGetErr
+			}
+			if gets.Load() < s.failFirstN {
+				return errors.New("logicalclusters permission claim not accepted")
+			}
+			lc := obj.(*unstructured.Unstructured)
+			lc.SetAnnotations(map[string]string{"kcp.io/path": s.path})
+			if s.owner != "" {
+				lc.Object["spec"] = map[string]any{"owner": map[string]any{"cluster": s.owner}}
+			}
+			return nil
+		})
+
+	if s.withStore {
+		orgsCluster := mocks.NewCluster(t)
+		orgsClient := mocks.NewClient(t)
+		mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("root:orgs")).Return(orgsCluster, nil)
+		orgsCluster.EXPECT().GetClient().Return(orgsClient)
+		orgsClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, _ ...ctrlruntimeclient.GetOption) error {
+				status := map[string]any{}
+				if s.storeID != "" {
+					status["storeId"] = s.storeID
+				}
+				obj.(*unstructured.Unstructured).Object = map[string]any{"status": status}
+				return nil
+			})
+	}
+
+	backoff := s.backoff
+	if backoff == (wait.Backoff{}) {
+		backoff = fastBackoff
+	}
+	cc, err := clustercache.New(mgr, clustercache.WithBackoff(backoff))
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() { cancel(); waitStopped(t, &gets) })
+	assert.NoError(t, cc.Engage(ctx, testCluster, cl))
+
+	return fixture{cc: cc}
+}
+
+func (f fixture) cachedEventually(t *testing.T) (clustercache.ClusterInfo, bool) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		_, ok := f.cc.Get(testCluster)
+		return ok
+	}, 3*time.Second, time.Millisecond, "expected cluster to be cached")
+	return f.cc.Get(testCluster)
+}
+
+func TestNew(t *testing.T) {
+	cc, err := clustercache.New(mocks.NewManager(t))
 	assert.NoError(t, err)
 	assert.NotNil(t, cc)
 }
 
-func TestClusterCache_Engage(t *testing.T) {
-	tests := []struct {
-		name            string
-		path            string
-		ownerCluster    string
-		setupOrgsClient func(*mocks.Client)
-		setupCluster    func(*mocks.Cluster)
-		lcGetErr        error
-		wantCached      bool
-		wantAccountName string
-		wantErr         bool
-	}{
-		{
-			name:         "caches cluster info successfully",
-			path:         "root:orgs:myorg:ws:child",
-			ownerCluster: "parent-cluster-id",
-			setupOrgsClient: func(c *mocks.Client) {
-				setupStoreGet(c, "myorg", "myorg-store-id")
-			},
-			setupCluster:    func(c *mocks.Cluster) { c.EXPECT().GetConfig().Return(&rest.Config{Host: "https://example.com"}) },
-			wantCached:      true,
-			wantAccountName: "child",
-		},
-		{
-			name:    "returns error when owner missing",
-			path:    "root:orgs:myorg",
-			wantErr: true,
-		},
-		{
-			name:       "skips non-org path",
-			path:       "root:platform-mesh-system",
-			wantCached: false,
-		},
-		{
-			name:     "returns error on logical cluster get failure",
-			path:     "root:orgs:myorg",
-			lcGetErr: errors.New("connection refused"),
-			wantErr:  true,
-		},
-		{
-			name:         "returns error when storeId missing",
-			path:         "root:orgs:myorg",
-			ownerCluster: "parent-cluster",
-			setupOrgsClient: func(c *mocks.Client) {
-				setupStoreGetMissing(c, "myorg")
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cl := mocks.NewCluster(t)
-			k8sClient := mocks.NewClient(t)
-			mgr := mocks.NewManager(t)
-			orgsCluster := mocks.NewCluster(t)
-			orgsClient := mocks.NewClient(t)
-
-			cl.EXPECT().GetClient().Return(k8sClient)
-
-			ctx := t.Context()
-			if tt.lcGetErr != nil {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithCancel(ctx)
-				cancel()
-			}
-
-			k8sClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "cluster"}, mock.Anything, mock.Anything).
-				Run(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) {
-					lc := obj.(*unstructured.Unstructured)
-					lc.SetAnnotations(map[string]string{"kcp.io/path": tt.path})
-					if tt.ownerCluster != "" {
-						lc.Object["spec"] = map[string]any{
-							"owner": map[string]any{"cluster": tt.ownerCluster},
-						}
-					}
-				}).
-				Return(tt.lcGetErr)
-
-			if tt.setupOrgsClient != nil {
-				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("root:orgs")).Return(orgsCluster, nil)
-				orgsCluster.EXPECT().GetClient().Return(orgsClient)
-				tt.setupOrgsClient(orgsClient)
-			}
-			if tt.setupCluster != nil {
-				tt.setupCluster(cl)
-			}
-
-			cc, err := clustercache.New(mgr)
-			assert.NoError(t, err)
-			err = cc.Engage(ctx, multicluster.ClusterName("test-cluster"), cl)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-
-			info, found := cc.Get(multicluster.ClusterName("test-cluster"))
-			assert.Equal(t, tt.wantCached, found)
-			if tt.wantCached {
-				assert.Equal(t, tt.wantAccountName, info.AccountName)
-				assert.Equal(t, tt.ownerCluster, info.ParentClusterID)
-				assert.NotNil(t, info.RESTMapper)
-			}
-		})
-	}
-}
-
 func TestClusterCache_Get_NotFound(t *testing.T) {
-	mgr := mocks.NewManager(t)
-	cc, err := clustercache.New(mgr)
+	cc, err := clustercache.New(mocks.NewManager(t))
 	assert.NoError(t, err)
 	info, found := cc.Get(multicluster.ClusterName("non-existing"))
 	assert.False(t, found)
 	assert.Empty(t, info.StoreID)
 }
 
-func setupStoreGet(c *mocks.Client, orgName, storeID string) {
-	c.EXPECT().Get(mock.Anything, types.NamespacedName{Name: orgName}, mock.Anything, mock.Anything).
-		Run(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) {
-			obj.(*unstructured.Unstructured).Object = map[string]any{
-				"status": map[string]any{"storeId": storeID},
+// TestClusterCache_Engage covers the resolution outcomes: a workspace is cached
+// only when the LogicalCluster and Store fully resolve; every incomplete or
+// failing case must leave the cache empty (Engage stays non-blocking and never
+// caches a bad workspace). failFirstN also proves the resolver keeps retrying
+// past a transient failure and past Backoff.Steps.
+func TestClusterCache_Engage(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       spec
+		wantCached bool
+		wantAccot  string
+		wantParent string
+	}{
+		{
+			name:       "caches once LogicalCluster and Store resolve",
+			spec:       spec{path: "root:orgs:myorg:ws:child", owner: "parent-cluster-id", storeID: "myorg-store-id", withStore: true},
+			wantCached: true, wantAccot: "child", wantParent: "parent-cluster-id",
+		},
+		{
+			name:       "recovers after transient LogicalCluster failures",
+			spec:       spec{path: "root:orgs:myorg:ws:child", owner: "parent-cluster-id", storeID: "myorg-store-id", withStore: true, failFirstN: 2},
+			wantCached: true, wantAccot: "child", wantParent: "parent-cluster-id",
+		},
+		{
+			name:       "keeps retrying past Backoff.Steps",
+			spec:       spec{path: "root:orgs:myorg:ws:child", owner: "parent-cluster-id", storeID: "myorg-store-id", withStore: true, failFirstN: 20, backoff: wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: 3, Cap: time.Millisecond}},
+			wantCached: true, wantAccot: "child", wantParent: "parent-cluster-id",
+		},
+		{name: "skips non-org path", spec: spec{path: "root:platform-mesh-system"}},
+		{name: "does not cache when owner missing", spec: spec{path: "root:orgs:myorg"}},
+		{name: "does not cache on LogicalCluster get failure", spec: spec{path: "root:orgs:myorg", lcGetErr: errors.New("connection refused")}},
+		{name: "does not cache when storeId missing", spec: spec{path: "root:orgs:myorg", owner: "parent-cluster", withStore: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFixture(t, tt.spec)
+
+			if tt.wantCached {
+				info, _ := f.cachedEventually(t)
+				assert.Equal(t, tt.wantAccot, info.AccountName)
+				assert.Equal(t, tt.wantParent, info.ParentClusterID)
+				assert.NotNil(t, info.RESTMapper)
+				return
 			}
-		}).
-		Return(nil)
+			assert.Never(t, func() bool {
+				_, ok := f.cc.Get(testCluster)
+				return ok
+			}, 50*time.Millisecond, 5*time.Millisecond, "must not cache a bad workspace")
+		})
+	}
 }
 
-func setupStoreGetMissing(c *mocks.Client, orgName string) {
-	c.EXPECT().Get(mock.Anything, types.NamespacedName{Name: orgName}, mock.Anything, mock.Anything).
-		Run(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) {
-			obj.(*unstructured.Unstructured).Object = map[string]any{
-				"status": map[string]any{},
-			}
-		}).
-		Return(nil)
+// alwaysFail builds a cluster whose LogicalCluster Get never succeeds, counting
+// calls. Used to observe resolver retry behavior (dedup, cancellation).
+func alwaysFail(t *testing.T) (*mocks.Cluster, clustercache.Provider, *atomic.Int32) {
+	t.Helper()
+	cl := mocks.NewCluster(t)
+	k8sClient := mocks.NewClient(t)
+	cl.EXPECT().GetClient().Return(k8sClient)
+
+	var gets atomic.Int32
+	k8sClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "cluster"}, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ ctrlruntimeclient.ObjectKey, _ ctrlruntimeclient.Object, _ ...ctrlruntimeclient.GetOption) error {
+			gets.Add(1)
+			return errors.New("still failing")
+		})
+
+	slow := wait.Backoff{Duration: 20 * time.Millisecond, Factor: 1.0, Steps: 1, Cap: 20 * time.Millisecond}
+	cc, err := clustercache.New(mocks.NewManager(t), clustercache.WithBackoff(slow))
+	assert.NoError(t, err)
+	return cl, cc, &gets
+}
+
+// TestClusterCache_Engage_ReentrantDedup verifies repeated Engage of the same
+// cluster instance does not stack resolver goroutines: an always-failing
+// resolver on a 20ms cadence ticks ~5 times over 100ms; five stacked resolvers
+// would tick ~25.
+func TestClusterCache_Engage_ReentrantDedup(t *testing.T) {
+	cl, cc, gets := alwaysFail(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	for range 5 {
+		assert.NoError(t, cc.Engage(ctx, testCluster, cl))
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Less(t, gets.Load(), int32(15), "re-entrant Engage must not stack resolvers")
+
+	cancel()
+	waitStopped(t, gets)
+}
+
+// TestClusterCache_Engage_ContextCancellationStopsResolver verifies the resolver
+// stops making calls once its context is cancelled.
+func TestClusterCache_Engage_ContextCancellationStopsResolver(t *testing.T) {
+	cl, cc, gets := alwaysFail(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	assert.NoError(t, cc.Engage(ctx, testCluster, cl))
+
+	assert.Eventually(t, func() bool { return gets.Load() >= 1 }, time.Second, time.Millisecond)
+	cancel()
+	waitStopped(t, gets)
 }


### PR DESCRIPTION
Probably worth investigating if it makes sense to introduce a `max-concurrent-reconciles` equivalent to not nuke the operator on restart

Closes #190