### PR TITLE
fix(kubernetes-graphql-gateway): cap negative token cache, log denials

### DIFF
--- a/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview.go
@@ -54,6 +54,12 @@ func (NoopValidator) Validate(_ context.Context, _ string) (bool, error) {
 
 const maxCacheSize = 10000
 
+// negativeCacheTTL bounds how long a denied (authenticated:false) verdict may
+// be served from cache. Deny verdicts are often transient (token not yet
+// propagated, clock skew, revoked-then-reissued sessions) and must not stick
+// for the full positive cacheTTL. Kept as a var so tests can shrink it.
+var negativeCacheTTL = 2 * time.Second
+
 // TokenReviewValidator validates tokens via the Kubernetes TokenReview API.
 type TokenReviewValidator struct {
 	clientset kubernetes.Interface
@@ -128,6 +134,9 @@ func (v *TokenReviewValidator) Validate(ctx context.Context, token string) (bool
 				}
 				v.metrics.RecordCacheHit(labelResult)
 			}
+			if !item.Value() {
+				log.FromContext(ctx).V(1).Info("token denied (cached TokenReview verdict)")
+			}
 			return item.Value(), nil
 		}
 	}
@@ -145,9 +154,20 @@ func (v *TokenReviewValidator) Validate(ctx context.Context, token string) (bool
 			return false, err
 		}
 
+		if !tr.Status.Authenticated {
+			log.FromContext(ctx).Info("TokenReview denied token",
+				"error", tr.Status.Error, "cache", "fresh")
+		}
+
 		if v.cache != nil {
 			itemTTL := ttlcache.DefaultTTL
-			if exp := tokenExpiry(token); !exp.IsZero() {
+			if !tr.Status.Authenticated {
+				// Deny verdicts get a short TTL: enough to absorb request
+				// bursts (singleflight already dedupes concurrent ones), but
+				// short enough that a token that becomes valid (propagation
+				// delay, clock skew) is not rejected for the full cacheTTL.
+				itemTTL = min(v.cacheTTL, negativeCacheTTL)
+			} else if exp := tokenExpiry(token); !exp.IsZero() {
 				if remaining := time.Until(exp); remaining > 0 {
 					itemTTL = min(v.cacheTTL, remaining)
 				}

--- a/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview_test.go
@@ -19,10 +19,12 @@ package authn
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestNoopValidatorAcceptsAnyToken(t *testing.T) {
@@ -203,6 +206,75 @@ func TestCacheTTLCappedAtTokenExpiry(t *testing.T) {
 
 	_, _ = v.Validate(t.Context(), shortLivedToken)
 	assert.Equal(t, int32(2), calls.Load(), "should call API after token expired")
+}
+
+func TestNegativeVerdictNotCachedLong(t *testing.T) {
+	old := negativeCacheTTL
+	negativeCacheTTL = 50 * time.Millisecond
+	t.Cleanup(func() { negativeCacheTTL = old })
+
+	var callIdx atomic.Int32
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		idx := callIdx.Add(1)
+		tr := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr.Status.Authenticated = idx > 1 // first review denies, later ones allow
+		if idx == 1 {
+			tr.Status.Error = "token not yet valid"
+		}
+		return true, tr, nil
+	})
+	v := NewTokenReviewValidatorFromClientset(cs, 5*time.Minute)
+
+	ok, _ := v.Validate(t.Context(), "recovering-token")
+	assert.False(t, ok)
+
+	// Within the negative TTL the deny verdict is served from cache.
+	ok, _ = v.Validate(t.Context(), "recovering-token")
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), callIdx.Load())
+
+	time.Sleep(100 * time.Millisecond)
+
+	// After the short negative TTL a fresh review runs and succeeds.
+	ok, err := v.Validate(t.Context(), "recovering-token")
+	assert.NoError(t, err)
+	assert.True(t, ok, "deny verdict must not outlive the negative TTL")
+	assert.Equal(t, int32(2), callIdx.Load())
+}
+
+func TestDeniedVerdictIsLogged(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+	logger := funcr.New(func(prefix, args string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, args)
+	}, funcr.Options{Verbosity: 5})
+	ctx := log.IntoContext(t.Context(), logger)
+
+	var calls atomic.Int32
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		calls.Add(1)
+		tr := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr.Status.Authenticated = false
+		tr.Status.Error = "square/go-jose: error in cryptographic primitive"
+		return true, tr, nil
+	})
+	v := NewTokenReviewValidatorFromClientset(cs, 5*time.Minute)
+
+	_, _ = v.Validate(ctx, "bad-token") // fresh denial
+	_, _ = v.Validate(ctx, "bad-token") // cached denial
+
+	mu.Lock()
+	joined := ""
+	for _, l := range lines {
+		joined += l + "\n"
+	}
+	mu.Unlock()
+	assert.Contains(t, joined, "square/go-jose", "fresh denial must log tr.Status.Error")
+	assert.Contains(t, joined, "cached", "cached denial must be distinguishable from a fresh review")
 }
 
 func TestConcurrentValidation(t *testing.T) {

--- a/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/endpoint/endpoint.go
@@ -144,6 +144,7 @@ func New(
 
 		token, ok := utilscontext.GetTokenFromCtx(r.Context())
 		if !ok || token == "" {
+			log.FromContext(r.Context()).V(1).Info("request rejected: no bearer token", "cluster", name)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -154,6 +155,9 @@ func New(
 			return
 		}
 		if !authenticated {
+			// Verdict details (TokenReview status.error, cache-hit vs fresh)
+			// are logged by the validator.
+			log.FromContext(r.Context()).V(1).Info("request rejected: token failed TokenReview", "cluster", name)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/services/kubernetes-graphql-gateway/go.mod
+++ b/services/kubernetes-graphql-gateway/go.mod
@@ -8,6 +8,7 @@ replace github.com/graphql-go/handler => github.com/vertex451/handler v0.0.0-202
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/testify/v2 v2.4.2
 	github.com/gobuffalo/flect v1.0.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -64,7 +65,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect


### PR DESCRIPTION
Fixes #233, fixes #234.

Two changes to the token-review path, found while root-causing sporadic portal 401s on a kcp-backed deployment (kcp-dev/kcp#4115 — kcp rejected valid tokens for short windows after workspace-authenticator eviction, and the gateway both amplified and hid it):

- denied TokenReview verdicts are now cached for at most 2s instead of the full `--token-review-cache-ttl` (30s default). Positive caching is unchanged. The singleflight added in the standalone repo already dedupes concurrent reviews, so short negative TTL does not create a review stampede.
- fresh denials log the verdict including `tr.Status.Error` (the kcp failure above carried `oidc: authenticator not initialized` in that field on every rejection — it was read nowhere). Cached denials and the two unauthorized write sites log at V(1).

Validation: `go test ./gateway/gateway/authn/...` 14/14 incl. two new tests (`TestNegativeVerdictNotCachedLong` red-green against the old behavior, `TestDeniedVerdictIsLogged`); repo-pinned golangci-lint 2.12.2 with root config, 0 issues on both touched packages. `go.mod` gains `logr/funcr` (test-only, promotes an existing indirect).

No overlap with #218 — it touches the `New()` signature, this touches the auth middleware block ~70 lines below.
