### PR TITLE
feat(golang-commons): add PS256 signature algorithm support

### DIFF
--- a/golang-commons/middleware/token.go
+++ b/golang-commons/middleware/token.go
@@ -27,7 +27,7 @@ import (
 
 const tokenAuthPrefix = "BEARER"
 
-var signatureAlgorithms = []jose.SignatureAlgorithm{jose.RS256}
+var signatureAlgorithms = []jose.SignatureAlgorithm{jose.RS256, jose.PS256}
 
 // StoreWebToken returns middleware that extracts a JWT from the HTTP `Authorization` header
 // and stores it in the request pmcontext for downstream handlers.


### PR DESCRIPTION
## Summary
- Add PS256 (RSA-PSS) to accepted JWT signature algorithms alongside RS256
- System-trust issuer (`api.trust-dev.tools.sap`) signs JWTs with PS256, causing parse failures: `unexpected signature algorithm "PS256"; expected ["RS256"]`

## Test plan
- [x] `go test ./golang-commons/middleware/...` passes