### PR TITLE
fix(resource-broker): wait for staging workspace readiness

### DIFF
--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready.go
@@ -82,21 +82,21 @@ func (s *workspaceReadySubroutine) Process(ctx context.Context, obj ctrlruntimec
 			return subroutines.Result{}, fmt.Errorf("creating staging workspace %q: %w", sw.Name, err)
 		}
 		sw.Status.Phase = pmcoordbrokerv1alpha1.StagingWorkspacePhasePending
-		return subroutines.Pending(s.opts.RequeueInterval, "created staging workspace"), nil
+		return subroutines.StopWithRequeue(s.opts.RequeueInterval, "created staging workspace"), nil
 	case err != nil:
 		return subroutines.Result{}, fmt.Errorf("getting staging workspace %q: %w", sw.Name, err)
 	}
 
 	if !workspace.DeletionTimestamp.IsZero() {
 		sw.Status.Phase = pmcoordbrokerv1alpha1.StagingWorkspacePhasePending
-		return subroutines.Pending(s.opts.RequeueInterval, "staging workspace is terminating"), nil
+		return subroutines.StopWithRequeue(s.opts.RequeueInterval, "staging workspace is terminating"), nil
 	}
 
 	sw.Status.ClusterName = workspace.Spec.Cluster
 
 	if workspace.Status.Phase != kcpcorev1alpha1.LogicalClusterPhaseReady {
 		sw.Status.Phase = pmcoordbrokerv1alpha1.StagingWorkspacePhasePending
-		return subroutines.Pending(s.opts.RequeueInterval, "waiting for staging workspace to become ready"), nil
+		return subroutines.StopWithRequeue(s.opts.RequeueInterval, "waiting for staging workspace to become ready"), nil
 	}
 
 	return subroutines.OK(), nil

--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready_test.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready_test.go
@@ -55,18 +55,18 @@ func TestWorkspaceReadyFinalizers(t *testing.T) {
 
 func TestWorkspaceReadyProcess(t *testing.T) {
 	tests := []struct {
-		name        string
-		treeObjs    []ctrlruntimeclient.Object
-		wantPending bool
-		wantOK      bool
-		wantPhase   pmcoordbrokerv1alpha1.StagingWorkspacePhase
-		wantCluster string
-		verify      func(t *testing.T, treeClient ctrlruntimeclient.Client)
+		name                string
+		treeObjs            []ctrlruntimeclient.Object
+		wantStopWithRequeue bool
+		wantOK              bool
+		wantPhase           pmcoordbrokerv1alpha1.StagingWorkspacePhase
+		wantCluster         string
+		verify              func(t *testing.T, treeClient ctrlruntimeclient.Client)
 	}{
 		{
-			name:        "creates workspace",
-			wantPending: true,
-			wantPhase:   pmcoordbrokerv1alpha1.StagingWorkspacePhasePending,
+			name:                "creates workspace",
+			wantStopWithRequeue: true,
+			wantPhase:           pmcoordbrokerv1alpha1.StagingWorkspacePhasePending,
 			verify: func(t *testing.T, treeClient ctrlruntimeclient.Client) {
 				ws := &kcptenancyv1alpha1.Workspace{}
 				require.NoError(t, treeClient.Get(t.Context(), ctrlruntimeclient.ObjectKey{Name: testName}, ws))
@@ -77,8 +77,8 @@ func TestWorkspaceReadyProcess(t *testing.T) {
 			treeObjs: []ctrlruntimeclient.Object{&kcptenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: testName},
 			}},
-			wantPending: true,
-			wantPhase:   pmcoordbrokerv1alpha1.StagingWorkspacePhasePending,
+			wantStopWithRequeue: true,
+			wantPhase:           pmcoordbrokerv1alpha1.StagingWorkspacePhasePending,
 		},
 		{
 			name:        "ready workspace records cluster name",
@@ -96,7 +96,7 @@ func TestWorkspaceReadyProcess(t *testing.T) {
 
 			result, err := s.Process(t.Context(), sw)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantPending, result.IsPending())
+			assert.Equal(t, tt.wantStopWithRequeue, result.IsStopWithRequeue())
 			if tt.wantOK {
 				assert.True(t, result.IsContinue())
 				assert.Zero(t, result.Requeue())
@@ -126,7 +126,7 @@ func TestWorkspaceReadyProcessTerminatingWorkspace(t *testing.T) {
 	sw := testStagingWorkspace()
 	result, err := s.Process(t.Context(), sw)
 	require.NoError(t, err)
-	assert.True(t, result.IsPending())
+	assert.True(t, result.IsStopWithRequeue())
 	assert.Equal(t, pmcoordbrokerv1alpha1.StagingWorkspacePhasePending, sw.Status.Phase)
 }
 


### PR DESCRIPTION
## Summary

Prevent the StagingWorkspace reconciler from accessing a newly created kcp
workspace before it is ready.

`WorkspaceReady` previously returned `Pending` while the backing workspace was
being created, initialized, or terminated. `Pending` schedules another
reconciliation but continues the subroutine chain, allowing `BindingReady` to
access the unavailable workspace and produce repeated reconciliation errors.

Return `StopWithRequeue` for these states so `BindingReady` only runs after the
workspace reports `LogicalClusterPhaseReady`.

This also changes the `WorkspaceReady` condition during these waiting states
from `Unknown/Pending` to `False/Stopped`.

## Testing

- Updated the workspace readiness tests to verify that unavailable workspace
  states stop the subroutine chain.
- `task test`
- `task lint`
- `task test-e2e 'ADDITIONAL_COMMAND_ARGS=-run ^TestStagingWorkspaceDeletion$ -v'`

The focused e2e test previously produced repeated `BindingReady` errors and
warnings about returning both a requeue and a non-nil error. After this change,
`WorkspaceReady` stops the chain cleanly until the workspace becomes ready, and
the test passes without those errors.

Fixes #210
