### PR TITLE
chore: add parent account to the search index for pre-filtering

### DIFF
--- a/operators/search-operator/hack/kubeconfig-copy.sh
+++ b/operators/search-operator/hack/kubeconfig-copy.sh
@@ -36,7 +36,18 @@ echo "Checking for Kind cluster 'platform-mesh'..."
 if [ -n "${KIND_EXPERIMENTAL_PROVIDER:-}" ]; then
   export KIND_EXPERIMENTAL_PROVIDER
 fi
-if ! kind get clusters 2>/dev/null | grep -q "^platform-mesh$"; then
+
+# kind get clusters is broken with some podman versions (Go template incompatibility).
+# Fall back to querying podman directly when KIND_EXPERIMENTAL_PROVIDER=podman.
+_cluster_found=false
+if kind get clusters 2>/dev/null | grep -q "^platform-mesh$"; then
+  _cluster_found=true
+elif [ "${KIND_EXPERIMENTAL_PROVIDER:-}" = "podman" ] && \
+     podman ps -a --filter label=io.x-k8s.kind.cluster --format "{{.Names}}" 2>/dev/null | grep -q "^platform-mesh-"; then
+  _cluster_found=true
+fi
+
+if ! $_cluster_found; then
   echo "Error: Kind cluster 'platform-mesh' not found"
   echo "Available clusters:"
   kind get clusters 2>/dev/null || echo "(none)"

--- a/operators/search-operator/internal/opensearch/document.go
+++ b/operators/search-operator/internal/opensearch/document.go
@@ -27,7 +27,7 @@ import (
 
 // DefaultFilterableFields are always extractable for every resource and are
 // injected as filterable facets regardless of a SearchConfig's configuration.
-var DefaultFilterableFields = []string{"kind", "name", "namespace", "cluster_name", "workspace_path"}
+var DefaultFilterableFields = []string{"kind", "name", "namespace", "cluster_name", "workspace_path", "account_fga_object"}
 
 // FieldMappings holds the dot-notation field paths that drive the dynamic part of the index mapping.
 type FieldMappings struct {

--- a/operators/search-operator/internal/opensearch/document_test.go
+++ b/operators/search-operator/internal/opensearch/document_test.go
@@ -148,3 +148,46 @@ func TestDefaultIndexMappingSemanticWinsPriority(t *testing.T) {
 		t.Fatalf("spec.title type = %v, want semantic (priority)", got)
 	}
 }
+
+func TestSetDefaultFilterableFieldsAllocatesNilMap(t *testing.T) {
+	doc := &ResourceDocument{
+		Kind:          "ConfigMap",
+		Name:          "my-cm",
+		Namespace:     "default",
+		ClusterName:   "cluster-1",
+		WorkspacePath: "root:org:ws",
+	}
+
+	doc.SetDefaultFilterableFields()
+
+	want := map[string]any{
+		"kind":           "ConfigMap",
+		"name":           "my-cm",
+		"namespace":      "default",
+		"cluster_name":   "cluster-1",
+		"workspace_path": "root:org:ws",
+	}
+	for k, v := range want {
+		if got := doc.FilterableFields[k]; got != v {
+			t.Errorf("FilterableFields[%q] = %v, want %v", k, got, v)
+		}
+	}
+}
+
+func TestSetDefaultFilterableFieldsPreservesConfiguredFields(t *testing.T) {
+	doc := &ResourceDocument{
+		Kind: "ConfigMap",
+		FilterableFields: map[string]any{
+			"status.phase": "Ready",
+		},
+	}
+
+	doc.SetDefaultFilterableFields()
+
+	if got := doc.FilterableFields["status.phase"]; got != "Ready" {
+		t.Errorf("configured field status.phase = %v, want Ready", got)
+	}
+	if got := doc.FilterableFields["kind"]; got != "ConfigMap" {
+		t.Errorf("FilterableFields[kind] = %v, want ConfigMap", got)
+	}
+}

--- a/operators/search-operator/internal/subroutine/apibinding_watcher.go
+++ b/operators/search-operator/internal/subroutine/apibinding_watcher.go
@@ -286,9 +286,9 @@ type searchConfigFilter struct {
 
 func newSearchConfigFilter(cfg *pmsearchv1alpha1.SearchConfig) searchConfigFilter {
 	return searchConfigFilter{
-		excluded: sets.New[string](cfg.Spec.ExcludedFields...),
-		exact:    sets.New[string](cfg.Spec.ExactFields...),
-		semantic: sets.New[string](cfg.Spec.SemanticFields...),
+		excluded: sets.New(cfg.Spec.ExcludedFields...),
+		exact:    sets.New(cfg.Spec.ExactFields...),
+		semantic: sets.New(cfg.Spec.SemanticFields...),
 	}
 }
 

--- a/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
+++ b/operators/search-operator/internal/subroutine/indexable_resource_watcher.go
@@ -168,6 +168,7 @@ func (s *IndexableResourceWatcherSubroutine) Process(ctx context.Context, instan
 	doc.SemanticFields = extractStringConfiguredFields(resource, searchIndex.Spec.SemanticFields)
 	doc.FilterableFields = extractFilterableFields(resource, searchIndex.Spec.FilterableFields)
 	doc.SetDefaultFilterableFields()
+	doc.FilterableFields["account_fga_object"] = buildFGAObjectName(pmcorev1alpha1.GroupName, pmsearchv1alpha1.AccountKind, orgID, orgName, "")
 
 	accountInfo, err := s.getAccountInfo(ctx, workspacePath, gvk, resource)
 	if err != nil {


### PR DESCRIPTION
This PR is a preparation for pre-filtering the search results to what the user querying es even allowed to see as of [ADR 012: Search Authorization](https://github.com/platform-mesh/architecture/pull/48).

- Fetch most adjacent account to whatever Resource is being indexed
- Extract FGA object for this account via convention
- Register Account FGA object as exact filter

# Current State

1. User requests query results
2. Search Service requests everything from OpenSearch that matches
3. Open Search batch-checks the response via the Authorization backend
4. When access is denied the invalid results are discarded and backfilled
5. User gets only documents he's allowed to see

# Desired State

1. User requests query results
2. Search Service checks which accounts a user can see
3. Search Service asks OpenSearch for matches + the account filter
4. Open Search still batch-checks (no change expected)
6. User gets only documents he's allowed to see

## Account Discovery

Accounts can be pre-fetched via `fga query list-objects "user:<email>" member "core_platform-mesh_io_account"`

So the tuple in the index should be of the form: `core_platform-mesh_io_account:<cluster-id>/<account-name>`