### PR TITLE
Drop in-repo replaces

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -437,17 +437,6 @@ tasks:
         # Forward version-pin replaces from go.work into the module's go.mod so
         # it resolves standalone, e.g. in docker builds.
         replaces=$(GOWORK= go work edit -json | jq -r '.Replace[] | "\(.Old.Path)=\(.New.Path)@\(.New.Version)"')
-        {{- if not (has (index .MATCH 0) .LIBRARIES)}}
-        # Point in-repo dependencies at their source tree for the same reason.
-        # This also decouples this component from needing a release of the used library.
-        up=$(printf '%s' "$dir" | awk -F/ '{for (i = 1; i <= NF; i++) printf "../"}')
-        for d in $(GOWORK= go work edit -json | jq -r '.Use[].DiskPath'); do
-          if [ "$d" != "./$dir" ]; then
-            p=$(go mod edit -json "$d/go.mod" | jq -r '.Module.Path')
-            replaces="$replaces $p=$up${d#./}"
-          fi
-        done
-        {{- end}}
         cd "$dir"
         go mod edit $(printf ' -replace=%s' $replaces)
         go mod tidy

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -412,9 +412,9 @@ tasks:
   tidy:
     desc: Tidy every module's go.mod (standalone) and re-sync the workspace.
     cmds:
+      - go work sync
       - for: {var: COMPONENTS}
         cmd: task tidy-{{.ITEM}}
-      - go work sync
       # ref: https://github.com/golang/go/issues/63901
       # TLDR: go work sync doesn't actually everything.
       # We force fill the go.work.sum by downloading all deps.

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -3,7 +3,7 @@ module go.platform-mesh.io/apis
 go 1.26.0
 
 require (
-	github.com/kcp-dev/kcp-operator/sdk v0.0.0-00010101000000-000000000000
+	github.com/kcp-dev/kcp-operator/sdk v0.8.1-0.20260807064708-a6575ae6d6bb
 	github.com/kcp-dev/sdk v0.32.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1

--- a/go.work.sum
+++ b/go.work.sum
@@ -1711,6 +1711,7 @@ go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp
 go.opentelemetry.io/proto/otlp v1.7.0/go.mod h1:fSKjH6YJ7HDlwzltzyMj036AJ3ejJLCgCSHGj4efDDo=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.platform-mesh.io/account-operator v0.0.0-20260622214312-00032b10b96f/go.mod h1:CAm4BkaiJkSXmwDW6DgdEqHjnaZrlJIWXTVyJVwC+7A=
 go.platform-mesh.io/apis v0.0.0-20260622122527-e12b466d38ab/go.mod h1:oJLBH8/hifu56PqrnGQsr+n1ijw6jMwTKD+uRoFN8PM=
 go.platform-mesh.io/subroutines v0.0.0-20260622133610-fe2f9154f2a9/go.mod h1:AvyfyWGWHzL0mKS1oEuGzlTuVq28RoQpKDqdm6XArmc=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/go.work.sum
+++ b/go.work.sum
@@ -770,6 +770,7 @@ github.com/egymgmbh/go-prefix-writer v0.0.0-20180609083313-7326ea162eca/go.mod h
 github.com/elastic/crd-ref-docs v0.2.0 h1:U17MyGX71j4qfKTvYxbR4qZGoA1hc2thy7kseGYmP+o=
 github.com/elastic/crd-ref-docs v0.2.0/go.mod h1:0bklkJhTG7nC6AVsdDi0wt5bGoqvzdZSzMMQkilZ6XM=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.11.0/go.mod h1:VnHyVMpzcLvCFt9yUz1UnCwHLhwx1WguiVDV7pTG/tI=
@@ -977,6 +978,7 @@ github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD
 github.com/google/flatbuffers v2.0.8+incompatible h1:ivUb1cGomAB101ZM1T0nOiWz9pSrTMoa9+EiY7igmkM=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
+github.com/google/gnostic-models v0.6.9/go.mod h1:CiWsm0s6BSQd1hRn8/QmxqB6BesYcbSZxsz9b0KuDBw=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-pkcs11 v0.2.1-0.20230907215043-c6f79328ddf9/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
@@ -1147,9 +1149,11 @@ github.com/kataras/sitemap v0.0.6/go.mod h1:dW4dOCNs896OR1HmG+dMLdT7JjDk7mYBzoIR
 github.com/kataras/tunnel v0.0.4 h1:sCAqWuJV7nPzGrlb0os3j49lk2JhILT0rID38NHNLpA=
 github.com/kataras/tunnel v0.0.4/go.mod h1:9FkU4LaeifdMWqZu7o20ojmW4B7hdhv2CMLwfnHGpYw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3/go.mod h1:n0+EV+LGKl1MXXqGbGcn0AaBv7hdKsdazSYuq8nM8Us=
 github.com/kcp-dev/apimachinery/v2 v2.31.0/go.mod h1:ta+d3xQkLYWBEEg8ICed+PekW3MckEYqXG4amq6Uk9Y=
 github.com/kcp-dev/apimachinery/v2 v2.31.2-0.20260505083940-abda469632ba/go.mod h1:1Rkhiwoq345wlUYtq1/P+3chL2eE1rdoIgBPwb6Y9x8=
 github.com/kcp-dev/apimachinery/v2 v2.32.0/go.mod h1:1Rkhiwoq345wlUYtq1/P+3chL2eE1rdoIgBPwb6Y9x8=
+github.com/kcp-dev/client-go v0.0.0-20250223133118-3dea338dc267/go.mod h1:1lEs8b8BYzGrMr7Q8Fs7cNVaDAWogu5lLkz5t6HtRLI=
 github.com/kcp-dev/client-go v0.28.1-0.20260511140521-487de9552c40/go.mod h1:SVLehuEWP57f8F4rKUn8hJXCFXJFtER4va77pY+x2m8=
 github.com/kcp-dev/client-go v0.32.0/go.mod h1:gSxKl91JDVAxKYOI7KBCkeVii2EBxF40qwwMZPkHLTw=
 github.com/kcp-dev/code-generator/v3 v3.31.2 h1:cApGdB8t4+M1DkMatbf3hHkR6gjt0FOM8flfh3u2WNs=
@@ -1458,6 +1462,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1471,6 +1476,7 @@ github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmq
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -1713,6 +1719,8 @@ go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzK
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.platform-mesh.io/account-operator v0.0.0-20260622214312-00032b10b96f/go.mod h1:CAm4BkaiJkSXmwDW6DgdEqHjnaZrlJIWXTVyJVwC+7A=
 go.platform-mesh.io/apis v0.0.0-20260622122527-e12b466d38ab/go.mod h1:oJLBH8/hifu56PqrnGQsr+n1ijw6jMwTKD+uRoFN8PM=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d/go.mod h1:EX3ovmUqmC0lSJPqF7Qzkaxe7SZ6HCvVMH+wGjdNLHQ=
 go.platform-mesh.io/subroutines v0.0.0-20260622133610-fe2f9154f2a9/go.mod h1:AvyfyWGWHzL0mKS1oEuGzlTuVq28RoQpKDqdm6XArmc=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -2143,6 +2151,7 @@ golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxb
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw=
 golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
@@ -2637,6 +2646,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
+gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
@@ -2685,6 +2695,7 @@ k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kms v0.35.4/go.mod h1:c/uQe/eKrWdBkvizLFW+ThLA6tTzR0RkkwJJyzDRT1g=
 k8s.io/kms v0.36.2/go.mod h1:g91diTD9h0oJCCHkTb00krlF+Qm5HTnkWLi9Q/TpRoc=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
+k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7/go.mod h1:GewRfANuJ70iYzvn+i4lezLDAFzvjxZYK1gn1lWcfas=
 k8s.io/kube-openapi v0.0.0-20250814151709-d7b6acb124c3/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
@@ -2694,6 +2705,7 @@ k8s.io/streaming v0.36.2/go.mod h1:z6fV3D+NVkoeqRMtWwlUZK6U17SY/LqNzOxWL6GyR/s=
 k8s.io/system-validators v1.12.1 h1:AY1+COTLJN/Sj0w9QzH1H0yvyF3Kl6CguMnh32WlcUU=
 k8s.io/system-validators v1.12.1/go.mod h1:awfSS706v9R12VC7u7K89FKfqVy44G+E0L1A0FX9Wmw=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
@@ -2743,6 +2755,7 @@ sigs.k8s.io/controller-runtime v0.22.1/go.mod h1:FwiwRjkRPbiN+zp2QRp7wlTCzbUXxZ/
 sigs.k8s.io/controller-tools v0.19.0 h1:OU7jrPPiZusryu6YK0jYSjPqg8Vhf8cAzluP9XGI5uk=
 sigs.k8s.io/controller-tools v0.19.0/go.mod h1:y5HY/iNDFkmFla2CfQoVb2AQXMsBk4ad84iR1PLANB0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/knftables v0.0.17 h1:wGchTyRF/iGTIjd+vRaR1m676HM7jB8soFtyr/148ic=
 sigs.k8s.io/knftables v0.0.17/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/knftables v0.0.21 h1:mby+JtzhJH1Ucnq++ZJaM+ViQBY5JzIyX4bSCP8K5YQ=

--- a/operators/account-operator/go.mod
+++ b/operators/account-operator/go.mod
@@ -112,10 +112,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
-
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
-
-replace go.platform-mesh.io/subroutines => ../../subroutines
-
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/account-operator/go.mod
+++ b/operators/account-operator/go.mod
@@ -28,11 +28,13 @@ require (
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -55,8 +57,10 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -89,6 +93,8 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -111,5 +117,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/account-operator/go.sum
+++ b/operators/account-operator/go.sum
@@ -195,6 +195,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/backup-operator/go.mod
+++ b/operators/backup-operator/go.mod
@@ -108,10 +108,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/backup-operator/go.mod
+++ b/operators/backup-operator/go.mod
@@ -22,11 +22,13 @@ require (
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
@@ -49,8 +51,10 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -83,6 +87,8 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -107,8 +113,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/backup-operator/go.sum
+++ b/operators/backup-operator/go.sum
@@ -192,6 +192,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/extension-manager-operator/go.mod
+++ b/operators/extension-manager-operator/go.mod
@@ -38,6 +38,7 @@ replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/mu
 
 require (
 	github.com/99designs/gqlgen v0.17.91 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -68,7 +70,9 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -106,6 +110,8 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
@@ -127,8 +133,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/extension-manager-operator/go.mod
+++ b/operators/extension-manager-operator/go.mod
@@ -128,10 +128,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/extension-manager-operator/go.sum
+++ b/operators/extension-manager-operator/go.sum
@@ -232,6 +232,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/kcp-migration-operator/go.mod
+++ b/operators/kcp-migration-operator/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
@@ -108,8 +110,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/kcp-migration-operator/go.mod
+++ b/operators/kcp-migration-operator/go.mod
@@ -109,10 +109,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/kcp-migration-operator/go.sum
+++ b/operators/kcp-migration-operator/go.sum
@@ -192,6 +192,10 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/platform-mesh-deployer/go.mod
+++ b/operators/platform-mesh-deployer/go.mod
@@ -4,20 +4,17 @@ go 1.26.4
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885
 
-
-
-
 require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/cel-go v0.30.0
-	github.com/kcp-dev/kcp-operator/sdk v0.0.0-00010101000000-000000000000
+	github.com/kcp-dev/kcp-operator/sdk v0.8.1-0.20260807064708-a6575ae6d6bb
 	github.com/kcp-dev/kcp/sdk v0.28.3
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
-	go.platform-mesh.io/apis v0.0.0-00010101000000-000000000000
+	go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d
 	go.platform-mesh.io/golang-commons v0.18.1
 	golang.org/x/mod v0.38.0
 	k8s.io/api v0.36.3

--- a/operators/platform-mesh-deployer/go.mod
+++ b/operators/platform-mesh-deployer/go.mod
@@ -4,11 +4,8 @@ go 1.26.4
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 require (
 	github.com/go-logr/logr v1.4.4

--- a/operators/platform-mesh-deployer/go.sum
+++ b/operators/platform-mesh-deployer/go.sum
@@ -208,6 +208,10 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d h1:jDN5ZiJDRwm5haR30vkH7fIOhcrBeRQ8VkIxEczMVhc=
+go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d/go.mod h1:EX3ovmUqmC0lSJPqF7Qzkaxe7SZ6HCvVMH+wGjdNLHQ=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/resource-broker/go.mod
+++ b/operators/resource-broker/go.mod
@@ -2,7 +2,6 @@ module go.platform-mesh.io/resource-broker
 
 go 1.26.3
 
-replace go.platform-mesh.io/apis => ../../apis
 
 require (
 	github.com/go-logr/logr v1.4.4
@@ -100,8 +99,6 @@ require (
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/resource-broker/go.mod
+++ b/operators/resource-broker/go.mod
@@ -2,7 +2,6 @@ module go.platform-mesh.io/resource-broker
 
 go 1.26.3
 
-
 require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/cel-go v0.30.0
@@ -11,8 +10,8 @@ require (
 	github.com/kcp-dev/multicluster-provider/client v0.8.0
 	github.com/kcp-dev/sdk v0.32.3
 	github.com/stretchr/testify v1.11.1
-	go.platform-mesh.io/apis v0.0.3
-	go.platform-mesh.io/golang-commons v0.18.1
+	go.platform-mesh.io/apis v0.0.4-0.20260809133610-db141559915f
+	go.platform-mesh.io/golang-commons v0.18.2-0.20260809133610-db141559915f
 	go.platform-mesh.io/subroutines v0.6.1
 	golang.org/x/sync v0.22.0
 	k8s.io/api v0.36.3
@@ -98,7 +97,5 @@ require (
 )
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
-
-
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/resource-broker/go.sum
+++ b/operators/resource-broker/go.sum
@@ -152,6 +152,12 @@ go.opentelemetry.io/otel/metric v1.45.0 h1:7Eg1uH7CJ5cXv9is6tnBe1FI6rj1nwUdbFypR
 go.opentelemetry.io/otel/metric v1.45.0/go.mod h1:HAPbm1nd3p1PmFH7v2dR+6BjXxw+Lq4a2+pndMAm08s=
 go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOyVhxag=
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
+go.platform-mesh.io/apis v0.0.4-0.20260809133610-db141559915f h1:+CksS6Mya9yxzRAXgpqFnKkihPm3+cVLJed43imkG7c=
+go.platform-mesh.io/apis v0.0.4-0.20260809133610-db141559915f/go.mod h1:EX3ovmUqmC0lSJPqF7Qzkaxe7SZ6HCvVMH+wGjdNLHQ=
+go.platform-mesh.io/golang-commons v0.18.2-0.20260809133610-db141559915f h1:ZtouMa2NskOdap6iFKGuHYwGrPcYc2U+JroUovN+Xl0=
+go.platform-mesh.io/golang-commons v0.18.2-0.20260809133610-db141559915f/go.mod h1:Z2ZeQrB4e46rmtg/Gf8iY2j9/PA2DRjAUXxTDhjw7q8=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/search-operator/go.mod
+++ b/operators/search-operator/go.mod
@@ -25,12 +25,14 @@ replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/mu
 
 require (
 	github.com/99designs/gqlgen v0.17.91 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
@@ -54,8 +56,10 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -92,6 +96,8 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -115,8 +121,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/search-operator/go.mod
+++ b/operators/search-operator/go.mod
@@ -116,10 +116,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/search-operator/go.sum
+++ b/operators/search-operator/go.sum
@@ -220,6 +220,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/security-operator/go.mod
+++ b/operators/security-operator/go.mod
@@ -138,10 +138,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/security-operator/go.mod
+++ b/operators/security-operator/go.mod
@@ -41,6 +41,7 @@ replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/mu
 
 require (
 	github.com/99designs/gqlgen v0.17.91 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.15.1 // indirect
@@ -73,7 +75,9 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -118,6 +122,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
@@ -137,8 +142,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/security-operator/go.sum
+++ b/operators/security-operator/go.sum
@@ -245,6 +245,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/tenancy-operator/go.mod
+++ b/operators/tenancy-operator/go.mod
@@ -138,7 +138,6 @@ require (
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
-replace go.platform-mesh.io/apis => ../../apis
 
 // We use the VW SDK and that module requires a whole set of replace directives, sadly.
 replace (
@@ -173,6 +172,4 @@ replace (
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines

--- a/operators/tenancy-operator/go.mod
+++ b/operators/tenancy-operator/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
-	go.platform-mesh.io/apis v0.0.3
+	go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d
 	go.platform-mesh.io/golang-commons v0.18.1
 	golang.org/x/oauth2 v0.36.0
 	k8s.io/api v0.36.3

--- a/operators/tenancy-operator/go.mod
+++ b/operators/tenancy-operator/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
@@ -138,7 +140,6 @@ require (
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
-
 // We use the VW SDK and that module requires a whole set of replace directives, sadly.
 replace (
 	k8s.io/api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20260602065202-e006560fc76a
@@ -171,5 +172,3 @@ replace (
 )
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885
-
-

--- a/operators/tenancy-operator/go.sum
+++ b/operators/tenancy-operator/go.sum
@@ -263,6 +263,10 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d h1:jDN5ZiJDRwm5haR30vkH7fIOhcrBeRQ8VkIxEczMVhc=
+go.platform-mesh.io/apis v0.0.4-0.20260806145628-e7fde50f913d/go.mod h1:EX3ovmUqmC0lSJPqF7Qzkaxe7SZ6HCvVMH+wGjdNLHQ=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/operators/terminal-controller-manager/go.mod
+++ b/operators/terminal-controller-manager/go.mod
@@ -106,10 +106,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/terminal-controller-manager/go.mod
+++ b/operators/terminal-controller-manager/go.mod
@@ -24,11 +24,13 @@ require (
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -52,8 +54,10 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -83,6 +87,8 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -105,8 +111,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/operators/terminal-controller-manager/go.sum
+++ b/operators/terminal-controller-manager/go.sum
@@ -190,6 +190,12 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/services/iam-service/go.mod
+++ b/services/iam-service/go.mod
@@ -32,6 +32,15 @@ require (
 	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260806063852-035f642f8818
 )
 
+require (
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
+	github.com/google/cel-go v0.30.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
+	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
+)
+
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.1-0.20260714141811-833f063357f8
 
 require (
@@ -130,9 +139,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/iam-service/go.mod
+++ b/services/iam-service/go.mod
@@ -131,12 +131,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/account-operator => ../../operators/account-operator
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/iam-service/go.sum
+++ b/services/iam-service/go.sum
@@ -237,6 +237,14 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/account-operator v0.0.0-20260622214312-00032b10b96f h1:18uUSK4xdLgv9Aw4SWDVr7GtafLxpLD7spG6Fr4HbIE=
+go.platform-mesh.io/account-operator v0.0.0-20260622214312-00032b10b96f/go.mod h1:CAm4BkaiJkSXmwDW6DgdEqHjnaZrlJIWXTVyJVwC+7A=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
+go.platform-mesh.io/subroutines v0.6.1 h1:ejeC97tKlFyhfo2AIxANya7y6dzPgutJH/Tm0fCwPa0=
+go.platform-mesh.io/subroutines v0.6.1/go.mod h1:hS3XeKAMoJuMJB5CqLiT/RtSOOUXKC3m/eKI1MKjlok=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/services/kubernetes-graphql-gateway/go.mod
+++ b/services/kubernetes-graphql-gateway/go.mod
@@ -142,10 +142,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/kubernetes-graphql-gateway/go.mod
+++ b/services/kubernetes-graphql-gateway/go.mod
@@ -51,6 +51,7 @@ replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/mu
 
 require (
 	cel.dev/expr v0.25.1 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -61,6 +62,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
@@ -84,6 +86,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
@@ -123,6 +126,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
@@ -141,8 +145,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/kubernetes-graphql-gateway/go.sum
+++ b/services/kubernetes-graphql-gateway/go.sum
@@ -245,6 +245,10 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/services/search-service/go.mod
+++ b/services/search-service/go.mod
@@ -66,8 +66,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/search-service/go.mod
+++ b/services/search-service/go.mod
@@ -67,10 +67,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/search-service/go.sum
+++ b/services/search-service/go.sum
@@ -132,6 +132,10 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
+go.platform-mesh.io/golang-commons v0.18.1 h1:jg9k2FIRI3dON16y+nQVJ625gHAA3UfhcNR6PmPyFpo=
+go.platform-mesh.io/golang-commons v0.18.1/go.mod h1:ersNhRizduHTrodcTF/JGuOJYb30yzro7sk+0VRl0cY=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=

--- a/services/virtual-workspaces/go.mod
+++ b/services/virtual-workspaces/go.mod
@@ -202,10 +202,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.platform-mesh.io/apis => ../../apis
 
-replace go.platform-mesh.io/golang-commons => ../../golang-commons
 
-replace go.platform-mesh.io/subroutines => ../../subroutines
 
 replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/virtual-workspaces/go.mod
+++ b/services/virtual-workspaces/go.mod
@@ -63,6 +63,7 @@ replace (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cyphar.com/go-pathrs v0.2.2 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -152,6 +153,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -201,8 +203,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-
-
-
-replace github.com/kcp-dev/kcp-operator/sdk => github.com/ntnn/kcp-operator/sdk v0.8.1-0.20260726154422-be62fa798885

--- a/services/virtual-workspaces/go.sum
+++ b/services/virtual-workspaces/go.sum
@@ -309,6 +309,8 @@ go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOy
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.platform-mesh.io/apis v0.0.3 h1:UEE6UJo07NG8rkgdHxox0tPAfHZb0xkMcrJe7RmQeq0=
+go.platform-mesh.io/apis v0.0.3/go.mod h1:EVGHwmU3TD2fihHslTET/J94rW8LWagQzW8/vgRLAkA=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
1. Do the `go work sync` before tidying each module. 
  That should put all modules on the same dependencies without needing two runs.
2. Drop in-repo replace
  We did this because CI failed in the separate API module but this doesn't make a ton of sense. Instead we should ensure that CI is using the go.work where needed.