### PR TITLE
feat: add search service pagination

### DIFF
--- a/services/search-service/README.md
+++ b/services/search-service/README.md
@@ -15,7 +15,7 @@ The service is organization-aware and derives org context from the request host.
   - `GET /rest/v1/search`
   - `GET /rest/v1/search/resources`
   - `GET /rest/v1/search/filter-values`
-- Free-text search in OpenSearch with stable cursor pagination (`search_after`)
+- Free-text search in OpenSearch with cursor and page-based pagination
 - OpenFGA post-filtering (`relation=get`) with fail-closed behavior for incomplete auth context
 - Org-aware context + kcp token/org access pre-check
 - SearchIndex-driven resource/field metadata:
@@ -28,7 +28,7 @@ The service is organization-aware and derives org context from the request host.
 
 ### Search endpoint
 
-`GET /rest/v1/search?q=<query>&mode=<lexical|semantic>&limit=<n>&cursor=<opaque>&resource=<plural>&filter.<field>=<value>`
+`GET /rest/v1/search?q=<query>&mode=<lexical|semantic>&limit=<n>&page=<n>&cursor=<opaque>&resource=<plural>&filter.<field>=<value>`
 
 Query params:
 
@@ -37,7 +37,14 @@ Query params:
 - `resource` (optional for `lexical`, required for `semantic`): plural resource name; lexical mode can search across all resources, semantic mode must target a single resource
 - `filter.<field>` (optional, repeatable): exact-match filters; requires `resource`
 - `limit` (optional): default `20`, max `100`
+- `page` (optional): 1-based result page using `limit` as the page size; used when `cursor` is omitted
 - `cursor` (optional): opaque pagination cursor
+
+If both `page` and `cursor` are provided, cursor-based pagination takes precedence.
+
+Page-based pagination scans and authorizes preceding hits, so it is bounded by
+`MaxScannedHits / limit` (1000 scanned hits by default). Requests beyond that bound are rejected; use cursor-based
+pagination for deep traversal.
 
 Semantic mode behavior:
 
@@ -59,7 +66,8 @@ Response shape:
 - `results[]` with compact fields (`id`, `score`, `kind`, `name`, `namespace`, `apiGroup`, `apiVersion`, `workspacePath`, `clusterName`, `organizationId`, `organizationName`, `accountId`, `accountName`)
 - `results[].resource` indicates which resource index produced the hit
 - `source` containing the indexed document source per hit, including `default_fields`, `semantic_fields`, and `filterable_fields`
-- `nextCursor` for pagination
+- `nextCursor` for sequential continuation. It can also be returned for a page-based request; pass it as `cursor`
+  (without `page`) to continue after that page.
 
 ### Resource metadata endpoint
 

--- a/services/search-service/internal/router/router.go
+++ b/services/search-service/internal/router/router.go
@@ -61,6 +61,11 @@ func CreateRouter(svc SearchService, mws []func(http.Handler) http.Handler) *chi
 			http.Error(w, "invalid limit", http.StatusBadRequest)
 			return
 		}
+		page, err := parseOptionalPage(r.URL.Query().Get("page"))
+		if err != nil {
+			http.Error(w, "invalid page", http.StatusBadRequest)
+			return
+		}
 
 		filters, err := parseFilters(r.URL.Query())
 		if err != nil {
@@ -76,6 +81,7 @@ func CreateRouter(svc SearchService, mws []func(http.Handler) http.Handler) *chi
 			Resource:     strings.TrimSpace(r.URL.Query().Get("resource")),
 			Filters:      filters,
 			Limit:        limit,
+			Page:         page,
 			Cursor:       strings.TrimSpace(r.URL.Query().Get("cursor")),
 		})
 		if err != nil {
@@ -175,6 +181,19 @@ func parseOptionalLimit(raw string) (int, error) {
 		return 0, nil
 	}
 	return strconv.Atoi(raw)
+}
+
+func parseOptionalPage(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+
+	page, err := strconv.Atoi(raw)
+	if err != nil || page < 1 {
+		return 0, fmt.Errorf("page must be a positive integer")
+	}
+	return page, nil
 }
 
 func parseFilters(values map[string][]string) (map[string][]string, error) {

--- a/services/search-service/internal/router/router_test.go
+++ b/services/search-service/internal/router/router_test.go
@@ -71,7 +71,11 @@ func TestCreateRouterSearchSuccess(t *testing.T) {
 	svc := &fakeSearchService{response: search.SearchResponse{Results: []search.SearchHit{{ID: "1", Score: 1, Source: map[string]any{"id": "1"}}}}}
 	r := CreateRouter(svc, []func(http.Handler) http.Handler{withRequestContext(appcontext.RequestContext{Organization: "acme", User: "alice@example.com"})})
 
-	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=hello&mode=semantic&limit=15&cursor=abc&resource=accounts&filter.status=Ready", nil)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/rest/v1/search?q=hello&mode=semantic&limit=15&page=3&cursor=abc&resource=accounts&filter.status=Ready",
+		nil,
+	)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -81,7 +85,13 @@ func TestCreateRouterSearchSuccess(t *testing.T) {
 	if svc.lastReq.Organization != "acme" || svc.lastReq.User != "alice@example.com" {
 		t.Fatalf("unexpected request context: %+v", svc.lastReq)
 	}
-	if svc.lastReq.Query != "hello" || svc.lastReq.Mode != search.SearchModeSemantic || svc.lastReq.Limit != 15 || svc.lastReq.Cursor != "abc" || svc.lastReq.Resource != "accounts" {
+	requestFieldsMatch := svc.lastReq.Query == "hello" &&
+		svc.lastReq.Mode == search.SearchModeSemantic &&
+		svc.lastReq.Limit == 15 &&
+		svc.lastReq.Page == 3 &&
+		svc.lastReq.Cursor == "abc" &&
+		svc.lastReq.Resource == "accounts"
+	if !requestFieldsMatch {
 		t.Fatalf("unexpected request payload: %+v", svc.lastReq)
 	}
 	if len(svc.lastReq.Filters["status"]) != 1 || svc.lastReq.Filters["status"][0] != "Ready" {
@@ -94,6 +104,23 @@ func TestCreateRouterSearchSuccess(t *testing.T) {
 	}
 	if len(payload.Results) != 1 {
 		t.Fatalf("expected one result")
+	}
+}
+
+func TestCreateRouterSearchAcceptsFirstPage(t *testing.T) {
+	svc := &fakeSearchService{}
+	r := CreateRouter(svc, []func(http.Handler) http.Handler{
+		withRequestContext(appcontext.RequestContext{Organization: "acme", User: "alice@example.com"}),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=hello&page=1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if svc.lastReq.Page != 1 {
+		t.Fatalf("expected page 1, got %d", svc.lastReq.Page)
 	}
 }
 
@@ -170,6 +197,33 @@ func TestCreateRouterInvalidLimit(t *testing.T) {
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestCreateRouterInvalidPage(t *testing.T) {
+	tests := []struct {
+		name string
+		page string
+	}{
+		{name: "not a number", page: "bad"},
+		{name: "zero", page: "0"},
+		{name: "negative", page: "-1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &fakeSearchService{}
+			r := CreateRouter(svc, []func(http.Handler) http.Handler{
+				withRequestContext(appcontext.RequestContext{Organization: "acme", User: "alice@example.com"}),
+			})
+			req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=hello&page="+tc.page, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", rr.Code)
+			}
+		})
 	}
 }
 

--- a/services/search-service/internal/service/search/service.go
+++ b/services/search-service/internal/service/search/service.go
@@ -118,6 +118,28 @@ func (s *Service) Search(ctx context.Context, req SearchRequest) (SearchResponse
 		limit = s.cfg.MaxLimit
 	}
 
+	resultOffset := 0
+	if req.Cursor == "" {
+		if req.Page < 0 {
+			return SearchResponse{}, fmt.Errorf("%w: page must not be negative", ErrInvalidRequest)
+		}
+		if req.Page > 1 {
+			maxPage := s.cfg.MaxScannedHits / limit
+			if maxPage == 0 {
+				maxPage = 1
+			}
+			if req.Page > maxPage {
+				return SearchResponse{}, fmt.Errorf(
+					"%w: page exceeds the maximum of %d for limit %d",
+					ErrInvalidRequest,
+					maxPage,
+					limit,
+				)
+			}
+			resultOffset = (req.Page - 1) * limit
+		}
+	}
+
 	qHash := queryHash(query)
 	fHash := filtersHash(filters)
 	var searchAfter []any
@@ -186,6 +208,7 @@ func (s *Service) Search(ctx context.Context, req SearchRequest) (SearchResponse
 	results := make([]SearchHit, 0, limit)
 	var nextSearchAfter []any
 	var totalScanned int
+	var authorizedHits int
 	var exhausted bool
 
 outer:
@@ -241,6 +264,10 @@ outer:
 
 			if i >= len(authz.Allowed) || !authz.Allowed[i] {
 				log.Warn().Str("searchmode", mode).Str("organization", org).Str("queryHash", qHash).Str("resource", resource).Int("hitIndex", i).Msg("skipping unauthorized search hit")
+				continue
+			}
+			authorizedHits++
+			if authorizedHits <= resultOffset {
 				continue
 			}
 

--- a/services/search-service/internal/service/search/service_test.go
+++ b/services/search-service/internal/service/search/service_test.go
@@ -19,6 +19,7 @@ package search
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -105,6 +106,225 @@ func TestSearchFillsAuthorizedPageAcrossBatches(t *testing.T) {
 	}
 	if resp.NextCursor == nil {
 		t.Fatalf("expected non-nil next cursor")
+	}
+}
+
+func TestSearchReturnsRequestedPageOfAuthorizedResults(t *testing.T) {
+	searcher := &fakeSearcher{pages: []OpenSearchPage{
+		{Hits: []OpenSearchHit{
+			{ID: "1", Sort: []any{1.0, "1"}, Source: map[string]any{"id": "1"}},
+			{ID: "2", Sort: []any{0.9, "2"}, Source: map[string]any{"id": "2"}},
+		}},
+		{Hits: []OpenSearchHit{
+			{ID: "3", Sort: []any{0.8, "3"}, Source: map[string]any{"id": "3"}},
+			{ID: "4", Sort: []any{0.7, "4"}, Source: map[string]any{"id": "4"}},
+		}},
+		{Hits: []OpenSearchHit{
+			{ID: "5", Sort: []any{0.6, "5"}, Source: map[string]any{"id": "5"}},
+			{ID: "6", Sort: []any{0.5, "6"}, Source: map[string]any{"id": "6"}},
+		}},
+	}}
+	authorizer := &fakeAuthorizer{results: []AuthorizationResult{
+		{Allowed: []bool{true, false}, Denied: 1, Calls: 1},
+		{Allowed: []bool{true, true}, Calls: 1},
+		{Allowed: []bool{false, true}, Denied: 1, Calls: 1},
+	}}
+
+	svc := NewService(
+		fakeResolver{index: SearchIndexRef{IndexName: "idx-acme"}},
+		searcher,
+		authorizer,
+		nil,
+		ServiceConfig{DefaultLimit: 20, MaxLimit: 100, FetchBatchSize: 2, MaxScannedHits: 1000},
+	)
+
+	resp, err := svc.Search(context.Background(), SearchRequest{
+		Organization: "acme",
+		User:         "alice@example.com",
+		Query:        "foo",
+		Limit:        2,
+		Page:         2,
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].ID != "4" || resp.Results[1].ID != "6" {
+		t.Fatalf("expected authorized results [4 6], got [%s %s]", resp.Results[0].ID, resp.Results[1].ID)
+	}
+	if searcher.calls != 3 {
+		t.Fatalf("expected 3 OpenSearch calls, got %d", searcher.calls)
+	}
+	if resp.NextCursor == nil {
+		t.Fatalf("expected non-nil next cursor")
+	}
+}
+
+func TestSearchPageOneMatchesOmittedPage(t *testing.T) {
+	tests := []struct {
+		name string
+		page int
+	}{
+		{name: "page omitted"},
+		{name: "first page", page: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			searcher := &fakeSearcher{pages: []OpenSearchPage{{Hits: []OpenSearchHit{
+				{ID: "1", Sort: []any{1.0, "1"}, Source: map[string]any{"id": "1"}},
+				{ID: "2", Sort: []any{0.9, "2"}, Source: map[string]any{"id": "2"}},
+				{ID: "3", Sort: []any{0.8, "3"}, Source: map[string]any{"id": "3"}},
+			}}}}
+			authorizer := &fakeAuthorizer{results: []AuthorizationResult{{
+				Allowed: []bool{true, true, true},
+				Calls:   1,
+			}}}
+			svc := NewService(
+				fakeResolver{index: SearchIndexRef{IndexName: "idx-acme"}},
+				searcher,
+				authorizer,
+				nil,
+				ServiceConfig{
+					DefaultLimit:   20,
+					MaxLimit:       100,
+					FetchBatchSize: 3,
+					MaxScannedHits: 1000,
+				},
+			)
+
+			resp, err := svc.Search(context.Background(), SearchRequest{
+				Organization: "acme",
+				User:         "alice@example.com",
+				Query:        "foo",
+				Limit:        2,
+				Page:         tc.page,
+			})
+			if err != nil {
+				t.Fatalf("Search returned error: %v", err)
+			}
+			hasFirstPage := len(resp.Results) == 2 &&
+				resp.Results[0].ID == "1" &&
+				resp.Results[1].ID == "2"
+			if !hasFirstPage {
+				t.Fatalf("expected first page results [1 2], got %+v", resp.Results)
+			}
+		})
+	}
+}
+
+func TestSearchRejectsPageBeyondScannedHitsLimit(t *testing.T) {
+	searcher := &fakeSearcher{}
+	svc := NewService(
+		fakeResolver{index: SearchIndexRef{IndexName: "idx-acme"}},
+		searcher,
+		&fakeAuthorizer{},
+		nil,
+		ServiceConfig{
+			DefaultLimit:   20,
+			MaxLimit:       100,
+			FetchBatchSize: 2,
+			MaxScannedHits: 4,
+		},
+	)
+
+	_, err := svc.Search(context.Background(), SearchRequest{
+		Organization: "acme",
+		User:         "alice@example.com",
+		Query:        "foo",
+		Limit:        2,
+		Page:         math.MaxInt,
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest, got %v", err)
+	}
+	if searcher.calls != 0 {
+		t.Fatalf("expected no OpenSearch calls, got %d", searcher.calls)
+	}
+}
+
+func TestSearchPageBeyondAvailableResultsIsEmpty(t *testing.T) {
+	searcher := &fakeSearcher{pages: []OpenSearchPage{{Hits: []OpenSearchHit{
+		{ID: "1", Sort: []any{1.0, "1"}, Source: map[string]any{"id": "1"}},
+	}}}}
+	svc := NewService(
+		fakeResolver{index: SearchIndexRef{IndexName: "idx-acme"}},
+		searcher,
+		&fakeAuthorizer{results: []AuthorizationResult{{Allowed: []bool{true}, Calls: 1}}},
+		nil,
+		ServiceConfig{
+			DefaultLimit:   20,
+			MaxLimit:       100,
+			FetchBatchSize: 2,
+			MaxScannedHits: 4,
+		},
+	)
+
+	resp, err := svc.Search(context.Background(), SearchRequest{
+		Organization: "acme",
+		User:         "alice@example.com",
+		Query:        "foo",
+		Limit:        2,
+		Page:         2,
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(resp.Results) != 0 {
+		t.Fatalf("expected no results, got %+v", resp.Results)
+	}
+	if resp.NextCursor != nil {
+		t.Fatalf("expected no next cursor, got %q", *resp.NextCursor)
+	}
+}
+
+func TestSearchCursorTakesPrecedenceOverPage(t *testing.T) {
+	searchAfter := []any{0.9, "previous"}
+	cursor, err := EncodeCursor(CursorState{
+		Org:         "acme",
+		QueryHash:   queryHash("foo"),
+		Mode:        SearchModeLexical,
+		FiltersHash: filtersHash(nil),
+		Limit:       2,
+		SearchAfter: searchAfter,
+	})
+	if err != nil {
+		t.Fatalf("EncodeCursor returned error: %v", err)
+	}
+
+	searcher := &fakeSearcher{pages: []OpenSearchPage{{Hits: []OpenSearchHit{
+		{ID: "1", Sort: []any{0.8, "1"}, Source: map[string]any{"id": "1"}},
+		{ID: "2", Sort: []any{0.7, "2"}, Source: map[string]any{"id": "2"}},
+	}}}}
+	svc := NewService(
+		fakeResolver{index: SearchIndexRef{IndexName: "idx-acme"}},
+		searcher,
+		&fakeAuthorizer{results: []AuthorizationResult{{Allowed: []bool{true, true}, Calls: 1}}},
+		nil,
+		ServiceConfig{DefaultLimit: 20, MaxLimit: 100, FetchBatchSize: 2, MaxScannedHits: 1000},
+	)
+
+	resp, err := svc.Search(context.Background(), SearchRequest{
+		Organization: "acme",
+		User:         "alice@example.com",
+		Query:        "foo",
+		Limit:        2,
+		Page:         3,
+		Cursor:       cursor,
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(resp.Results) != 2 || resp.Results[0].ID != "1" || resp.Results[1].ID != "2" {
+		t.Fatalf("expected cursor results [1 2], got %+v", resp.Results)
+	}
+	if len(searcher.reqs) != 1 || len(searcher.reqs[0].SearchAfter) != 2 {
+		t.Fatalf("expected cursor search_after, got %+v", searcher.reqs)
+	}
+	if searcher.reqs[0].SearchAfter[1] != "previous" {
+		t.Fatalf("unexpected search_after: %+v", searcher.reqs[0].SearchAfter)
 	}
 }
 

--- a/services/search-service/internal/service/search/types.go
+++ b/services/search-service/internal/service/search/types.go
@@ -26,6 +26,7 @@ type SearchRequest struct {
 	Resource     string
 	Filters      map[string][]string
 	Limit        int
+	Page         int
 	Cursor       string
 }
 


### PR DESCRIPTION
This PR adds a page-based pagination to the already existing cursor-based one.
Therefor a new `page` parameter is added for the page number and the already existing parameter `limit` is used for the page size.

The new code adds checks for page and limit boundaries and applies the same auth checks for the returned results that existed before.
 
Fixes https://github.com/platform-mesh/backlog/issues/341