### PR TITLE
route FGA store lookup through paginated ListStores

### DIFF
--- a/operators/security-operator/go.mod
+++ b/operators/security-operator/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.32.3 // indirect

--- a/operators/security-operator/go.sum
+++ b/operators/security-operator/go.sum
@@ -124,6 +124,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=

--- a/operators/security-operator/internal/subroutine/store.go
+++ b/operators/security-operator/internal/subroutine/store.go
@@ -19,13 +19,13 @@ package subroutine
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	commonsstore "go.platform-mesh.io/golang-commons/fga/store"
 	"go.platform-mesh.io/golang-commons/logger"
 	iclient "go.platform-mesh.io/security-operator/internal/client"
 	"go.platform-mesh.io/subroutines"
@@ -91,15 +91,13 @@ func (s *storeSubroutine) Process(ctx context.Context, obj ctrlruntimeclient.Obj
 	if store.Status.StoreID == "" {
 		log.Info().Msg("Store ID not set, trying to find store by name")
 
-		list, err := s.fga.ListStores(ctx, &openfgav1.ListStoresRequest{})
+		storeID, found, err := commonsstore.FindStoreIDByName(ctx, s.fga, store.Name)
 		if err != nil {
 			return subroutines.OK(), err
 		}
-
-		storeIdx := slices.IndexFunc(list.GetStores(), func(i *openfgav1.Store) bool { return i.GetName() == store.Name })
-		if storeIdx != -1 {
+		if found {
 			log.Info().Msg("Store found, updating store ID")
-			store.Status.StoreID = list.GetStores()[storeIdx].GetId()
+			store.Status.StoreID = storeID
 			return subroutines.OK(), nil
 		}
 

--- a/services/search-service/go.mod
+++ b/services/search-service/go.mod
@@ -11,6 +11,7 @@ require (
 	go.platform-mesh.io/apis v0.0.3
 	go.platform-mesh.io/golang-commons v0.18.1
 	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 )
@@ -56,7 +57,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260610212136-7ab31c22f7ad // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260618221249-bc653b64f974 // indirect

--- a/services/search-service/internal/clients/fga/authorizer.go
+++ b/services/search-service/internal/clients/fga/authorizer.go
@@ -23,12 +23,16 @@ import (
 	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"go.platform-mesh.io/golang-commons/logger"
 	"go.platform-mesh.io/search-service/internal/service/search"
 )
 
-const batchCheckChunkSize = 100
+const (
+	batchCheckChunkSize = 100
+	listStoresPageSize  = 100
+)
 
 type Authorizer struct {
 	client openfgav1.OpenFGAServiceClient
@@ -118,14 +122,26 @@ func (a *Authorizer) FilterAuthorized(ctx context.Context, req search.Authorizat
 }
 
 func (a *Authorizer) resolveStoreID(ctx context.Context, org string) (string, error) {
-	res, err := a.client.ListStores(ctx, &openfgav1.ListStoresRequest{})
-	if err != nil {
-		return "", fmt.Errorf("list stores: %w", err)
-	}
+	// no Name filter: the match is trimSpace tolerant, which an exact server-side filter would defeat. So we paginate the full list instead.
+	var continuationToken string
+	for {
+		res, err := a.client.ListStores(ctx, &openfgav1.ListStoresRequest{
+			PageSize:          wrapperspb.Int32(listStoresPageSize),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return "", fmt.Errorf("list stores: %w", err)
+		}
 
-	for _, store := range res.GetStores() {
-		if strings.TrimSpace(store.GetName()) == org {
-			return store.GetId(), nil
+		for _, store := range res.GetStores() {
+			if strings.TrimSpace(store.GetName()) == org {
+				return store.GetId(), nil
+			}
+		}
+
+		continuationToken = res.GetContinuationToken()
+		if continuationToken == "" {
+			break
 		}
 	}
 


### PR DESCRIPTION
## Summary

Draft / blocked follow-up to the golang-commons ListStores pagination change. See https://github.com/platform-mesh/platform-mesh/pull/227

Updates the FGA store-by-name lookup in the consumer modules:
- security-operator: use the shared `store.FindStoreIDByName` helper
- search-service: paginate `ListStores` inline (keeps its TrimSpace-tolerant match)

## Related issue(-s)
Fixes https://github.com/platform-mesh/platform-mesh/issues/226

## TODO

Bump golang-commons version after https://github.com/platform-mesh/platform-mesh/pull/227 will be merged