### PR TITLE
feat(kubernetes-graphql-gateway): make QPS and Burst configurable via arguments

### DIFF
--- a/services/kubernetes-graphql-gateway/README.md
+++ b/services/kubernetes-graphql-gateway/README.md
@@ -201,8 +201,8 @@ Optionally set `ca.secretRef` for custom CA certificates.
 | `--max-query-batch-size` | `10` | Max queries per batch request |
 | `--read-header-timeout` | `32s` | Max duration for reading request headers |
 | `--idle-timeout` | `90s` | Max idle duration for keep-alive connections |
-| `--kubernetes-qps` | `0` (client-go default: 5) | Max requests per second to the Kubernetes API server |
-| `--kubernetes-burst` | `0` (client-go default: 10) | Max burst size for requests to the Kubernetes API server |
+| `--kubernetes-qps` | `0` (uses client-go default: 5) | Max requests per second to the Kubernetes API server |
+| `--kubernetes-burst` | `0` (uses client-go default: 10) | Max burst size for requests to the Kubernetes API server |
 
 Set any limit flag to `0` to disable that limit.
 

--- a/services/kubernetes-graphql-gateway/README.md
+++ b/services/kubernetes-graphql-gateway/README.md
@@ -201,6 +201,8 @@ Optionally set `ca.secretRef` for custom CA certificates.
 | `--max-query-batch-size` | `10` | Max queries per batch request |
 | `--read-header-timeout` | `32s` | Max duration for reading request headers |
 | `--idle-timeout` | `90s` | Max idle duration for keep-alive connections |
+| `--kubernetes-qps` | `0` (client-go default: 5) | Max requests per second to the Kubernetes API server |
+| `--kubernetes-burst` | `0` (client-go default: 10) | Max burst size for requests to the Kubernetes API server |
 
 Set any limit flag to `0` to disable that limit.
 

--- a/services/kubernetes-graphql-gateway/gateway/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/config.go
@@ -59,6 +59,8 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 		},
 		TokenReviewCacheTTL: cfg.Options.TokenReviewCacheTTL,
 		Metrics:             metrics.NewCollector(prometheus.DefaultRegisterer),
+		KubernetesQPS:       cfg.Options.KubernetesQPS,
+		KubernetesBurst:     cfg.Options.KubernetesBurst,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gateway server: %w", err)

--- a/services/kubernetes-graphql-gateway/gateway/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/config.go
@@ -23,6 +23,7 @@ import (
 
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway"
 	gatewayconfig "go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/config"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/cluster"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/metrics"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/middleware"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/http"
@@ -59,8 +60,10 @@ func NewConfig(opts *options.CompletedOptions) (*Config, error) {
 		},
 		TokenReviewCacheTTL: cfg.Options.TokenReviewCacheTTL,
 		Metrics:             metrics.NewCollector(prometheus.DefaultRegisterer),
-		KubernetesQPS:       cfg.Options.KubernetesQPS,
-		KubernetesBurst:     cfg.Options.KubernetesBurst,
+		ClusterOptions: cluster.Options{
+			KubernetesQPS:   cfg.Options.KubernetesQPS,
+			KubernetesBurst: cfg.Options.KubernetesBurst,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gateway server: %w", err)

--- a/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster.go
@@ -46,6 +46,8 @@ func New(
 	ctx context.Context,
 	name string,
 	metadata *pmgatewayv1alpha1.ClusterMetadata,
+	kubernetesQPS float32,
+	kubernetesBurst int,
 ) (*Cluster, error) {
 	if metadata == nil {
 		return nil, fmt.Errorf("cluster %s requires cluster metadata", name)
@@ -60,6 +62,9 @@ func New(
 	if err != nil {
 		return nil, fmt.Errorf("failed to build config from metadata: %w", err)
 	}
+
+	cluster.restCfg.QPS = kubernetesQPS
+	cluster.restCfg.Burst = kubernetesBurst
 
 	cluster.adminCfg = rest.CopyConfig(cluster.restCfg)
 

--- a/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster.go
@@ -41,13 +41,19 @@ type Cluster struct {
 	adminCfg *rest.Config
 }
 
+type Options struct {
+	// KubernetesQPS is the max requests per second to the Kubernetes API server.
+	KubernetesQPS float32
+	// KubernetesBurst is the max burst size for requests to the Kubernetes API server.
+	KubernetesBurst int
+}
+
 // New creates a new Cluster connection from cluster metadata.
 func New(
 	ctx context.Context,
 	name string,
 	metadata *pmgatewayv1alpha1.ClusterMetadata,
-	kubernetesQPS float32,
-	kubernetesBurst int,
+	opts Options,
 ) (*Cluster, error) {
 	if metadata == nil {
 		return nil, fmt.Errorf("cluster %s requires cluster metadata", name)
@@ -63,8 +69,12 @@ func New(
 		return nil, fmt.Errorf("failed to build config from metadata: %w", err)
 	}
 
-	cluster.restCfg.QPS = kubernetesQPS
-	cluster.restCfg.Burst = kubernetesBurst
+	if opts.KubernetesQPS > 0 {
+		cluster.restCfg.QPS = opts.KubernetesQPS
+	}
+	if opts.KubernetesBurst > 0 {
+		cluster.restCfg.Burst = opts.KubernetesBurst
+	}
 
 	cluster.adminCfg = rest.CopyConfig(cluster.restCfg)
 

--- a/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/cluster/cluster_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	pmgatewayv1alpha1 "go.platform-mesh.io/apis/gateway/v1alpha1"
+	"k8s.io/client-go/rest"
+)
+
+// buildRestCfg calls BuildRestConfigFromMetadata with a minimal valid metadata,
+// then applies Options the same way cluster.New does — without the full
+// controller-runtime client setup which requires a reachable API server.
+func applyOptions(t *testing.T, opts Options) *rest.Config {
+	t.Helper()
+	metadata := pmgatewayv1alpha1.ClusterMetadata{
+		Host: "https://localhost:6443",
+	}
+	cfg, err := pmgatewayv1alpha1.BuildRestConfigFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("BuildRestConfigFromMetadata: %v", err)
+	}
+	if opts.KubernetesQPS > 0 {
+		cfg.QPS = opts.KubernetesQPS
+	}
+	if opts.KubernetesBurst > 0 {
+		cfg.Burst = opts.KubernetesBurst
+	}
+	return cfg
+}
+
+func TestOptions_nonZeroValuesApplied(t *testing.T) {
+	cfg := applyOptions(t, Options{KubernetesQPS: 50, KubernetesBurst: 100})
+	if cfg.QPS != 50 {
+		t.Errorf("QPS = %v, want 50", cfg.QPS)
+	}
+	if cfg.Burst != 100 {
+		t.Errorf("Burst = %v, want 100", cfg.Burst)
+	}
+}
+
+func TestOptions_zeroLeavesClientGoDefaults(t *testing.T) {
+	// Build baseline with zero options to capture what BuildRestConfigFromMetadata sets.
+	baseline := applyOptions(t, Options{})
+	cfg := applyOptions(t, Options{KubernetesQPS: 0, KubernetesBurst: 0})
+	if cfg.QPS != baseline.QPS {
+		t.Errorf("QPS = %v, want baseline %v", cfg.QPS, baseline.QPS)
+	}
+	if cfg.Burst != baseline.Burst {
+		t.Errorf("Burst = %v, want baseline %v", cfg.Burst, baseline.Burst)
+	}
+}

--- a/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
@@ -65,6 +65,12 @@ type Gateway struct {
 	// Metrics is optional. When non-nil, all components record Prometheus
 	// metrics. Pass nil to disable instrumentation entirely.
 	Metrics *metrics.Collector
+
+	// KubernetesQPS is the maximum queries per second to the Kubernetes API server.
+	KubernetesQPS float32
+
+	// KubernetesBurst is the maximum burst size for requests to the Kubernetes API server.
+	KubernetesBurst int
 }
 
 // GraphQL holds GraphQL handler configuration.

--- a/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/config/config.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/authn"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/cluster"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/metrics"
 )
 
@@ -66,11 +67,8 @@ type Gateway struct {
 	// metrics. Pass nil to disable instrumentation entirely.
 	Metrics *metrics.Collector
 
-	// KubernetesQPS is the maximum queries per second to the Kubernetes API server.
-	KubernetesQPS float32
-
-	// KubernetesBurst is the maximum burst size for requests to the Kubernetes API server.
-	KubernetesBurst int
+	// ClusterOptions holds tuning parameters applied to every cluster connection.
+	ClusterOptions cluster.Options
 }
 
 // GraphQL holds GraphQL handler configuration.

--- a/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
@@ -58,6 +58,8 @@ func New(
 	tokenReviewCacheTTL time.Duration,
 	injectedValidator authn.Validator,
 	m *metrics.Collector,
+	kubernetesQPS float32,
+	kubernetesBurst int,
 ) (*Endpoint, error) {
 	var endpointM *metrics.EndpointMetrics
 	var resolverM *metrics.ResolverMetrics
@@ -73,7 +75,7 @@ func New(
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 
-	cl, err := cluster.New(ctx, name, schemaData.ClusterMetadata)
+	cl, err := cluster.New(ctx, name, schemaData.ClusterMetadata, kubernetesQPS, kubernetesBurst)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster: %w", err)
 	}

--- a/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
@@ -58,8 +58,7 @@ func New(
 	tokenReviewCacheTTL time.Duration,
 	injectedValidator authn.Validator,
 	m *metrics.Collector,
-	kubernetesQPS float32,
-	kubernetesBurst int,
+	clusterOpts cluster.Options,
 ) (*Endpoint, error) {
 	var endpointM *metrics.EndpointMetrics
 	var resolverM *metrics.ResolverMetrics
@@ -75,7 +74,7 @@ func New(
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 
-	cl, err := cluster.New(ctx, name, schemaData.ClusterMetadata, kubernetesQPS, kubernetesBurst)
+	cl, err := cluster.New(ctx, name, schemaData.ClusterMetadata, clusterOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster: %w", err)
 	}

--- a/services/kubernetes-graphql-gateway/gateway/gateway/registry/registry.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/registry/registry.go
@@ -64,6 +64,8 @@ func (r *Registry) OnSchemaChanged(ctx context.Context, clusterName string, sche
 		r.config.TokenReviewCacheTTL,
 		r.config.Validator,
 		r.config.Metrics,
+		r.config.KubernetesQPS,
+		r.config.KubernetesBurst,
 	)
 	if err != nil {
 		logger.Error(err, "Failed to create endpoint", "cluster", clusterName)

--- a/services/kubernetes-graphql-gateway/gateway/gateway/registry/registry.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/registry/registry.go
@@ -64,8 +64,7 @@ func (r *Registry) OnSchemaChanged(ctx context.Context, clusterName string, sche
 		r.config.TokenReviewCacheTTL,
 		r.config.Validator,
 		r.config.Metrics,
-		r.config.KubernetesQPS,
-		r.config.KubernetesBurst,
+		r.config.ClusterOptions,
 	)
 	if err != nil {
 		logger.Error(err, "Failed to create endpoint", "cluster", clusterName)

--- a/services/kubernetes-graphql-gateway/gateway/options/options.go
+++ b/services/kubernetes-graphql-gateway/gateway/options/options.go
@@ -156,6 +156,8 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&options.ReadHeaderTimeout, "read-header-timeout", options.ReadHeaderTimeout, "maximum duration for reading request headers (0 to disable)")
 	fs.DurationVar(&options.IdleTimeout, "idle-timeout", options.IdleTimeout, "maximum duration an idle keep-alive connection remains open (0 to disable)")
 	fs.StringVar(&options.EndpointSuffix, "endpoint-suffix", options.EndpointSuffix, "suffix appended to the cluster endpoint path (default \"/graphql\")")
+	fs.Float32Var(&options.KubernetesQPS, "kubernetes-qps", options.KubernetesQPS, "max requests per second to the Kubernetes API server (0 uses client-go default of 5)")
+	fs.IntVar(&options.KubernetesBurst, "kubernetes-burst", options.KubernetesBurst, "max burst size for requests to the Kubernetes API server (0 uses client-go default of 10)")
 }
 
 func (options *Options) Complete() (*CompletedOptions, error) {
@@ -224,6 +226,14 @@ func (options *CompletedOptions) Validate() error {
 
 	if options.IdleTimeout < 0 {
 		return errors.New("--idle-timeout must not be negative")
+	}
+
+	if options.KubernetesQPS < 0 {
+		return errors.New("--kubernetes-qps must not be negative")
+	}
+
+	if options.KubernetesBurst < 0 {
+		return errors.New("--kubernetes-burst must not be negative")
 	}
 
 	return nil

--- a/services/kubernetes-graphql-gateway/gateway/options/options.go
+++ b/services/kubernetes-graphql-gateway/gateway/options/options.go
@@ -79,6 +79,10 @@ type ExtraOptions struct {
 	IdleTimeout time.Duration
 	// EndpointSuffix is the suffix appended to the cluster endpoint path (e.g. "/graphql").
 	EndpointSuffix string
+	// KubernetesQPS is the maximum queries per second to the Kubernetes API server.
+	KubernetesQPS float32
+	// KubernetesBurst is the maximum burst size for requests to the Kubernetes API server.
+	KubernetesBurst int
 }
 
 type completedOptions struct {


### PR DESCRIPTION
The kubernetes-graphql-gateway uses the client-go REST client to talk to Kubernetes API servers. QPS and Burst are left at client-go defaults (5 QPS / 10 burst), with no way to tune them.

The PR adds two CLI flags to expose these settings:

--kubernetes-qps - max requests per second (default 0, which preserves the client-go default of 5)
--kubernetes-burst - max burst size (default 0, which preserves the client-go default of 10)
The values are threaded from ExtraOptions → gateway.Config → endpoint.New → cluster.New, where they are applied to the rest.Config before any clients are built.

Setting either flag to 0 keeps the existing client-go default behaviour.