### PR TITLE
feat: make default synthetic fields filterable

### DIFF
--- a/operators/search-operator/internal/opensearch/document.go
+++ b/operators/search-operator/internal/opensearch/document.go
@@ -25,6 +25,10 @@ import (
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 )
 
+// DefaultFilterableFields are always extractable for every resource and are
+// injected as filterable facets regardless of a SearchConfig's configuration.
+var DefaultFilterableFields = []string{"kind", "name", "namespace", "cluster_name", "workspace_path"}
+
 // FieldMappings holds the dot-notation field paths that drive the dynamic part of the index mapping.
 type FieldMappings struct {
 	Default    []string
@@ -345,4 +349,16 @@ func (d *ResourceDocument) AddPermission(user, relation, object string) {
 		Relation: relation,
 		Object:   object,
 	})
+}
+
+// SetDefaultFilterableFields injects the synthetic fields to filters.
+func (d *ResourceDocument) SetDefaultFilterableFields() {
+	if d.FilterableFields == nil {
+		d.FilterableFields = make(map[string]any, len(DefaultFilterableFields))
+	}
+	d.FilterableFields["kind"] = d.Kind
+	d.FilterableFields["name"] = d.Name
+	d.FilterableFields["namespace"] = d.Namespace
+	d.FilterableFields["cluster_name"] = d.ClusterName
+	d.FilterableFields["workspace_path"] = d.WorkspacePath
 }

--- a/operators/search-operator/internal/subroutine/apibinding_watcher.go
+++ b/operators/search-operator/internal/subroutine/apibinding_watcher.go
@@ -29,6 +29,7 @@ import (
 	"go.platform-mesh.io/golang-commons/logger"
 	"go.platform-mesh.io/search-operator/internal/config"
 	"go.platform-mesh.io/search-operator/internal/metrics"
+	"go.platform-mesh.io/search-operator/internal/opensearch"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -231,6 +232,9 @@ func (s *apiBindingWatcherSubroutine) resolveFieldsForPermissionClaim(ctx contex
 			}
 		}
 	}
+
+	// default filters that can always be extracted for each Resource
+	exactFields.Insert(opensearch.DefaultFilterableFields...)
 
 	return &searchIndexFields{
 		defaultFields:    sets.List(defaultFields),

--- a/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
+++ b/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
@@ -167,6 +167,7 @@ func (s *IndexableResourceWatcherSubroutine) Process(ctx context.Context, instan
 	doc.DefaultFields = extractConfiguredFields(resource, searchIndex.Spec.DefaultFields)
 	doc.SemanticFields = extractStringConfiguredFields(resource, searchIndex.Spec.SemanticFields)
 	doc.FilterableFields = extractFilterableFields(resource, searchIndex.Spec.FilterableFields)
+	doc.SetDefaultFilterableFields()
 
 	accountInfo, err := s.getAccountInfo(ctx, workspacePath, gvk, resource)
 	if err != nil {


### PR DESCRIPTION
Some fields indexed in OpenSearch are always available (extractable) from every resource such as the KCP path, kind, or logical cluster ID. Those fields cannot be configured to be filterable because they're not part of the custom resource that is being indexed (see search configuration as per [ADR-007](https://github.com/platform-mesh/architecture/blob/main/adr/007-search-config-resource.md) and ticket https://github.com/platform-mesh/backlog/issues/279).

Default fields now filterable:
- kind
- name
- namespace
- cluster_name
- workspace_path

On-behalf-of: @SAP florian.wuermseer@sap.com