### PR TITLE
fix(security-operator): re-key orphaned account role tuples

### DIFF
--- a/operators/security-operator/cmd/initializer.go
+++ b/operators/security-operator/cmd/initializer.go
@@ -111,20 +111,6 @@ var initializerCmd = &cobra.Command{
 			initializerCfg.IDP.AdditionalRedirectURLs = []string{}
 		}
 
-		kcpClientGetter := iclient.NewConfigSchemeKCPClientGetter(restCfg, scheme)
-		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetter, initializerCfg, runtimeClient, mgr, controller.ControllerOptions{
-			Name:            "OrgLogicalClusterInitializer",
-			InitializerName: initializerCfg.InitializerName(),
-		})
-		if err != nil {
-			setupLog.Error(err, "unable to create LogicalCluster initializer")
-			os.Exit(1)
-		}
-		if err := orgReconciler.SetupWithManager(mgr, defaultCfg, predicates.LogicalClusterIsAccountTypeOrg()); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "LogicalCluster")
-			os.Exit(1)
-		}
-
 		conn, err := grpc.NewClient(initializerCfg.FGA.Target, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.Error().Err(err).Msg("unable to create grpc client")
@@ -138,6 +124,20 @@ var initializerCmd = &cobra.Command{
 			initializerCfg.FGA.StoreIDCacheTTL,
 			log,
 		)
+
+		kcpClientGetter := iclient.NewConfigSchemeKCPClientGetter(restCfg, scheme)
+		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetter, initializerCfg, runtimeClient, mgr, fgaClient, storeIDGetter, controller.ControllerOptions{
+			Name:            "OrgLogicalClusterInitializer",
+			InitializerName: initializerCfg.InitializerName(),
+		})
+		if err != nil {
+			setupLog.Error(err, "unable to create LogicalCluster initializer")
+			os.Exit(1)
+		}
+		if err := orgReconciler.SetupWithManager(mgr, defaultCfg, predicates.LogicalClusterIsAccountTypeOrg()); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "LogicalCluster")
+			os.Exit(1)
+		}
 
 		alcReconciler, err := controller.NewAccountLogicalClusterController(log, initializerCfg, fgaClient, storeIDGetter, mgr, kcpClientGetter, controller.ControllerOptions{
 			Name:            "AccountLogicalClusterInitializer",

--- a/operators/security-operator/cmd/operator.go
+++ b/operators/security-operator/cmd/operator.go
@@ -192,7 +192,7 @@ var operatorCmd = &cobra.Command{
 			log.Error().Err(err).Str("controller", "invite").Msg("unable to create controller")
 			return err
 		}
-		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetterWithConfig, operatorCfg, runtimeClient, mgr, controller.ControllerOptions{
+		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetterWithConfig, operatorCfg, runtimeClient, mgr, fga, storeIDGetter, controller.ControllerOptions{
 			Name: "OrgLogicalClusterReconciler",
 		})
 		if err != nil {

--- a/operators/security-operator/cmd/terminator.go
+++ b/operators/security-operator/cmd/terminator.go
@@ -104,7 +104,7 @@ var terminatorCmd = &cobra.Command{
 		)
 		kcpClientGetter := iclient.NewConfigSchemeKCPClientGetter(mgr.GetLocalManager().GetConfig(), mgr.GetLocalManager().GetScheme())
 
-		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetter, terminatorCfg, nil, mgr, controller.ControllerOptions{
+		orgReconciler, err := controller.NewOrgLogicalClusterController(log, kcpClientGetter, terminatorCfg, nil, mgr, fgaClient, storeIDGetter, controller.ControllerOptions{
 			Name:           "OrgLogicalClusterTerminator",
 			TerminatorName: terminatorCfg.TerminatorName(),
 		})

--- a/operators/security-operator/internal/config/config.go
+++ b/operators/security-operator/internal/config/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	HttpClientTimeoutSeconds         int
 	SetDefaultPassword               bool
 	AllowMemberTuplesEnabled         bool
+	RekeyOrphanedTuplesEnabled       bool
 	IDP                              IDPConfig
 	Keycloak                         KeycloakConfig
 	Initializer                      InitializerConfig
@@ -179,6 +180,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.HttpClientTimeoutSeconds, "http-client-timeout-seconds", c.HttpClientTimeoutSeconds, "Set HTTP client timeout in seconds")
 	fs.BoolVar(&c.SetDefaultPassword, "set-default-password", c.SetDefaultPassword, "Enable setting default password for identity provider users")
 	fs.BoolVar(&c.AllowMemberTuplesEnabled, "allow-member-tuples-enabled", c.AllowMemberTuplesEnabled, "Enable allow-member tuples management")
+	fs.BoolVar(&c.RekeyOrphanedTuplesEnabled, "rekey-orphaned-tuples-enabled", c.RekeyOrphanedTuplesEnabled, "Enable re-keying of org tuples orphaned by a workspace re-creation (cluster-id change)")
 	fs.StringSliceVar(&c.IDP.RealmDenyList, "idp-realm-deny-list", c.IDP.RealmDenyList, "Comma-separated list of Keycloak realms to ignore")
 	fs.StringVar(&c.IDP.SMTPServer, "idp-smtp-server", c.IDP.SMTPServer, "Set Keycloak SMTP server host")
 	fs.IntVar(&c.IDP.SMTPPort, "idp-smtp-port", c.IDP.SMTPPort, "Set Keycloak SMTP server port")

--- a/operators/security-operator/internal/config/config_test.go
+++ b/operators/security-operator/internal/config/config_test.go
@@ -48,6 +48,7 @@ func TestConfigAddFlags(t *testing.T) {
 		"--webhooks-enabled=true",
 		"--webhooks-port=10443",
 		"--additional-audiences=aud-a,aud-b",
+		"--rekey-orphaned-tuples-enabled=true",
 	})
 
 	assert.NoError(t, err)
@@ -57,6 +58,12 @@ func TestConfigAddFlags(t *testing.T) {
 	assert.True(t, cfg.Webhooks.Enabled)
 	assert.Equal(t, 10443, cfg.Webhooks.Port)
 	assert.Equal(t, []string{"aud-a", "aud-b"}, cfg.AdditionalAudiences)
+	assert.True(t, cfg.RekeyOrphanedTuplesEnabled)
+}
+
+func TestConfigRekeyOrphanedTuplesDefaultsToDisabled(t *testing.T) {
+	cfg := NewConfig()
+	assert.False(t, cfg.RekeyOrphanedTuplesEnabled)
 }
 
 func TestInitContainerConfigAddFlags(t *testing.T) {

--- a/operators/security-operator/internal/controller/orglogicalcluster_controller.go
+++ b/operators/security-operator/internal/controller/orglogicalcluster_controller.go
@@ -21,12 +21,15 @@ import (
 	"fmt"
 	"time"
 
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
 	platformeshconfig "go.platform-mesh.io/golang-commons/config"
 	"go.platform-mesh.io/golang-commons/controller/filter"
 	"go.platform-mesh.io/golang-commons/controller/lifecycle/ratelimiter"
 	"go.platform-mesh.io/golang-commons/logger"
 	iclient "go.platform-mesh.io/security-operator/internal/client"
 	"go.platform-mesh.io/security-operator/internal/config"
+	"go.platform-mesh.io/security-operator/internal/fga"
 	"go.platform-mesh.io/security-operator/internal/metrics"
 	"go.platform-mesh.io/security-operator/internal/subroutine"
 	"go.platform-mesh.io/subroutines"
@@ -58,7 +61,7 @@ type OrgLogicalClusterController struct {
 	rateLimiter workqueue.TypedRateLimiter[mcreconcile.Request]
 }
 
-func NewOrgLogicalClusterController(log *logger.Logger, kcpClientGetter iclient.KCPClientGetter, cfg config.Config, inClusterClient ctrlruntimeclient.Client, mgr mcmanager.Manager, opts ControllerOptions) (*OrgLogicalClusterController, error) {
+func NewOrgLogicalClusterController(log *logger.Logger, kcpClientGetter iclient.KCPClientGetter, cfg config.Config, inClusterClient ctrlruntimeclient.Client, mgr mcmanager.Manager, fgaClient openfgav1.OpenFGAServiceClient, storeIDGetter fga.StoreIDGetter, opts ControllerOptions) (*OrgLogicalClusterController, error) {
 	rl, err := ratelimiter.NewStaticThenExponentialRateLimiter[mcreconcile.Request](ratelimiter.NewConfig())
 	if err != nil {
 		return nil, fmt.Errorf("creating RateLimiter: %w", err)
@@ -85,6 +88,9 @@ func NewOrgLogicalClusterController(log *logger.Logger, kcpClientGetter iclient.
 	}
 	if cfg.Initializer.WorkspaceAuthEnabled {
 		subs = append(subs, subroutine.NewWorkspaceAuthConfigurationSubroutine(inClusterClient, mgr, kcpClientGetter, cfg))
+	}
+	if cfg.RekeyOrphanedTuplesEnabled {
+		subs = append(subs, subroutine.NewRekeyTuplesSubroutine(cfg, mgr, fgaClient, storeIDGetter, kcpClientGetter))
 	}
 	lc := lifecycle.New(mgr, opts.Name, func() ctrlruntimeclient.Object {
 		return &kcpcorev1alpha1.LogicalCluster{}

--- a/operators/security-operator/internal/fga/rekey.go
+++ b/operators/security-operator/internal/fga/rekey.go
@@ -18,84 +18,9 @@ package fga
 
 import (
 	"slices"
-	"strings"
 
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
 )
-
-// AccountKey is the parsed form of the two FGA key shapes that embed an
-// account's origin cluster id:
-//
-//	role:<objectType>/<clusterID>/<name>/<role>[#<relation>]
-//	<objectType>:<clusterID>/<name>[#<relation>]
-//
-// When the org workspace backing an account is deleted and re-created, the
-// cluster id changes and every tuple built from these keys goes stale.
-type AccountKey struct {
-	ObjectType string
-	ClusterID  string
-	Name       string
-	Role       string // non-empty for the role shape
-	Relation   string // optional "#<relation>" suffix (e.g. "assignee")
-}
-
-// ParseAccountKey parses s into an AccountKey. It returns false for strings
-// that do not match either of the two shapes (e.g. "user:someone",
-// "role:authenticated#assignee").
-//
-// The match is purely structural: other key families share the raw
-// `<type>:<clusterID>/<name>` shape (e.g. the
-// `apis_kcp_io_apiexport:<providerClusterID>/<exportName>` user keys written
-// into the same org store for APIExportPolicies), so callers MUST additionally
-// check ObjectType against the configured account object type before treating
-// the result as an account key.
-func ParseAccountKey(s string) (AccountKey, bool) {
-	var k AccountKey
-
-	if i := strings.IndexByte(s, '#'); i >= 0 {
-		k.Relation = s[i+1:]
-		s = s[:i]
-		if k.Relation == "" {
-			return AccountKey{}, false
-		}
-	}
-
-	typ, rest, found := strings.Cut(s, ":")
-	if !found || typ == "" || typ == "user" {
-		return AccountKey{}, false
-	}
-
-	parts := strings.Split(rest, "/")
-	switch {
-	case typ == "role" && len(parts) == 4:
-		k.ObjectType, k.ClusterID, k.Name, k.Role = parts[0], parts[1], parts[2], parts[3]
-	case typ != "role" && len(parts) == 2:
-		k.ObjectType, k.ClusterID, k.Name = typ, parts[0], parts[1]
-	default:
-		return AccountKey{}, false
-	}
-
-	if k.ObjectType == "" || k.ClusterID == "" || k.Name == "" || (typ == "role" && k.Role == "") {
-		return AccountKey{}, false
-	}
-
-	return k, true
-}
-
-// String renders the key back into its tuple representation. It round-trips
-// with ParseAccountKey.
-func (k AccountKey) String() string {
-	var s string
-	if k.Role != "" {
-		s = RenderRolePrefix(k.ObjectType, k.ClusterID, k.Name) + k.Role
-	} else {
-		s = renderAccountEntity(k.ObjectType, k.ClusterID, k.Name)
-	}
-	if k.Relation != "" {
-		s += "#" + k.Relation
-	}
-	return s
-}
 
 // StaleAccountTupleFilter returns a filter matching tuples that reference
 // accountName under the account object type objectType with a cluster id other

--- a/operators/security-operator/internal/fga/rekey.go
+++ b/operators/security-operator/internal/fga/rekey.go
@@ -1,0 +1,149 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fga
+
+import (
+	"slices"
+	"strings"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+)
+
+// AccountKey is the parsed form of the two FGA key shapes that embed an
+// account's origin cluster id:
+//
+//	role:<objectType>/<clusterID>/<name>/<role>[#<relation>]
+//	<objectType>:<clusterID>/<name>[#<relation>]
+//
+// When the org workspace backing an account is deleted and re-created, the
+// cluster id changes and every tuple built from these keys goes stale.
+type AccountKey struct {
+	ObjectType string
+	ClusterID  string
+	Name       string
+	Role       string // non-empty for the role shape
+	Relation   string // optional "#<relation>" suffix (e.g. "assignee")
+}
+
+// ParseAccountKey parses s into an AccountKey. It returns false for strings
+// that do not match either of the two shapes (e.g. "user:someone",
+// "role:authenticated#assignee").
+//
+// The match is purely structural: other key families share the raw
+// `<type>:<clusterID>/<name>` shape (e.g. the
+// `apis_kcp_io_apiexport:<providerClusterID>/<exportName>` user keys written
+// into the same org store for APIExportPolicies), so callers MUST additionally
+// check ObjectType against the configured account object type before treating
+// the result as an account key.
+func ParseAccountKey(s string) (AccountKey, bool) {
+	var k AccountKey
+
+	if i := strings.IndexByte(s, '#'); i >= 0 {
+		k.Relation = s[i+1:]
+		s = s[:i]
+		if k.Relation == "" {
+			return AccountKey{}, false
+		}
+	}
+
+	typ, rest, found := strings.Cut(s, ":")
+	if !found || typ == "" || typ == "user" {
+		return AccountKey{}, false
+	}
+
+	parts := strings.Split(rest, "/")
+	switch {
+	case typ == "role" && len(parts) == 4:
+		k.ObjectType, k.ClusterID, k.Name, k.Role = parts[0], parts[1], parts[2], parts[3]
+	case typ != "role" && len(parts) == 2:
+		k.ObjectType, k.ClusterID, k.Name = typ, parts[0], parts[1]
+	default:
+		return AccountKey{}, false
+	}
+
+	if k.ObjectType == "" || k.ClusterID == "" || k.Name == "" || (typ == "role" && k.Role == "") {
+		return AccountKey{}, false
+	}
+
+	return k, true
+}
+
+// String renders the key back into its tuple representation. It round-trips
+// with ParseAccountKey.
+func (k AccountKey) String() string {
+	var s string
+	if k.Role != "" {
+		s = RenderRolePrefix(k.ObjectType, k.ClusterID, k.Name) + k.Role
+	} else {
+		s = renderAccountEntity(k.ObjectType, k.ClusterID, k.Name)
+	}
+	if k.Relation != "" {
+		s += "#" + k.Relation
+	}
+	return s
+}
+
+// StaleAccountTupleFilter returns a filter matching tuples that reference
+// accountName under the account object type objectType with a cluster id other
+// than currentClusterID, in either their Object or their User key.
+func StaleAccountTupleFilter(objectType, accountName, currentClusterID string) TupleFilter {
+	return func(t pmcorev1alpha1.Tuple) bool {
+		return len(StaleClusterIDs(t, objectType, accountName, currentClusterID)) > 0
+	}
+}
+
+// StaleClusterIDs returns the distinct cluster ids other than currentClusterID
+// under which the tuple's Object or User key references accountName with the
+// account object type objectType. Keys of any other object type are ignored
+// even when they share the raw key shape and the account's name (see
+// ParseAccountKey). A tuple built from account keys references exactly one
+// cluster id; more than one returned id means the tuple is ambiguous and must
+// not be re-keyed blindly.
+func StaleClusterIDs(t pmcorev1alpha1.Tuple, objectType, accountName, currentClusterID string) []string {
+	if objectType == "" || accountName == "" || currentClusterID == "" {
+		return nil
+	}
+
+	var ids []string
+	for _, s := range []string{t.Object, t.User} {
+		k, ok := ParseAccountKey(s)
+		if ok && k.ObjectType == objectType && k.Name == accountName && k.ClusterID != currentClusterID && !slices.Contains(ids, k.ClusterID) {
+			ids = append(ids, k.ClusterID)
+		}
+	}
+	return ids
+}
+
+// RekeyTuple returns a copy of t in which every Object and User key of the
+// account object type objectType that carries oldClusterID is rewritten to
+// carry newClusterID instead. Keys that do not parse as account keys, that
+// carry another object type, or that carry a different cluster id, are left
+// untouched.
+func RekeyTuple(t pmcorev1alpha1.Tuple, objectType, oldClusterID, newClusterID string) pmcorev1alpha1.Tuple {
+	t.Object = rekeyKey(t.Object, objectType, oldClusterID, newClusterID)
+	t.User = rekeyKey(t.User, objectType, oldClusterID, newClusterID)
+	return t
+}
+
+func rekeyKey(s, objectType, oldClusterID, newClusterID string) string {
+	k, ok := ParseAccountKey(s)
+	if !ok || k.ObjectType != objectType || k.ClusterID != oldClusterID {
+		return s
+	}
+	k.ClusterID = newClusterID
+	return k.String()
+}

--- a/operators/security-operator/internal/fga/rekey_test.go
+++ b/operators/security-operator/internal/fga/rekey_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fga
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	"go.platform-mesh.io/golang-commons/logger/testlogger"
+	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
+)
+
+func TestParseAccountKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want AccountKey
+		ok   bool
+	}{
+		{
+			in:   "core_platform-mesh_io_account:abc123/myorg",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg"},
+			ok:   true,
+		},
+		{
+			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner"},
+			ok:   true,
+		},
+		{
+			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner#assignee",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner", Relation: "assignee"},
+			ok:   true,
+		},
+		{
+			in:   "core_platform-mesh_io_account:abc123/myorg#member",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Relation: "member"},
+			ok:   true,
+		},
+		// Non-account keys must not parse.
+		{in: "user:someone.example.com", ok: false},
+		{in: "user:*", ok: false},
+		{in: "role:authenticated", ok: false},
+		{in: "role:authenticated#assignee", ok: false},
+		{in: "no-colon-here", ok: false},
+		{in: "core_platform-mesh_io_account:abc123", ok: false},
+		{in: "core_platform-mesh_io_account:abc123/a/b", ok: false},
+		{in: "role:type/cluster/name", ok: false},
+		{in: "role:type/cluster/name/role/extra", ok: false},
+		{in: "role:type//name/owner", ok: false},
+		{in: ":cluster/name", ok: false},
+		{in: "core_platform-mesh_io_account:abc123/myorg#", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			got, ok := ParseAccountKey(test.in)
+			assert.Equal(t, test.ok, ok)
+			if test.ok {
+				assert.Equal(t, test.want, got)
+				// Round-trip.
+				assert.Equal(t, test.in, got.String())
+			}
+		})
+	}
+}
+
+func TestStaleAccountTupleFilter(t *testing.T) {
+	filter := StaleAccountTupleFilter("acct", "myorg", "new-id")
+
+	tests := []struct {
+		name  string
+		tuple pmcorev1alpha1.Tuple
+		want  bool
+	}{
+		{
+			name:  "stale role object",
+			tuple: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/old-id/myorg/owner"},
+			want:  true,
+		},
+		{
+			name:  "stale role user and account object",
+			tuple: pmcorev1alpha1.Tuple{User: "role:acct/old-id/myorg/owner#assignee", Relation: "owner", Object: "acct:old-id/myorg"},
+			want:  true,
+		},
+		{
+			name:  "current cluster id",
+			tuple: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/new-id/myorg/owner"},
+			want:  false,
+		},
+		{
+			name:  "different account name",
+			tuple: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/old-id/otherorg/owner"},
+			want:  false,
+		},
+		{
+			name:  "non-account keys",
+			tuple: pmcorev1alpha1.Tuple{User: "user:*", Relation: "assignee", Object: "role:authenticated"},
+			want:  false,
+		},
+		// Keys of OTHER object types share the raw shape (the org store holds
+		// e.g. apis_kcp_io_apiexport user keys for APIExportPolicies) and must
+		// never match, even with the org's name and a stale cluster id.
+		{
+			name:  "other object type in user key",
+			tuple: pmcorev1alpha1.Tuple{User: "apis_kcp_io_apiexport:old-id/myorg", Relation: "member", Object: "acct:new-id/myorg"},
+			want:  false,
+		},
+		{
+			name:  "other object type in object key",
+			tuple: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "member", Object: "apis_kcp_io_apiexport:old-id/myorg"},
+			want:  false,
+		},
+		{
+			name:  "other object type in role key",
+			tuple: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:apis_kcp_io_apiexport/old-id/myorg/owner"},
+			want:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, filter(test.tuple))
+		})
+	}
+
+	t.Run("empty object type, account name or cluster id never match", func(t *testing.T) {
+		stale := pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/old-id/myorg/owner"}
+		assert.False(t, StaleAccountTupleFilter("", "myorg", "new-id")(stale))
+		assert.False(t, StaleAccountTupleFilter("acct", "", "new-id")(stale))
+		assert.False(t, StaleAccountTupleFilter("acct", "myorg", "")(stale))
+	})
+}
+
+func TestStaleClusterIDs(t *testing.T) {
+	t.Run("single stale id from both keys", func(t *testing.T) {
+		tuple := pmcorev1alpha1.Tuple{User: "role:acct/old-id/myorg/owner#assignee", Relation: "owner", Object: "acct:old-id/myorg"}
+		assert.Equal(t, []string{"old-id"}, StaleClusterIDs(tuple, "acct", "myorg", "new-id"))
+	})
+	t.Run("two distinct stale ids are both reported", func(t *testing.T) {
+		tuple := pmcorev1alpha1.Tuple{User: "role:acct/old-a/myorg/owner#assignee", Relation: "owner", Object: "acct:old-b/myorg"}
+		assert.ElementsMatch(t, []string{"old-a", "old-b"}, StaleClusterIDs(tuple, "acct", "myorg", "new-id"))
+	})
+	t.Run("no stale ids", func(t *testing.T) {
+		tuple := pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/new-id/myorg/owner"}
+		assert.Empty(t, StaleClusterIDs(tuple, "acct", "myorg", "new-id"))
+	})
+	t.Run("other object types are invisible", func(t *testing.T) {
+		// The apiexport key references the org's name under a foreign old id:
+		// it must not contribute a stale id.
+		tuple := pmcorev1alpha1.Tuple{User: "apis_kcp_io_apiexport:other-old/myorg", Relation: "member", Object: "acct:old-id/myorg"}
+		assert.Equal(t, []string{"old-id"}, StaleClusterIDs(tuple, "acct", "myorg", "new-id"))
+	})
+}
+
+func TestRekeyTuple(t *testing.T) {
+	tests := []struct {
+		name string
+		in   pmcorev1alpha1.Tuple
+		want pmcorev1alpha1.Tuple
+	}{
+		{
+			name: "creator tuple: only object rewritten",
+			in:   pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/old-id/myorg/owner"},
+			want: pmcorev1alpha1.Tuple{User: "user:alice", Relation: "assignee", Object: "role:acct/new-id/myorg/owner"},
+		},
+		{
+			name: "role-assignee tuple: object and user rewritten",
+			in:   pmcorev1alpha1.Tuple{User: "role:acct/old-id/myorg/owner#assignee", Relation: "owner", Object: "acct:old-id/myorg"},
+			want: pmcorev1alpha1.Tuple{User: "role:acct/new-id/myorg/owner#assignee", Relation: "owner", Object: "acct:new-id/myorg"},
+		},
+		{
+			name: "keys with other cluster ids untouched",
+			in:   pmcorev1alpha1.Tuple{User: "acct:another-id/parent", Relation: "parent", Object: "acct:old-id/myorg"},
+			want: pmcorev1alpha1.Tuple{User: "acct:another-id/parent", Relation: "parent", Object: "acct:new-id/myorg"},
+		},
+		{
+			name: "non-account keys untouched",
+			in:   pmcorev1alpha1.Tuple{User: "user:*", Relation: "assignee", Object: "role:authenticated"},
+			want: pmcorev1alpha1.Tuple{User: "user:*", Relation: "assignee", Object: "role:authenticated"},
+		},
+		{
+			name: "keys of other object types untouched even with matching cluster id",
+			in:   pmcorev1alpha1.Tuple{User: "apis_kcp_io_apiexport:old-id/myorg", Relation: "member", Object: "acct:old-id/myorg"},
+			want: pmcorev1alpha1.Tuple{User: "apis_kcp_io_apiexport:old-id/myorg", Relation: "member", Object: "acct:new-id/myorg"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, RekeyTuple(test.in, "acct", "old-id", "new-id"))
+		})
+	}
+}
+
+func chunkTestTuples(n int) []pmcorev1alpha1.Tuple {
+	tuples := make([]pmcorev1alpha1.Tuple, 0, n)
+	for i := 0; i < n; i++ {
+		tuples = append(tuples, pmcorev1alpha1.Tuple{
+			User:     fmt.Sprintf("user:user-%d", i),
+			Relation: "assignee",
+			Object:   "role:acct/old-id/myorg/member",
+		})
+	}
+	return tuples
+}
+
+func TestTupleManager_ApplyChunked(t *testing.T) {
+	t.Run("chunks writes into requests of at most 100 tuples", func(t *testing.T) {
+		client := mocks.NewMockOpenFGAServiceClient(t)
+		var chunkSizes []int
+		client.EXPECT().Write(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			require.NotNil(t, req.Writes)
+			require.Nil(t, req.Deletes)
+			chunkSizes = append(chunkSizes, len(req.Writes.TupleKeys))
+			return &openfgav1.WriteResponse{}, nil
+		}).Times(3)
+
+		log := testlogger.New()
+		mgr := NewTupleManager(client, "store-id", "model-id", log.Logger)
+		err := mgr.ApplyChunked(context.Background(), chunkTestTuples(250))
+		require.NoError(t, err)
+		assert.Equal(t, []int{100, 100, 50}, chunkSizes)
+	})
+
+	t.Run("empty input does not call the client", func(t *testing.T) {
+		client := mocks.NewMockOpenFGAServiceClient(t)
+		log := testlogger.New()
+		mgr := NewTupleManager(client, "store-id", "model-id", log.Logger)
+		require.NoError(t, mgr.ApplyChunked(context.Background(), nil))
+	})
+
+	t.Run("stops at the first failed chunk", func(t *testing.T) {
+		client := mocks.NewMockOpenFGAServiceClient(t)
+		client.EXPECT().Write(mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
+		log := testlogger.New()
+		mgr := NewTupleManager(client, "store-id", "model-id", log.Logger)
+		err := mgr.ApplyChunked(context.Background(), chunkTestTuples(250))
+		assert.Error(t, err)
+	})
+}
+
+func TestTupleManager_DeleteChunked(t *testing.T) {
+	t.Run("chunks deletes into requests of at most 100 tuples", func(t *testing.T) {
+		client := mocks.NewMockOpenFGAServiceClient(t)
+		var chunkSizes []int
+		client.EXPECT().Write(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			require.NotNil(t, req.Deletes)
+			require.Nil(t, req.Writes)
+			chunkSizes = append(chunkSizes, len(req.Deletes.TupleKeys))
+			return &openfgav1.WriteResponse{}, nil
+		}).Times(3)
+
+		log := testlogger.New()
+		mgr := NewTupleManager(client, "store-id", "model-id", log.Logger)
+		err := mgr.DeleteChunked(context.Background(), chunkTestTuples(201))
+		require.NoError(t, err)
+		assert.Equal(t, []int{100, 100, 1}, chunkSizes)
+	})
+
+	t.Run("stops at the first failed chunk", func(t *testing.T) {
+		client := mocks.NewMockOpenFGAServiceClient(t)
+		client.EXPECT().Write(mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
+		log := testlogger.New()
+		mgr := NewTupleManager(client, "store-id", "model-id", log.Logger)
+		err := mgr.DeleteChunked(context.Background(), chunkTestTuples(150))
+		assert.Error(t, err)
+	})
+}

--- a/operators/security-operator/internal/fga/rekey_test.go
+++ b/operators/security-operator/internal/fga/rekey_test.go
@@ -32,59 +32,6 @@ import (
 	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
 )
 
-func TestParseAccountKey(t *testing.T) {
-	tests := []struct {
-		in   string
-		want AccountKey
-		ok   bool
-	}{
-		{
-			in:   "core_platform-mesh_io_account:abc123/myorg",
-			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg"},
-			ok:   true,
-		},
-		{
-			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner",
-			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner"},
-			ok:   true,
-		},
-		{
-			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner#assignee",
-			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner", Relation: "assignee"},
-			ok:   true,
-		},
-		{
-			in:   "core_platform-mesh_io_account:abc123/myorg#member",
-			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Relation: "member"},
-			ok:   true,
-		},
-		// Non-account keys must not parse.
-		{in: "user:someone.example.com", ok: false},
-		{in: "user:*", ok: false},
-		{in: "role:authenticated", ok: false},
-		{in: "role:authenticated#assignee", ok: false},
-		{in: "no-colon-here", ok: false},
-		{in: "core_platform-mesh_io_account:abc123", ok: false},
-		{in: "core_platform-mesh_io_account:abc123/a/b", ok: false},
-		{in: "role:type/cluster/name", ok: false},
-		{in: "role:type/cluster/name/role/extra", ok: false},
-		{in: "role:type//name/owner", ok: false},
-		{in: ":cluster/name", ok: false},
-		{in: "core_platform-mesh_io_account:abc123/myorg#", ok: false},
-	}
-	for _, test := range tests {
-		t.Run(test.in, func(t *testing.T) {
-			got, ok := ParseAccountKey(test.in)
-			assert.Equal(t, test.ok, ok)
-			if test.ok {
-				assert.Equal(t, test.want, got)
-				// Round-trip.
-				assert.Equal(t, test.in, got.String())
-			}
-		})
-	}
-}
-
 func TestStaleAccountTupleFilter(t *testing.T) {
 	filter := StaleAccountTupleFilter("acct", "myorg", "new-id")
 
@@ -213,7 +160,7 @@ func TestRekeyTuple(t *testing.T) {
 
 func chunkTestTuples(n int) []pmcorev1alpha1.Tuple {
 	tuples := make([]pmcorev1alpha1.Tuple, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		tuples = append(tuples, pmcorev1alpha1.Tuple{
 			User:     fmt.Sprintf("user:user-%d", i),
 			Relation: "assignee",

--- a/operators/security-operator/internal/fga/tuple_manager.go
+++ b/operators/security-operator/internal/fga/tuple_manager.go
@@ -118,6 +118,36 @@ func (m *TupleManager) Delete(ctx context.Context, tuples []pmcorev1alpha1.Tuple
 	return nil
 }
 
+// maxTuplesPerWrite is the maximum number of tuple keys OpenFGA accepts in a
+// single Write request (the server's default max_tuples_per_write).
+const maxTuplesPerWrite = 100
+
+// ApplyChunked writes tuples through Apply in chunks of at most
+// maxTuplesPerWrite tuples per Write request. Like Apply it ignores duplicate
+// writes, so a partially applied set can safely be re-applied.
+func (m *TupleManager) ApplyChunked(ctx context.Context, tuples []pmcorev1alpha1.Tuple) error {
+	for start := 0; start < len(tuples); start += maxTuplesPerWrite {
+		end := min(start+maxTuplesPerWrite, len(tuples))
+		if err := m.Apply(ctx, tuples[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteChunked deletes tuples through Delete in chunks of at most
+// maxTuplesPerWrite tuples per Write request. Like Delete it ignores missing
+// tuples, so a partially deleted set can safely be re-deleted.
+func (m *TupleManager) DeleteChunked(ctx context.Context, tuples []pmcorev1alpha1.Tuple) error {
+	for start := 0; start < len(tuples); start += maxTuplesPerWrite {
+		end := min(start+maxTuplesPerWrite, len(tuples))
+		if err := m.Delete(ctx, tuples[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ListWithFilter gets all tuples in the store and returns a list of all tuples
 // that match the given filter.
 func (m *TupleManager) ListWithFilter(ctx context.Context, filter TupleFilter) ([]pmcorev1alpha1.Tuple, error) {

--- a/operators/security-operator/internal/fga/tuples.go
+++ b/operators/security-operator/internal/fga/tuples.go
@@ -114,8 +114,89 @@ func formatUser(user string) string {
 	return strings.ReplaceAll(user, ":", ".")
 }
 
+// AccountKey is the structured form of the two FGA key shapes that embed an
+// account's origin cluster id:
+//
+//	<objectType>:<clusterID>/<name>[#<relation>]
+//	role:<objectType>/<clusterID>/<name>/<role>[#<relation>]
+//
+// It is the single source of truth for that format: every renderer below
+// builds keys through String, and ParseAccountKey reads them back, so the two
+// directions cannot drift apart (round-trip asserted in the tests).
+type AccountKey struct {
+	ObjectType string
+	ClusterID  string
+	Name       string
+	Role       string // non-empty for the role shape
+	Relation   string // optional "#<relation>" suffix (e.g. "assignee")
+}
+
+// String renders the key into its tuple representation. It round-trips with
+// ParseAccountKey.
+func (k AccountKey) String() string {
+	var s string
+	if k.Role != "" {
+		s = k.RolePrefix() + k.Role
+	} else {
+		s = fmt.Sprintf("%s:%s/%s", k.ObjectType, k.ClusterID, k.Name)
+	}
+	if k.Relation != "" {
+		s += "#" + k.Relation
+	}
+	return s
+}
+
+// RolePrefix returns the prefix shared by all role keys of this account
+// (e.g. "role:objectType/clusterID/name/").
+func (k AccountKey) RolePrefix() string {
+	return fmt.Sprintf("role:%s/%s/%s/", k.ObjectType, k.ClusterID, k.Name)
+}
+
+// ParseAccountKey parses s into an AccountKey. It returns false for strings
+// that do not match either shape rendered by AccountKey.String (e.g.
+// "user:someone", "role:authenticated#assignee").
+//
+// The match is purely structural: other key families share the raw
+// `<type>:<clusterID>/<name>` shape (e.g. the
+// `apis_kcp_io_apiexport:<providerClusterID>/<exportName>` user keys written
+// into the same org store for APIExportPolicies), so callers MUST additionally
+// check ObjectType against the configured account object type before treating
+// the result as an account key.
+func ParseAccountKey(s string) (AccountKey, bool) {
+	var k AccountKey
+
+	if i := strings.IndexByte(s, '#'); i >= 0 {
+		k.Relation = s[i+1:]
+		s = s[:i]
+		if k.Relation == "" {
+			return AccountKey{}, false
+		}
+	}
+
+	typ, rest, found := strings.Cut(s, ":")
+	if !found || typ == "" || typ == "user" {
+		return AccountKey{}, false
+	}
+
+	parts := strings.Split(rest, "/")
+	switch {
+	case typ == "role" && len(parts) == 4:
+		k.ObjectType, k.ClusterID, k.Name, k.Role = parts[0], parts[1], parts[2], parts[3]
+	case typ != "role" && len(parts) == 2:
+		k.ObjectType, k.ClusterID, k.Name = typ, parts[0], parts[1]
+	default:
+		return AccountKey{}, false
+	}
+
+	if k.ObjectType == "" || k.ClusterID == "" || k.Name == "" || (typ == "role" && k.Role == "") {
+		return AccountKey{}, false
+	}
+
+	return k, true
+}
+
 func renderAccountEntity(objectType, originClusterID, name string) string {
-	return fmt.Sprintf("%s:%s/%s", objectType, originClusterID, name)
+	return AccountKey{ObjectType: objectType, ClusterID: originClusterID, Name: name}.String()
 }
 
 func renderCreatorUser(creator string) string {
@@ -125,13 +206,19 @@ func renderCreatorUser(creator string) string {
 // RenderRolePrefix returns the prefix for role User strings that reference an
 // Account's roles (e.g. "role:objectType/originClusterID/name/").
 func RenderRolePrefix(objectType, originClusterID, name string) string {
-	return fmt.Sprintf("role:%s/%s/%s/", objectType, originClusterID, name)
+	return AccountKey{ObjectType: objectType, ClusterID: originClusterID, Name: name}.RolePrefix()
 }
 
 func renderOwnerRole(objectType, originClusterID, name string) string {
-	return RenderRolePrefix(objectType, originClusterID, name) + "owner"
+	return AccountKey{ObjectType: objectType, ClusterID: originClusterID, Name: name, Role: "owner"}.String()
 }
 
 func renderOwnerRoleAssigneeGroup(objectType, originClusterID, name string) string {
-	return RenderRolePrefix(objectType, originClusterID, name) + "owner#assignee"
+	return AccountKey{
+		ObjectType: objectType,
+		ClusterID:  originClusterID,
+		Name:       name,
+		Role:       "owner",
+		Relation:   "assignee",
+	}.String()
 }

--- a/operators/security-operator/internal/fga/tuples_test.go
+++ b/operators/security-operator/internal/fga/tuples_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fga
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,4 +112,102 @@ func TestInitialTuplesForAccount_nilCreator(t *testing.T) {
 	_, err := InitialTuplesForAccount(in)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "creator is empty")
+}
+
+func TestParseAccountKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want AccountKey
+		ok   bool
+	}{
+		{
+			in:   "core_platform-mesh_io_account:abc123/myorg",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg"},
+			ok:   true,
+		},
+		{
+			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner"},
+			ok:   true,
+		},
+		{
+			in:   "role:core_platform-mesh_io_account/abc123/myorg/owner#assignee",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Role: "owner", Relation: "assignee"},
+			ok:   true,
+		},
+		{
+			in:   "core_platform-mesh_io_account:abc123/myorg#member",
+			want: AccountKey{ObjectType: "core_platform-mesh_io_account", ClusterID: "abc123", Name: "myorg", Relation: "member"},
+			ok:   true,
+		},
+		// Non-account keys must not parse.
+		{in: "user:someone.example.com", ok: false},
+		{in: "user:*", ok: false},
+		{in: "role:authenticated", ok: false},
+		{in: "role:authenticated#assignee", ok: false},
+		{in: "no-colon-here", ok: false},
+		{in: "core_platform-mesh_io_account:abc123", ok: false},
+		{in: "core_platform-mesh_io_account:abc123/a/b", ok: false},
+		{in: "role:type/cluster/name", ok: false},
+		{in: "role:type/cluster/name/role/extra", ok: false},
+		{in: "role:type//name/owner", ok: false},
+		{in: ":cluster/name", ok: false},
+		{in: "core_platform-mesh_io_account:abc123/myorg#", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			got, ok := ParseAccountKey(test.in)
+			assert.Equal(t, test.ok, ok)
+			if test.ok {
+				assert.Equal(t, test.want, got)
+				// Round-trip.
+				assert.Equal(t, test.in, got.String())
+			}
+		})
+	}
+}
+
+// TestRenderersRoundTripThroughAccountKey pins the renderers and the parser to
+// each other: every key the package writes must parse back into the fields it
+// was built from. Changing one direction without the other fails here.
+func TestRenderersRoundTripThroughAccountKey(t *testing.T) {
+	const (
+		objectType = "core_platform-mesh_io_account"
+		clusterID  = "abc123"
+		name       = "myorg"
+	)
+	tests := []struct {
+		name     string
+		rendered string
+		want     AccountKey
+	}{
+		{
+			name:     "renderAccountEntity",
+			rendered: renderAccountEntity(objectType, clusterID, name),
+			want:     AccountKey{ObjectType: objectType, ClusterID: clusterID, Name: name},
+		},
+		{
+			name:     "renderOwnerRole",
+			rendered: renderOwnerRole(objectType, clusterID, name),
+			want:     AccountKey{ObjectType: objectType, ClusterID: clusterID, Name: name, Role: "owner"},
+		},
+		{
+			name:     "renderOwnerRoleAssigneeGroup",
+			rendered: renderOwnerRoleAssigneeGroup(objectType, clusterID, name),
+			want:     AccountKey{ObjectType: objectType, ClusterID: clusterID, Name: name, Role: "owner", Relation: "assignee"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := ParseAccountKey(test.rendered)
+			require.True(t, ok, "renderer output %q must parse as an account key", test.rendered)
+			assert.Equal(t, test.want, got)
+			assert.Equal(t, test.rendered, got.String())
+		})
+	}
+
+	// RenderRolePrefix is a prefix, not a whole key: every role key starts with it.
+	prefix := RenderRolePrefix(objectType, clusterID, name)
+	assert.Equal(t, prefix, AccountKey{ObjectType: objectType, ClusterID: clusterID, Name: name}.RolePrefix())
+	assert.True(t, strings.HasPrefix(renderOwnerRole(objectType, clusterID, name), prefix))
 }

--- a/operators/security-operator/internal/metrics/metrics.go
+++ b/operators/security-operator/internal/metrics/metrics.go
@@ -50,6 +50,16 @@ var (
 		},
 		[]string{"operation", "result"},
 	)
+
+	// RekeyedTuples counts FGA tuples handled by the orphaned-tuple re-key
+	// subroutine, by result (rekeyed/skipped_live/skipped_ambiguous/skipped_error).
+	RekeyedTuples = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "security_operator_rekeyed_tuples_total",
+			Help: "Total number of FGA tuples re-keyed (or skipped) after an org cluster-id change, by result.",
+		},
+		[]string{"result"},
+	)
 )
 
 func init() {
@@ -57,5 +67,6 @@ func init() {
 		ReconcileTotal,
 		ReconcileDuration,
 		FGAOperations,
+		RekeyedTuples,
 	)
 }

--- a/operators/security-operator/internal/metrics/metrics_test.go
+++ b/operators/security-operator/internal/metrics/metrics_test.go
@@ -68,3 +68,15 @@ func (s *MetricsTestSuite) TestFGAOperations() {
 	metrics.FGAOperations.WithLabelValues("list", "success").Inc()
 	s.Require().Equal(before+1, testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("list", "success")))
 }
+
+// TestRekeyedTuples verifies that the RekeyedTuples counter accumulates tuple
+// counts per result label.
+func (s *MetricsTestSuite) TestRekeyedTuples() {
+	before := testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("rekeyed"))
+	metrics.RekeyedTuples.WithLabelValues("rekeyed").Add(42)
+	s.Require().Equal(before+42, testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("rekeyed")))
+
+	before = testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("skipped_live"))
+	metrics.RekeyedTuples.WithLabelValues("skipped_live").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("skipped_live")))
+}

--- a/operators/security-operator/internal/subroutine/rekey_tuples.go
+++ b/operators/security-operator/internal/subroutine/rekey_tuples.go
@@ -1,0 +1,274 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutine
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	"go.platform-mesh.io/golang-commons/logger"
+	iclient "go.platform-mesh.io/security-operator/internal/client"
+	"go.platform-mesh.io/security-operator/internal/config"
+	"go.platform-mesh.io/security-operator/internal/fga"
+	"go.platform-mesh.io/security-operator/internal/metrics"
+	"go.platform-mesh.io/subroutines"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+
+	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+const rekeyEventComponent = "security-operator"
+
+// RekeyTuplesSubroutine re-keys FGA tuples that were orphaned by an org
+// workspace re-creation: the org's logical cluster hash is embedded in every
+// role/account tuple key, so when the workspace is re-created under a new hash
+// all pre-existing tuples (memberships, role assignments) silently stop
+// matching. The subroutine scans the org's store for tuples that reference the
+// org account under a cluster id other than the current one, verifies that the
+// old cluster id is actually dead, writes re-keyed copies, and only then
+// deletes the originals.
+//
+// Only keys of the configured account object type (Config.FGA.ObjectType) are
+// considered — other key families in the same store share the raw key shape
+// (e.g. apis_kcp_io_apiexport user keys) and must never be rewritten. The
+// whole pass is skipped when a descendant Account shares the org's name,
+// because such an account's tuples are keyed by its (equally dead) parent
+// cluster id and cannot be told apart from the org's own.
+//
+// It is fully gated behind Config.RekeyOrphanedTuplesEnabled and does nothing
+// when the flag is off.
+type RekeyTuplesSubroutine struct {
+	mgr             mcmanager.Manager
+	fga             openfgav1.OpenFGAServiceClient
+	storeIDGetter   fga.StoreIDGetter
+	kcpClientGetter iclient.KCPClientGetter
+	cfg             config.Config
+}
+
+func NewRekeyTuplesSubroutine(cfg config.Config, mgr mcmanager.Manager, fgaClient openfgav1.OpenFGAServiceClient, storeIDGetter fga.StoreIDGetter, kcpClientGetter iclient.KCPClientGetter) *RekeyTuplesSubroutine {
+	return &RekeyTuplesSubroutine{
+		mgr:             mgr,
+		fga:             fgaClient,
+		storeIDGetter:   storeIDGetter,
+		kcpClientGetter: kcpClientGetter,
+		cfg:             cfg,
+	}
+}
+
+// GetName implements subroutines.Subroutine.
+func (s *RekeyTuplesSubroutine) GetName() string { return "RekeyTuplesSubroutine" }
+
+// Initialize implements subroutines.Initializer.
+func (s *RekeyTuplesSubroutine) Initialize(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	return s.reconcile(ctx, obj)
+}
+
+// Process implements subroutines.Processor.
+func (s *RekeyTuplesSubroutine) Process(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	return s.reconcile(ctx, obj)
+}
+
+func (s *RekeyTuplesSubroutine) reconcile(ctx context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	if !s.cfg.RekeyOrphanedTuplesEnabled {
+		return subroutines.OK(), nil
+	}
+
+	log := logger.LoadLoggerFromContext(ctx)
+	lc := obj.(*kcpcorev1alpha1.LogicalCluster)
+
+	cluster, err := s.mgr.ClusterFromContext(ctx)
+	if err != nil {
+		return subroutines.OK(), fmt.Errorf("failed to get cluster from context: %w", err)
+	}
+
+	var ai pmcorev1alpha1.AccountInfo
+	if err := cluster.GetClient().Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name: "account",
+	}, &ai); err != nil && !apierrors.IsNotFound(err) {
+		return subroutines.OK(), fmt.Errorf("getting AccountInfo for LogicalCluster: %w", err)
+	} else if apierrors.IsNotFound(err) {
+		return subroutines.StopWithRequeue(5*time.Second, "AccountInfo not found yet, requeuing"), nil
+	}
+
+	accountName := ai.Spec.Account.Name
+	currentClusterID := ai.Spec.Account.OriginClusterId
+	if accountName == "" || currentClusterID == "" {
+		return subroutines.StopWithRequeue(5*time.Second, "AccountInfo does not carry the account name and origin cluster id yet, requeuing"), nil
+	}
+
+	storeID, err := s.storeIDGetter.Get(ctx, accountName)
+	if err != nil {
+		if fga.IsStoreNotFound(err) {
+			return subroutines.StopWithRequeue(5*time.Second, "org store not found yet, requeuing"), nil
+		}
+		return subroutines.OK(), fmt.Errorf("getting store ID: %w", err)
+	}
+
+	objectType := s.cfg.FGA.ObjectType
+
+	tm := fga.NewTupleManager(s.fga, storeID, fga.AuthorizationModelIDLatest, log)
+	stale, err := tm.ListWithFilter(ctx, fga.StaleAccountTupleFilter(objectType, accountName, currentClusterID))
+	if err != nil {
+		return subroutines.OK(), fmt.Errorf("listing stale tuples: %w", err)
+	}
+	if len(stale) == 0 {
+		return subroutines.OK(), nil
+	}
+
+	// Positive attribution guard: sub-account tuples are keyed by their PARENT
+	// workspace's cluster id (see account_tuples.go), so a descendant Account
+	// carrying the org's own name produces tuples that are indistinguishable
+	// from the org's after a tree re-creation — both reference accountName
+	// under a now-dead cluster id. Re-keying those onto the org's current
+	// cluster id would merge the sub-account's role assignees into the org's
+	// roles. If such an Account exists in the org workspace, never guess: skip
+	// the whole pass.
+	var sameNameAccount pmcorev1alpha1.Account
+	err = cluster.GetClient().Get(ctx, ctrlruntimeclient.ObjectKey{Name: accountName}, &sameNameAccount)
+	switch {
+	case err == nil:
+		log.Warn().
+			Str("account", accountName).
+			Int("count", len(stale)).
+			Msg("a descendant Account shares the org's name, stale tuples cannot be attributed to the org, skipping re-key")
+		metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous").Add(float64(len(stale)))
+		cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+			"a descendant Account named %q exists in the org workspace; %d stale tuples cannot be attributed to the org, skipping re-key", accountName, len(stale))
+		return subroutines.OK(), nil
+	case apierrors.IsNotFound(err):
+		// No same-name descendant: the stale tuples can be attributed safely.
+	default:
+		// Fail closed: without the guard's answer no tuple may be touched.
+		return subroutines.OK(), fmt.Errorf("checking for a descendant Account named like the org: %w", err)
+	}
+
+	// Group the stale tuples by the old cluster id they reference. A tuple
+	// referencing more than one stale cluster id is ambiguous — skip it, never
+	// guess.
+	groups := map[string][]pmcorev1alpha1.Tuple{}
+	for _, t := range stale {
+		ids := fga.StaleClusterIDs(t, objectType, accountName, currentClusterID)
+		if len(ids) != 1 {
+			log.Warn().
+				Str("object", t.Object).
+				Str("user", t.User).
+				Msg("stale tuple references multiple old cluster ids, skipping")
+			metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous").Inc()
+			cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+				"tuple (object=%s user=%s) references multiple old cluster ids, skipping re-key", t.Object, t.User)
+			continue
+		}
+		groups[ids[0]] = append(groups[ids[0]], t)
+	}
+
+	requeue := false
+	for _, oldClusterID := range slices.Sorted(maps.Keys(groups)) {
+		group := groups[oldClusterID]
+
+		alive, aliveErr := s.logicalClusterExists(ctx, oldClusterID)
+		if aliveErr != nil {
+			// Fail closed: only re-key when the liveness check proves the old
+			// cluster id dead.
+			log.Warn().Err(aliveErr).
+				Str("old_cluster_id", oldClusterID).
+				Int("count", len(group)).
+				Msg("could not verify logical cluster liveness, skipping re-key for this cluster id")
+			metrics.RekeyedTuples.WithLabelValues("skipped_error").Add(float64(len(group)))
+			requeue = true
+			continue
+		}
+		if alive {
+			// The referenced logical cluster still exists — these tuples are
+			// not orphaned by this org's re-creation. Never guess.
+			log.Info().
+				Str("old_cluster_id", oldClusterID).
+				Int("count", len(group)).
+				Msg("referenced logical cluster is still alive, skipping re-key for this cluster id")
+			metrics.RekeyedTuples.WithLabelValues("skipped_live").Add(float64(len(group)))
+			cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+				"logical cluster %s referenced by %d tuples of account %q is still alive, skipping re-key", oldClusterID, len(group), accountName)
+			continue
+		}
+
+		rekeyed := make([]pmcorev1alpha1.Tuple, 0, len(group))
+		for _, t := range group {
+			rekeyed = append(rekeyed, fga.RekeyTuple(t, objectType, oldClusterID, currentClusterID))
+		}
+
+		// Write the re-keyed copies first; delete the originals only after all
+		// writes succeeded, so an interrupted run never loses tuples.
+		if err := tm.ApplyChunked(ctx, rekeyed); err != nil {
+			return subroutines.OK(), fmt.Errorf("applying re-keyed tuples for old cluster id %s: %w", oldClusterID, err)
+		}
+		if err := tm.DeleteChunked(ctx, group); err != nil {
+			return subroutines.OK(), fmt.Errorf("deleting stale tuples for old cluster id %s: %w", oldClusterID, err)
+		}
+
+		log.Info().
+			Str("old_cluster_id", oldClusterID).
+			Str("new_cluster_id", currentClusterID).
+			Int("count", len(group)).
+			Msg("re-keyed orphaned tuples")
+		metrics.RekeyedTuples.WithLabelValues("rekeyed").Add(float64(len(group)))
+		cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeNormal, "OrphanedTuplesRekeyed",
+			"re-keyed %d FGA tuples of account %q from dead cluster id %s to %s", len(group), accountName, oldClusterID, currentClusterID)
+	}
+
+	if requeue {
+		return subroutines.StopWithRequeue(30*time.Second, "could not verify liveness for at least one old cluster id, requeuing"), nil
+	}
+	return subroutines.OK(), nil
+}
+
+// logicalClusterExists reports whether the logical cluster behind clusterID
+// still exists, by getting its LogicalCluster "cluster" object. kcp answers
+// with NotFound or Forbidden for logical clusters that are gone; any other
+// error is returned so callers can fail closed.
+func (s *RekeyTuplesSubroutine) logicalClusterExists(ctx context.Context, clusterID string) (bool, error) {
+	clusterClient, err := s.kcpClientGetter.NewClientForLogicalCluster(ctx, clusterID)
+	if err != nil {
+		return false, fmt.Errorf("getting client for logical cluster %s: %w", clusterID, err)
+	}
+
+	var lc kcpcorev1alpha1.LogicalCluster
+	err = clusterClient.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name: "cluster",
+	}, &lc)
+	switch {
+	case err == nil:
+		return true, nil
+	case apierrors.IsNotFound(err) || apierrors.IsForbidden(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("getting LogicalCluster for cluster %s: %w", clusterID, err)
+	}
+}
+
+var (
+	_ subroutines.Initializer = &RekeyTuplesSubroutine{}
+	_ subroutines.Processor   = &RekeyTuplesSubroutine{}
+)

--- a/operators/security-operator/internal/subroutine/rekey_tuples.go
+++ b/operators/security-operator/internal/subroutine/rekey_tuples.go
@@ -41,7 +41,12 @@ import (
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 )
 
-const rekeyEventComponent = "security-operator"
+const (
+	rekeyEventComponent = "security-operator"
+	// rekeyEventAction is the "action" field of the events API: what this
+	// controller did to the org, regardless of the per-event outcome.
+	rekeyEventAction = "RekeyOrphanedTuples"
+)
 
 // RekeyTuplesSubroutine re-keys FGA tuples that were orphaned by an org
 // workspace re-creation: the org's logical cluster hash is embedded in every
@@ -156,7 +161,7 @@ func (s *RekeyTuplesSubroutine) reconcile(ctx context.Context, obj ctrlruntimecl
 			Int("count", len(stale)).
 			Msg("a descendant Account shares the org's name, stale tuples cannot be attributed to the org, skipping re-key")
 		metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous").Add(float64(len(stale)))
-		cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+		cluster.GetEventRecorder(rekeyEventComponent).Eventf(lc, nil, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped", rekeyEventAction,
 			"a descendant Account named %q exists in the org workspace; %d stale tuples cannot be attributed to the org, skipping re-key", accountName, len(stale))
 		return subroutines.OK(), nil
 	case apierrors.IsNotFound(err):
@@ -178,7 +183,7 @@ func (s *RekeyTuplesSubroutine) reconcile(ctx context.Context, obj ctrlruntimecl
 				Str("user", t.User).
 				Msg("stale tuple references multiple old cluster ids, skipping")
 			metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous").Inc()
-			cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+			cluster.GetEventRecorder(rekeyEventComponent).Eventf(lc, nil, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped", rekeyEventAction,
 				"tuple (object=%s user=%s) references multiple old cluster ids, skipping re-key", t.Object, t.User)
 			continue
 		}
@@ -209,7 +214,7 @@ func (s *RekeyTuplesSubroutine) reconcile(ctx context.Context, obj ctrlruntimecl
 				Int("count", len(group)).
 				Msg("referenced logical cluster is still alive, skipping re-key for this cluster id")
 			metrics.RekeyedTuples.WithLabelValues("skipped_live").Add(float64(len(group)))
-			cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped",
+			cluster.GetEventRecorder(rekeyEventComponent).Eventf(lc, nil, corev1.EventTypeWarning, "OrphanedTupleRekeySkipped", rekeyEventAction,
 				"logical cluster %s referenced by %d tuples of account %q is still alive, skipping re-key", oldClusterID, len(group), accountName)
 			continue
 		}
@@ -234,7 +239,7 @@ func (s *RekeyTuplesSubroutine) reconcile(ctx context.Context, obj ctrlruntimecl
 			Int("count", len(group)).
 			Msg("re-keyed orphaned tuples")
 		metrics.RekeyedTuples.WithLabelValues("rekeyed").Add(float64(len(group)))
-		cluster.GetEventRecorderFor(rekeyEventComponent).Eventf(lc, corev1.EventTypeNormal, "OrphanedTuplesRekeyed",
+		cluster.GetEventRecorder(rekeyEventComponent).Eventf(lc, nil, corev1.EventTypeNormal, "OrphanedTuplesRekeyed", rekeyEventAction,
 			"re-keyed %d FGA tuples of account %q from dead cluster id %s to %s", len(group), accountName, oldClusterID, currentClusterID)
 	}
 

--- a/operators/security-operator/internal/subroutine/rekey_tuples_test.go
+++ b/operators/security-operator/internal/subroutine/rekey_tuples_test.go
@@ -1,0 +1,455 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutine_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	"go.platform-mesh.io/security-operator/internal/config"
+	"go.platform-mesh.io/security-operator/internal/metrics"
+	"go.platform-mesh.io/security-operator/internal/subroutine"
+	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
+	"go.platform-mesh.io/subroutines"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+const (
+	rekeyTestOrg   = "myorg"
+	rekeyTestOldID = "old-id"
+	rekeyTestNewID = "new-id"
+)
+
+var (
+	lcGroupResource      = schema.GroupResource{Group: "core.kcp.io", Resource: "logicalclusters"}
+	accountGroupResource = schema.GroupResource{Group: "core.platform-mesh.io", Resource: "accounts"}
+)
+
+type rekeyTestMocks struct {
+	manager       *mocks.MockManager
+	cluster       *mocks.MockCluster
+	clusterClient *mocks.MockClient
+	kcpHelper     *mocks.MockKCPClientGetter
+	deadClient    *mocks.MockClient
+	storeIDGetter *mocks.MockStoreIDGetter
+	fgaClient     *mocks.MockOpenFGAServiceClient
+	recorder      *record.FakeRecorder
+}
+
+func newRekeyTestMocks(t *testing.T) *rekeyTestMocks {
+	t.Helper()
+	return &rekeyTestMocks{
+		manager:       mocks.NewMockManager(t),
+		cluster:       mocks.NewMockCluster(t),
+		clusterClient: mocks.NewMockClient(t),
+		kcpHelper:     mocks.NewMockKCPClientGetter(t),
+		deadClient:    mocks.NewMockClient(t),
+		storeIDGetter: mocks.NewMockStoreIDGetter(t),
+		fgaClient:     mocks.NewMockOpenFGAServiceClient(t),
+		recorder:      record.NewFakeRecorder(50),
+	}
+}
+
+func (m *rekeyTestMocks) newSubroutine(enabled bool) *subroutine.RekeyTuplesSubroutine {
+	cfg := config.Config{}
+	cfg.RekeyOrphanedTuplesEnabled = enabled
+	cfg.FGA.ObjectType = "acct"
+	return subroutine.NewRekeyTuplesSubroutine(cfg, m.manager, m.fgaClient, m.storeIDGetter, m.kcpHelper)
+}
+
+// expectOrgContext wires up ClusterFromContext + the AccountInfo lookup that
+// yields the org's current cluster id, and the store id resolution.
+func (m *rekeyTestMocks) expectOrgContext() {
+	m.manager.EXPECT().ClusterFromContext(mock.Anything).Return(m.cluster, nil)
+	m.cluster.EXPECT().GetClient().Return(m.clusterClient)
+	m.clusterClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.Anything).
+		RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+			if ai, ok := o.(*pmcorev1alpha1.AccountInfo); ok {
+				ai.Spec.Account.Name = rekeyTestOrg
+				ai.Spec.Account.OriginClusterId = rekeyTestNewID
+			}
+			return nil
+		})
+	m.storeIDGetter.EXPECT().Get(mock.Anything, rekeyTestOrg).Return("store-id", nil)
+}
+
+// expectRead makes the store scan return the given tuples in a single page.
+func (m *rekeyTestMocks) expectRead(tuples ...pmcorev1alpha1.Tuple) {
+	fgaTuples := make([]*openfgav1.Tuple, 0, len(tuples))
+	for _, t := range tuples {
+		fgaTuples = append(fgaTuples, &openfgav1.Tuple{Key: &openfgav1.TupleKey{
+			Object:   t.Object,
+			Relation: t.Relation,
+			User:     t.User,
+		}})
+	}
+	m.fgaClient.EXPECT().Read(mock.Anything, mock.Anything).
+		Return(&openfgav1.ReadResponse{Tuples: fgaTuples}, nil).Once()
+}
+
+// expectNoSameNameChild makes the same-name-descendant guard find no Account
+// named like the org in the org workspace.
+func (m *rekeyTestMocks) expectNoSameNameChild() {
+	m.clusterClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: rekeyTestOrg}, mock.Anything).
+		Return(apierrors.NewNotFound(accountGroupResource, rekeyTestOrg))
+}
+
+// expectLiveness makes the liveness check for the old cluster id answer with
+// the given error (nil = the cluster still exists).
+func (m *rekeyTestMocks) expectLiveness(getErr error) {
+	m.kcpHelper.EXPECT().NewClientForLogicalCluster(mock.Anything, rekeyTestOldID).Return(m.deadClient, nil)
+	m.deadClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "cluster"}, mock.Anything).Return(getErr)
+}
+
+func staleCreatorTuple() pmcorev1alpha1.Tuple {
+	return pmcorev1alpha1.Tuple{
+		User:     "user:alice",
+		Relation: "assignee",
+		Object:   "role:acct/" + rekeyTestOldID + "/" + rekeyTestOrg + "/owner",
+	}
+}
+
+func staleOwnerGroupTuple() pmcorev1alpha1.Tuple {
+	return pmcorev1alpha1.Tuple{
+		User:     "role:acct/" + rekeyTestOldID + "/" + rekeyTestOrg + "/owner#assignee",
+		Relation: "owner",
+		Object:   "acct:" + rekeyTestOldID + "/" + rekeyTestOrg,
+	}
+}
+
+func currentCreatorTuple() pmcorev1alpha1.Tuple {
+	return pmcorev1alpha1.Tuple{
+		User:     "user:bob",
+		Relation: "assignee",
+		Object:   "role:acct/" + rekeyTestNewID + "/" + rekeyTestOrg + "/owner",
+	}
+}
+
+func TestRekeyTuplesSubroutine_GetName(t *testing.T) {
+	sub := subroutine.NewRekeyTuplesSubroutine(config.Config{}, nil, nil, nil, nil)
+	assert.Equal(t, "RekeyTuplesSubroutine", sub.GetName())
+}
+
+func TestRekeyTuplesSubroutine_FlagOff_NoAction(t *testing.T) {
+	// All mocks are created without any expectations: any call to any of them
+	// fails the test. With the flag off the subroutine must be a no-op.
+	m := newRekeyTestMocks(t)
+	sub := m.newSubroutine(false)
+
+	for _, fn := range []func(context.Context, ctrlruntimeclient.Object) (subroutines.Result, error){sub.Process, sub.Initialize} {
+		result, err := fn(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+		require.NoError(t, err)
+		assert.Equal(t, subroutines.OK(), result)
+	}
+}
+
+func TestRekeyTuplesSubroutine_RekeysStaleGroupWithDeadCluster(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple(), currentCreatorTuple())
+	m.expectNoSameNameChild()
+	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+
+	var ops []string
+	var written []*openfgav1.TupleKey
+	var deletedKeys []*openfgav1.TupleKeyWithoutCondition
+	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			if req.Writes != nil {
+				ops = append(ops, "write")
+				written = append(written, req.Writes.TupleKeys...)
+			}
+			if req.Deletes != nil {
+				ops = append(ops, "delete")
+				deletedKeys = append(deletedKeys, req.Deletes.TupleKeys...)
+			}
+			return &openfgav1.WriteResponse{}, nil
+		}).Times(2)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Initialize(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+
+	// Write happened strictly before delete.
+	require.Equal(t, []string{"write", "delete"}, ops)
+
+	// The written tuples are the stale ones re-keyed to the new cluster id.
+	require.Len(t, written, 2)
+	assert.Equal(t, "role:acct/new-id/myorg/owner", written[0].Object)
+	assert.Equal(t, "user:alice", written[0].User)
+	assert.Equal(t, "acct:new-id/myorg", written[1].Object)
+	assert.Equal(t, "role:acct/new-id/myorg/owner#assignee", written[1].User)
+
+	// The deleted tuples are exactly the stale originals; the tuple already on
+	// the current cluster id is untouched.
+	require.Len(t, deletedKeys, 2)
+	assert.Equal(t, "role:acct/old-id/myorg/owner", deletedKeys[0].Object)
+	assert.Equal(t, "acct:old-id/myorg", deletedKeys[1].Object)
+
+	// An event with the tuple count was emitted.
+	select {
+	case ev := <-m.recorder.Events:
+		assert.Contains(t, ev, "OrphanedTuplesRekeyed")
+		assert.Contains(t, ev, "2 FGA tuples")
+	default:
+		t.Fatal("expected an OrphanedTuplesRekeyed event")
+	}
+}
+
+func TestRekeyTuplesSubroutine_FailsClosedWhenLivenessCheckErrors(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple())
+	m.expectNoSameNameChild()
+	// Liveness check fails with an error that is neither NotFound nor
+	// Forbidden: no tuple may be touched. Note: no Write expectation is set,
+	// so any Write call fails the test.
+	m.expectLiveness(apierrors.NewInternalError(assert.AnError))
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.True(t, result.IsStopWithRequeue(), "must requeue to retry the liveness check")
+}
+
+func TestRekeyTuplesSubroutine_SkipsGroupWhenClusterStillAlive(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple())
+	m.expectNoSameNameChild()
+	// The referenced cluster still exists: never guess, never touch tuples.
+	m.expectLiveness(nil)
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+
+	select {
+	case ev := <-m.recorder.Events:
+		assert.Contains(t, ev, "OrphanedTupleRekeySkipped")
+	default:
+		t.Fatal("expected an OrphanedTupleRekeySkipped event")
+	}
+}
+
+func TestRekeyTuplesSubroutine_TreatsForbiddenAsDead(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple())
+	m.expectNoSameNameChild()
+	m.expectLiveness(apierrors.NewForbidden(lcGroupResource, "cluster", assert.AnError))
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+
+	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).Return(&openfgav1.WriteResponse{}, nil).Times(2)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+}
+
+func TestRekeyTuplesSubroutine_NoDeleteWhenWriteFails(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple())
+	m.expectNoSameNameChild()
+	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
+
+	// The write of the re-keyed copies fails: the originals must NOT be
+	// deleted (only one Write call in total).
+	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			require.NotNil(t, req.Writes, "the only Write call must be the write of re-keyed copies, not a delete")
+			return nil, assert.AnError
+		}).Once()
+
+	sub := m.newSubroutine(true)
+	_, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.Error(t, err)
+}
+
+func TestRekeyTuplesSubroutine_ChunksGroupsOver100Tuples(t *testing.T) {
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+
+	stale := make([]pmcorev1alpha1.Tuple, 0, 250)
+	for i := 0; i < 250; i++ {
+		stale = append(stale, pmcorev1alpha1.Tuple{
+			User:     fmt.Sprintf("user:member-%d", i),
+			Relation: "assignee",
+			Object:   "role:acct/" + rekeyTestOldID + "/" + rekeyTestOrg + "/member",
+		})
+	}
+	m.expectRead(stale...)
+	m.expectNoSameNameChild()
+	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+
+	var ops []string
+	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			switch {
+			case req.Writes != nil:
+				require.LessOrEqual(t, len(req.Writes.TupleKeys), 100)
+				ops = append(ops, fmt.Sprintf("write-%d", len(req.Writes.TupleKeys)))
+			case req.Deletes != nil:
+				require.LessOrEqual(t, len(req.Deletes.TupleKeys), 100)
+				ops = append(ops, fmt.Sprintf("delete-%d", len(req.Deletes.TupleKeys)))
+			}
+			return &openfgav1.WriteResponse{}, nil
+		}).Times(6)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+
+	// All writes happen before any delete, and every request is capped at 100.
+	assert.Equal(t, []string{"write-100", "write-100", "write-50", "delete-100", "delete-100", "delete-50"}, ops)
+}
+
+func TestRekeyTuplesSubroutine_SkipsAllWhenSameNameDescendantAccountExists(t *testing.T) {
+	// A sub-account may legally carry the org's own name (Account names are
+	// only unique per workspace). Its tuples are keyed by its parent
+	// workspace's cluster id, which after a tree re-creation is just as dead
+	// as the org's old origin cluster id — so stale tuples cannot be
+	// attributed to the org. Re-keying them would merge the sub-account's role
+	// assignees into the org's roles: the subroutine must not touch anything.
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple())
+	// The guard finds an Account named like the org in the org workspace.
+	m.clusterClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: rekeyTestOrg}, mock.Anything).Return(nil)
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	// Note: no liveness and no Write expectations are set, so any FGA write or
+	// kcp client call fails the test.
+
+	before := testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous"))
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+
+	assert.Equal(t, before+2, testutil.ToFloat64(metrics.RekeyedTuples.WithLabelValues("skipped_ambiguous")))
+
+	select {
+	case ev := <-m.recorder.Events:
+		assert.Contains(t, ev, "OrphanedTupleRekeySkipped")
+		assert.Contains(t, ev, rekeyTestOrg)
+	default:
+		t.Fatal("expected an OrphanedTupleRekeySkipped event")
+	}
+}
+
+func TestRekeyTuplesSubroutine_FailsClosedWhenDescendantCheckErrors(t *testing.T) {
+	// The same-name-descendant guard cannot be evaluated: no tuple may be
+	// touched (no Write expectation is set, so any Write call fails the test).
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(staleCreatorTuple())
+	m.clusterClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: rekeyTestOrg}, mock.Anything).
+		Return(apierrors.NewInternalError(assert.AnError))
+
+	sub := m.newSubroutine(true)
+	_, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.Error(t, err)
+}
+
+func TestRekeyTuplesSubroutine_IgnoresForeignObjectTypeKeys(t *testing.T) {
+	// The org store also holds keys of other object types in the same raw
+	// shape — e.g. apis_kcp_io_apiexport user keys written for
+	// APIExportPolicies. Even when such a key carries the org's name under an
+	// old cluster id it must be invisible to the re-key pass.
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	apiExportTuple := pmcorev1alpha1.Tuple{
+		User:     "apis_kcp_io_apiexport:" + rekeyTestOldID + "/" + rekeyTestOrg,
+		Relation: "member",
+		Object:   "acct:" + rekeyTestNewID + "/" + rekeyTestOrg,
+	}
+	m.expectRead(apiExportTuple, staleCreatorTuple())
+	m.expectNoSameNameChild()
+	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
+	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+
+	var written []*openfgav1.TupleKey
+	var deletedKeys []*openfgav1.TupleKeyWithoutCondition
+	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, req *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+			if req.Writes != nil {
+				written = append(written, req.Writes.TupleKeys...)
+			}
+			if req.Deletes != nil {
+				deletedKeys = append(deletedKeys, req.Deletes.TupleKeys...)
+			}
+			return &openfgav1.WriteResponse{}, nil
+		}).Times(2)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+
+	// Only the genuine account tuple was re-keyed and deleted; the apiexport
+	// key never appears in any request.
+	require.Len(t, written, 1)
+	assert.Equal(t, "role:acct/new-id/myorg/owner", written[0].Object)
+	assert.Equal(t, "user:alice", written[0].User)
+	require.Len(t, deletedKeys, 1)
+	assert.Equal(t, "role:acct/old-id/myorg/owner", deletedKeys[0].Object)
+}
+
+func TestRekeyTuplesSubroutine_SecondPassIsIdempotent(t *testing.T) {
+	// After a successful re-key the store only contains tuples on the current
+	// cluster id: the next reconcile must not issue any Write.
+	m := newRekeyTestMocks(t)
+	m.expectOrgContext()
+	m.expectRead(
+		currentCreatorTuple(),
+		pmcorev1alpha1.Tuple{
+			User:     "role:acct/" + rekeyTestNewID + "/" + rekeyTestOrg + "/owner#assignee",
+			Relation: "owner",
+			Object:   "acct:" + rekeyTestNewID + "/" + rekeyTestOrg,
+		},
+	)
+
+	sub := m.newSubroutine(true)
+	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, subroutines.OK(), result)
+}

--- a/operators/security-operator/internal/subroutine/rekey_tuples_test.go
+++ b/operators/security-operator/internal/subroutine/rekey_tuples_test.go
@@ -38,7 +38,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
@@ -63,7 +63,7 @@ type rekeyTestMocks struct {
 	deadClient    *mocks.MockClient
 	storeIDGetter *mocks.MockStoreIDGetter
 	fgaClient     *mocks.MockOpenFGAServiceClient
-	recorder      *record.FakeRecorder
+	recorder      *events.FakeRecorder
 }
 
 func newRekeyTestMocks(t *testing.T) *rekeyTestMocks {
@@ -76,7 +76,7 @@ func newRekeyTestMocks(t *testing.T) *rekeyTestMocks {
 		deadClient:    mocks.NewMockClient(t),
 		storeIDGetter: mocks.NewMockStoreIDGetter(t),
 		fgaClient:     mocks.NewMockOpenFGAServiceClient(t),
-		recorder:      record.NewFakeRecorder(50),
+		recorder:      events.NewFakeRecorder(50),
 	}
 }
 
@@ -179,7 +179,7 @@ func TestRekeyTuplesSubroutine_RekeysStaleGroupWithDeadCluster(t *testing.T) {
 	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple(), currentCreatorTuple())
 	m.expectNoSameNameChild()
 	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 
 	var ops []string
 	var written []*openfgav1.TupleKey
@@ -251,7 +251,7 @@ func TestRekeyTuplesSubroutine_SkipsGroupWhenClusterStillAlive(t *testing.T) {
 	m.expectNoSameNameChild()
 	// The referenced cluster still exists: never guess, never touch tuples.
 	m.expectLiveness(nil)
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 
 	sub := m.newSubroutine(true)
 	result, err := sub.Process(context.Background(), &kcpcorev1alpha1.LogicalCluster{})
@@ -272,7 +272,7 @@ func TestRekeyTuplesSubroutine_TreatsForbiddenAsDead(t *testing.T) {
 	m.expectRead(staleCreatorTuple())
 	m.expectNoSameNameChild()
 	m.expectLiveness(apierrors.NewForbidden(lcGroupResource, "cluster", assert.AnError))
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 
 	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).Return(&openfgav1.WriteResponse{}, nil).Times(2)
 
@@ -317,7 +317,7 @@ func TestRekeyTuplesSubroutine_ChunksGroupsOver100Tuples(t *testing.T) {
 	m.expectRead(stale...)
 	m.expectNoSameNameChild()
 	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 
 	var ops []string
 	m.fgaClient.EXPECT().Write(mock.Anything, mock.Anything).
@@ -354,7 +354,7 @@ func TestRekeyTuplesSubroutine_SkipsAllWhenSameNameDescendantAccountExists(t *te
 	m.expectRead(staleCreatorTuple(), staleOwnerGroupTuple())
 	// The guard finds an Account named like the org in the org workspace.
 	m.clusterClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: rekeyTestOrg}, mock.Anything).Return(nil)
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 	// Note: no liveness and no Write expectations are set, so any FGA write or
 	// kcp client call fails the test.
 
@@ -405,7 +405,7 @@ func TestRekeyTuplesSubroutine_IgnoresForeignObjectTypeKeys(t *testing.T) {
 	m.expectRead(apiExportTuple, staleCreatorTuple())
 	m.expectNoSameNameChild()
 	m.expectLiveness(apierrors.NewNotFound(lcGroupResource, "cluster"))
-	m.cluster.EXPECT().GetEventRecorderFor(mock.Anything).Return(m.recorder)
+	m.cluster.EXPECT().GetEventRecorder(mock.Anything).Return(m.recorder)
 
 	var written []*openfgav1.TupleKey
 	var deletedKeys []*openfgav1.TupleKeyWithoutCondition

--- a/operators/security-operator/internal/subroutine/rekey_tuples_test.go
+++ b/operators/security-operator/internal/subroutine/rekey_tuples_test.go
@@ -307,7 +307,7 @@ func TestRekeyTuplesSubroutine_ChunksGroupsOver100Tuples(t *testing.T) {
 	m.expectOrgContext()
 
 	stale := make([]pmcorev1alpha1.Tuple, 0, 250)
-	for i := 0; i < 250; i++ {
+	for i := range 250 {
 		stale = append(stale, pmcorev1alpha1.Tuple{
 			User:     fmt.Sprintf("user:member-%d", i),
 			Relation: "assignee",


### PR DESCRIPTION
Fixes #214.

When an org workspace is deleted and re-created under the same name, its logical cluster hash changes, but the OpenFGA role tuples keep the old hash in their object keys. The operator re-creates only the creator's tuples (`Account.spec.creator`), so every other member silently drops off the org roster — we hit this in production and had to reconstruct rosters by hand from the orphaned tuples (which survive in the store because it is adopted by name).

This adds an org-level scan-and-re-key subroutine to the OrgLogicalCluster controller, gated behind `--rekey-orphaned-tuples-enabled` (default off — without the flag, behavior is byte-identical):

- tuple filters are objectType-restricted so only role/org tuples for the reconciled org are touched (nothing else in a shared store)
- before re-keying, the old cluster is checked for liveness via a LogicalCluster GET; anything but NotFound/Forbidden fails closed (skip + requeue) so tuples of a live cluster are never moved
- writes-first-deletes-after, chunked at the 100-tuple write cap; a same-name descendant Account in the org workspace skips the entire pass (prevents cross-account key capture)
- emits event `OrphanedTuplesRekeyed` and metric `security_operator_rekeyed_tuples_total{result}`; idempotent on re-reconcile

Validation: all unit packages green (`go test ./internal/...`), table-driven tests for the filter/re-key/liveness/guard paths (+742 test lines); gofmt/gci clean. The kcp-envtest integration suite was not run locally (missing kcp binary) — CI covers it.

Related: #104 proposes a delete-only orphan sweep; note that deleting orphaned tuples destroys the only recoverable record of pre-re-creation rosters — re-keying preserves them. The flag default keeps this opt-in until operators choose the behavior.
