### PR TITLE
feat: add entityType validation for ContentConfiguration

### DIFF
--- a/operators/extension-manager-operator/Taskfile.yaml
+++ b/operators/extension-manager-operator/Taskfile.yaml
@@ -131,7 +131,7 @@ tasks:
   test:
     deps: [tools:kcp]
     cmds:
-      - go test ./...
+      - go test -race -count=1 ./...
   test-e2e:
     deps: [tools:kcp, tools:envtest, clean]
     env:

--- a/operators/extension-manager-operator/cmd/server.go
+++ b/operators/extension-manager-operator/cmd/server.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -33,8 +32,6 @@ import (
 	platformmeshcontext "go.platform-mesh.io/golang-commons/context"
 	"go.platform-mesh.io/golang-commons/traces"
 
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -116,9 +113,9 @@ func RunServer(_ *cobra.Command, _ []string) { // coverage-ignore
 func initServerEntityTypeRegistry(ctx context.Context) *validation.EntityTypeRegistry { // coverage-ignore
 	registry := validation.NewEntityTypeRegistry()
 
-	k8sClient := buildServerK8sClient()
-	if k8sClient == nil {
-		return registry
+	k8sClient, err := buildServerK8sClient()
+	if err != nil {
+		log.Fatal().Err(err).Msg("entity type validation is enabled but failed to connect to cluster")
 	}
 
 	loadRegistryFromCluster(ctx, k8sClient, registry)
@@ -127,30 +124,17 @@ func initServerEntityTypeRegistry(ctx context.Context) *validation.EntityTypeReg
 	return registry
 }
 
-func buildServerK8sClient() ctrlruntimeclient.Reader { // coverage-ignore
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	var restCfg *rest.Config
-	var err error
-	if kubeconfigPath != "" {
-		restCfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to load kubeconfig, entity type validation will only recognize 'global'")
-			return nil
-		}
-	} else {
-		restCfg, err = rest.InClusterConfig()
-		if err != nil {
-			log.Warn().Err(err).Msg("not running in cluster, entity type validation will only recognize 'global'")
-			return nil
-		}
+func buildServerK8sClient() (ctrlruntimeclient.Reader, error) { // coverage-ignore
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	k8sClient, err := ctrlruntimeclient.New(restCfg, ctrlruntimeclient.Options{Scheme: scheme})
 	if err != nil {
-		log.Warn().Err(err).Msg("failed to create k8s client, entity type validation will only recognize 'global'")
-		return nil
+		return nil, err
 	}
-	return k8sClient
+	return k8sClient, nil
 }
 
 func loadRegistryFromCluster(ctx context.Context, k8sClient ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) { // coverage-ignore

--- a/operators/extension-manager-operator/cmd/server.go
+++ b/operators/extension-manager-operator/cmd/server.go
@@ -18,19 +18,25 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
+	pmuiv1alpha1 "go.platform-mesh.io/apis/ui/v1alpha1"
 	"go.platform-mesh.io/extension-manager-operator/internal/server"
 	"go.platform-mesh.io/extension-manager-operator/pkg/validation"
 	platformmeshcontext "go.platform-mesh.io/golang-commons/context"
 	"go.platform-mesh.io/golang-commons/traces"
 
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -70,8 +76,14 @@ func RunServer(_ *cobra.Command, _ []string) { // coverage-ignore
 	// Create Prometheus metrics handler
 	metricsHandler := promhttp.Handler()
 
+	// Initialize entity type registry from cluster if enabled
+	var registry *validation.EntityTypeRegistry
+	if serverCfg.EntityTypeValidationEnabled {
+		registry = initServerEntityTypeRegistry(ctx)
+	}
+
 	// Register Prometheus metrics endpoint
-	rt := server.CreateRouter(defaultCfg.IsLocal, log, validation.NewContentConfiguration())
+	rt := server.CreateRouter(defaultCfg.IsLocal, log, validation.NewContentConfiguration(), registry)
 	rt.Handle("/metrics", metricsHandler)
 
 	srv := &http.Server{
@@ -99,4 +111,81 @@ func RunServer(_ *cobra.Command, _ []string) { // coverage-ignore
 		log.Error().Err(err).Msg("Graceful shutdown failed")
 	}
 	log.Info().Msg("Server stopped")
+}
+
+func initServerEntityTypeRegistry(ctx context.Context) *validation.EntityTypeRegistry { // coverage-ignore
+	registry := validation.NewEntityTypeRegistry()
+
+	k8sClient := buildServerK8sClient()
+	if k8sClient == nil {
+		return registry
+	}
+
+	loadRegistryFromCluster(ctx, k8sClient, registry)
+	log.Info().Int("entityTypes", len(registry.KnownTypes())).Msg("initialized server entity type registry")
+	go refreshRegistryPeriodically(ctx, k8sClient, registry)
+	return registry
+}
+
+func buildServerK8sClient() ctrlruntimeclient.Reader { // coverage-ignore
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	var restCfg *rest.Config
+	var err error
+	if kubeconfigPath != "" {
+		restCfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to load kubeconfig, entity type validation will only recognize 'global'")
+			return nil
+		}
+	} else {
+		restCfg, err = rest.InClusterConfig()
+		if err != nil {
+			log.Warn().Err(err).Msg("not running in cluster, entity type validation will only recognize 'global'")
+			return nil
+		}
+	}
+
+	k8sClient, err := ctrlruntimeclient.New(restCfg, ctrlruntimeclient.Options{Scheme: scheme})
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to create k8s client, entity type validation will only recognize 'global'")
+		return nil
+	}
+	return k8sClient
+}
+
+func loadRegistryFromCluster(ctx context.Context, k8sClient ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) { // coverage-ignore
+	var ccList pmuiv1alpha1.ContentConfigurationList
+	if err := k8sClient.List(ctx, &ccList); err != nil {
+		log.Warn().Err(err).Msg("failed to list ContentConfigurations, entity type validation will only recognize 'global'")
+		return
+	}
+
+	var configs []validation.ContentConfiguration
+	for _, cc := range ccList.Items {
+		if cc.Status.ConfigurationResult == "" {
+			continue
+		}
+		var parsed validation.ContentConfiguration
+		if err := json.Unmarshal([]byte(cc.Status.ConfigurationResult), &parsed); err != nil {
+			log.Warn().Err(err).Str("name", cc.Name).Msg("failed to parse ConfigurationResult for entity type registry")
+			continue
+		}
+		configs = append(configs, parsed)
+	}
+
+	registry.Bulkload(configs)
+	log.Debug().Int("entityTypes", len(registry.KnownTypes())).Msg("refreshed server entity type registry")
+}
+
+func refreshRegistryPeriodically(ctx context.Context, k8sClient ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) { // coverage-ignore
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			loadRegistryFromCluster(ctx, k8sClient, registry)
+		}
+	}
 }

--- a/operators/extension-manager-operator/internal/config/config.go
+++ b/operators/extension-manager-operator/internal/config/config.go
@@ -21,31 +21,37 @@ import (
 )
 
 type ServerConfig struct {
-	ServerPort string
+	ServerPort                  string
+	EntityTypeValidationEnabled bool
 }
 
 func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
-		ServerPort: "8088",
+		ServerPort:                  "8088",
+		EntityTypeValidationEnabled: false,
 	}
 }
 
 func (c *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ServerPort, "server-port", c.ServerPort, "Set the server port")
+	fs.BoolVar(&c.EntityTypeValidationEnabled, "entity-type-validation-enabled", c.EntityTypeValidationEnabled, "Enable entityType validation for ContentConfigurations")
 }
 
 type OperatorConfig struct {
 	KCPAPIExportEndpointSliceName          string
 	SubroutinesContentConfigurationEnabled bool
+	EntityTypeValidationEnabled            bool
 }
 
 func NewOperatorConfig() *OperatorConfig {
 	return &OperatorConfig{
 		SubroutinesContentConfigurationEnabled: true,
+		EntityTypeValidationEnabled:            false,
 	}
 }
 
 func (c *OperatorConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KCPAPIExportEndpointSliceName, "kcp-api-export-endpoint-slice-name", c.KCPAPIExportEndpointSliceName, "Optional APIExportEndpointSlice name to reconcile against")
 	fs.BoolVar(&c.SubroutinesContentConfigurationEnabled, "subroutines-content-configuration-enabled", c.SubroutinesContentConfigurationEnabled, "Enable the content configuration subroutine")
+	fs.BoolVar(&c.EntityTypeValidationEnabled, "entity-type-validation-enabled", c.EntityTypeValidationEnabled, "Enable entityType validation for ContentConfigurations")
 }

--- a/operators/extension-manager-operator/internal/controller/contentconfiguration_controller.go
+++ b/operators/extension-manager-operator/internal/controller/contentconfiguration_controller.go
@@ -56,7 +56,11 @@ func NewContentConfigurationReconciler(log *logger.Logger, mgr mcmanager.Manager
 			registry = validation.NewEntityTypeRegistry()
 			reader = mgr.GetLocalManager().GetClient()
 		}
-		subs = append(subs, extsub.NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, reader, registry))
+		sub, err := extsub.NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, reader, registry)
+		if err != nil {
+			panic("failed to create ContentConfigurationSubroutine: " + err.Error())
+		}
+		subs = append(subs, sub)
 	}
 	lc := lifecycle.New(mgr, contentConfigurationReconcilerName, func() ctrlruntimeclient.Object {
 		return &pmuiv1alpha1.ContentConfiguration{}

--- a/operators/extension-manager-operator/internal/controller/contentconfiguration_controller.go
+++ b/operators/extension-manager-operator/internal/controller/contentconfiguration_controller.go
@@ -50,7 +50,13 @@ type ContentConfigurationReconciler struct {
 func NewContentConfigurationReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.OperatorConfig) *ContentConfigurationReconciler {
 	var subs []subroutines.Subroutine
 	if cfg.SubroutinesContentConfigurationEnabled {
-		subs = append(subs, extsub.NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient))
+		var registry *validation.EntityTypeRegistry
+		var reader ctrlruntimeclient.Reader
+		if cfg.EntityTypeValidationEnabled {
+			registry = validation.NewEntityTypeRegistry()
+			reader = mgr.GetLocalManager().GetClient()
+		}
+		subs = append(subs, extsub.NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, reader, registry))
 	}
 	lc := lifecycle.New(mgr, contentConfigurationReconcilerName, func() ctrlruntimeclient.Object {
 		return &pmuiv1alpha1.ContentConfiguration{}

--- a/operators/extension-manager-operator/internal/server/router.go
+++ b/operators/extension-manager-operator/internal/server/router.go
@@ -31,6 +31,7 @@ func CreateRouter(
 	isLocal bool,
 	log *logger.Logger,
 	validator validation.ExtensionConfiguration,
+	registry *validation.EntityTypeRegistry,
 ) *chi.Mux {
 	router := chi.NewRouter()
 
@@ -49,7 +50,7 @@ func CreateRouter(
 		router.Use(rl.Handler)
 	}
 
-	vh := NewHttpValidateHandler(log, validator)
+	vh := NewHttpValidateHandler(log, validator, registry)
 
 	router.MethodFunc(http.MethodPost, "/validate", vh.HandlerValidate)
 	router.MethodFunc(http.MethodGet, "/healthz", vh.HandlerHealthz)

--- a/operators/extension-manager-operator/internal/server/router_test.go
+++ b/operators/extension-manager-operator/internal/server/router_test.go
@@ -175,7 +175,7 @@ func TestCreateRouter_WithEntityTypeRegistry(t *testing.T) {
 				"contentType": "json",
 				"contentConfiguration": "{\"name\": \"test\", \"luigiConfigFragment\": {\"data\": {\"nodes\": [{\"entityType\": \"nonexistent\", \"pathSegment\": \"home\"}]}}}"
 			}`,
-			expectCode:       http.StatusOK,
+			expectCode:       http.StatusUnprocessableEntity,
 			expectValidation: true,
 		},
 		{

--- a/operators/extension-manager-operator/internal/server/router_test.go
+++ b/operators/extension-manager-operator/internal/server/router_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -99,7 +100,7 @@ func TestCreateRouter(t *testing.T) {
 
 			validator := validation.NewContentConfiguration()
 
-			router := CreateRouter(tt.isLocal, log, validator)
+			router := CreateRouter(tt.isLocal, log, validator, nil)
 			assert.NotNil(t, router)
 
 			req := httptest.NewRequest(tt.method, tt.path, bytes.NewBufferString(tt.reqBody))
@@ -108,6 +109,106 @@ func TestCreateRouter(t *testing.T) {
 			router.ServeHTTP(rr, req)
 
 			assert.Equal(t, tt.expectCode, rr.Code)
+		})
+	}
+}
+
+func TestCreateRouter_SelfReferencingCC(t *testing.T) {
+	registry := validation.NewEntityTypeRegistry()
+
+	log := initLog()
+	validator := validation.NewContentConfiguration()
+	router := CreateRouter(false, log, validator, registry)
+
+	// CC defines "project" via defineEntity and references it on a child node.
+	// The registry only knows "global", so without the self-referencing fix this would fail.
+	reqBody := `{
+		"contentType": "json",
+		"contentConfiguration": "{\"name\": \"self-ref\", \"luigiConfigFragment\": {\"data\": {\"nodes\": [{\"entityType\": \"global\", \"pathSegment\": \"root\", \"defineEntity\": {\"id\": \"project\"}, \"children\": [{\"entityType\": \"project\", \"pathSegment\": \"overview\"}]}]}}}"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp Response
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	assert.NoError(t, err)
+	assert.Empty(t, resp.ValidationErrors, "self-referencing CC should pass entity type validation")
+	assert.NotEmpty(t, resp.ParsedConfiguration)
+}
+
+func TestCreateRouter_WithEntityTypeRegistry(t *testing.T) {
+	registry := validation.NewEntityTypeRegistry()
+	registry.Bulkload([]validation.ContentConfiguration{
+		{
+			LuigiConfigFragment: validation.LuigiConfigFragment{
+				Data: validation.LuigiConfigData{
+					Nodes: []validation.Node{
+						{EntityType: "global", DefineEntity: &validation.DefineEntity{Id: "project"}},
+					},
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name             string
+		reqBody          string
+		expectCode       int
+		expectValidation bool
+	}{
+		{
+			name: "valid entityType with registry",
+			reqBody: `{
+				"contentType": "json",
+				"contentConfiguration": "{\"name\": \"test\", \"luigiConfigFragment\": {\"data\": {\"nodes\": [{\"entityType\": \"global\", \"pathSegment\": \"home\"}]}}}"
+			}`,
+			expectCode: http.StatusOK,
+		},
+		{
+			name: "unknown entityType with registry",
+			reqBody: `{
+				"contentType": "json",
+				"contentConfiguration": "{\"name\": \"test\", \"luigiConfigFragment\": {\"data\": {\"nodes\": [{\"entityType\": \"nonexistent\", \"pathSegment\": \"home\"}]}}}"
+			}`,
+			expectCode:       http.StatusOK,
+			expectValidation: true,
+		},
+		{
+			name: "known entityType project with registry",
+			reqBody: `{
+				"contentType": "json",
+				"contentConfiguration": "{\"name\": \"test\", \"luigiConfigFragment\": {\"data\": {\"nodes\": [{\"entityType\": \"project\", \"pathSegment\": \"home\"}]}}}"
+			}`,
+			expectCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := initLog()
+			validator := validation.NewContentConfiguration()
+
+			router := CreateRouter(false, log, validator, registry)
+			assert.NotNil(t, router)
+
+			req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(tt.reqBody))
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectCode, rr.Code)
+
+			if tt.expectValidation {
+				var resp Response
+				err := json.NewDecoder(rr.Body).Decode(&resp)
+				assert.NoError(t, err)
+				assert.NotEmpty(t, resp.ValidationErrors)
+			}
 		})
 	}
 }

--- a/operators/extension-manager-operator/internal/server/validate_endpoint.go
+++ b/operators/extension-manager-operator/internal/server/validate_endpoint.go
@@ -134,7 +134,7 @@ func (h *HttpValidateHandler) writeValidationErrors(w http.ResponseWriter, merr 
 
 	responseBytes, _ := json.Marshal(responseErr)
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusUnprocessableEntity)
 	_, err := w.Write(responseBytes)
 	if err != nil {
 		h.log.Error().Err(err).Msg("Writing response failed")

--- a/operators/extension-manager-operator/internal/server/validate_endpoint.go
+++ b/operators/extension-manager-operator/internal/server/validate_endpoint.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/hashicorp/go-multierror"
+
 	"go.platform-mesh.io/extension-manager-operator/pkg/validation"
 	"go.platform-mesh.io/golang-commons/logger"
 	"go.platform-mesh.io/golang-commons/sentry"
@@ -39,16 +41,18 @@ type validationError struct {
 	Message string `json:"message"`
 }
 
-func NewHttpValidateHandler(log *logger.Logger, validator validation.ExtensionConfiguration) *HttpValidateHandler {
+func NewHttpValidateHandler(log *logger.Logger, validator validation.ExtensionConfiguration, registry *validation.EntityTypeRegistry) *HttpValidateHandler {
 	return &HttpValidateHandler{
-		validator: validator,
-		log:       log,
+		validator:      validator,
+		log:            log,
+		entityRegistry: registry,
 	}
 }
 
 type HttpValidateHandler struct {
-	validator validation.ExtensionConfiguration
-	log       *logger.Logger
+	validator      validation.ExtensionConfiguration
+	log            *logger.Logger
+	entityRegistry *validation.EntityTypeRegistry
 }
 
 func (h *HttpValidateHandler) HandlerHealthz(w http.ResponseWriter, _ *http.Request) {
@@ -95,22 +99,17 @@ func (h *HttpValidateHandler) HandlerValidate(w http.ResponseWriter, r *http.Req
 	// validation
 	parsedConfig, merr := h.validator.Validate([]byte(request.ContentConfiguration), request.ContentType)
 	if merr != nil && merr.Len() > 0 {
-		var responseErr Response
-		for _, e := range merr.Errors {
-			responseErr.ValidationErrors = append(responseErr.ValidationErrors, validationError{
-				Message: e.Error(),
-			})
-		}
-
-		responseBytes, _ := json.Marshal(responseErr)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(responseBytes)
-		if err != nil {
-			h.log.Error().Err(err).Msg("Writing response failed")
-			sentry.CaptureError(err, sentry.Tags{"error": "Writing response failed"}, sentry.Extras{"data": responseErr})
-		}
+		h.writeValidationErrors(w, merr)
 		return
+	}
+
+	// entity type validation
+	if h.entityRegistry != nil {
+		entityTypeErr := h.validator.ValidateEntityTypes([]byte(parsedConfig), "json", h.entityRegistry)
+		if entityTypeErr != nil && entityTypeErr.Len() > 0 {
+			h.writeValidationErrors(w, entityTypeErr)
+			return
+		}
 	}
 
 	// send response
@@ -122,5 +121,23 @@ func (h *HttpValidateHandler) HandlerValidate(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		h.log.Error().Err(err).Msg("Writing response failed")
 		sentry.CaptureError(err, sentry.Tags{"error": "Writing response failed"}, sentry.Extras{"data": rValid})
+	}
+}
+
+func (h *HttpValidateHandler) writeValidationErrors(w http.ResponseWriter, merr *multierror.Error) {
+	var responseErr Response
+	for _, e := range merr.Errors {
+		responseErr.ValidationErrors = append(responseErr.ValidationErrors, validationError{
+			Message: e.Error(),
+		})
+	}
+
+	responseBytes, _ := json.Marshal(responseErr)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(responseBytes)
+	if err != nil {
+		h.log.Error().Err(err).Msg("Writing response failed")
+		sentry.CaptureError(err, sentry.Tags{"error": "Writing response failed"}, sentry.Extras{"data": responseErr})
 	}
 }

--- a/operators/extension-manager-operator/internal/server/validate_endpoint_test.go
+++ b/operators/extension-manager-operator/internal/server/validate_endpoint_test.go
@@ -66,7 +66,7 @@ func TestHandlerValidate_Error(t *testing.T) {
 	}()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.GreaterOrEqual(t, len(r.ValidationErrors), 1)
 }
 
@@ -159,7 +159,7 @@ func TestYAML_FailureWrongType(t *testing.T) {
 	err := decoder.Decode(re)
 	assert.Nil(t, err)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.GreaterOrEqual(t, len(re.ValidationErrors), 1)
 }
 
@@ -190,7 +190,7 @@ func TestValidation_Error(t *testing.T) {
 	}()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.GreaterOrEqual(t, len(r.ValidationErrors), 1)
 }
 
@@ -250,7 +250,7 @@ func TestValidation_ErrorMarshallingValidatedResponse(t *testing.T) {
 	}()
 
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 	assert.GreaterOrEqual(t, len(r.ValidationErrors), 1)
 }
 
@@ -324,7 +324,7 @@ func TestHandlerValidate_WriteErrorOnValidationErrorResponse(t *testing.T) {
 
 	w := mocks.NewResponseWriter(t)
 	w.EXPECT().Header().Return(http.Header{})
-	w.EXPECT().WriteHeader(http.StatusOK)
+	w.EXPECT().WriteHeader(http.StatusUnprocessableEntity)
 	w.EXPECT().Write(mock.Anything).Return(0, errors.New("simulated write error"))
 
 	reqBody := OK_VALID_JSON_CONTENT
@@ -333,5 +333,5 @@ func TestHandlerValidate_WriteErrorOnValidationErrorResponse(t *testing.T) {
 	handler.HandlerValidate(w, req)
 
 	w.AssertCalled(t, "Write", mock.Anything)
-	w.AssertCalled(t, "WriteHeader", http.StatusOK)
+	w.AssertCalled(t, "WriteHeader", http.StatusUnprocessableEntity)
 }

--- a/operators/extension-manager-operator/internal/server/validate_endpoint_test.go
+++ b/operators/extension-manager-operator/internal/server/validate_endpoint_test.go
@@ -46,7 +46,7 @@ func TestHandlerValidate_Error(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	reqBody := ERROR_INVALID_JSON_CONTENT
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -74,7 +74,7 @@ func TestHandlerValidate_Success(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	reqBody := OK_VALID_JSON_CONTENT
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -104,7 +104,7 @@ func TestYAML_Success(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	reqBody := OK_VALID_YAML_CONTENT
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -139,7 +139,7 @@ func TestYAML_FailureWrongType(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	reqBody := ERROR_INVALID_JSON_CONTENT_WRONG_TYPE
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -170,9 +170,7 @@ func TestValidation_Error(t *testing.T) {
 	mockValidator := mocks.NewExtensionConfiguration(t)
 	merr := &multierror.Error{Errors: []error{errors.New("error")}}
 	mockValidator.On("Validate", mock.Anything, mock.Anything).Return("", merr)
-	handler := NewHttpValidateHandler(log, mockValidator)
-
-	// handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, mockValidator, nil)
 
 	reqBody := ERROR_INVALID_JSON_CONTENT2
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -207,7 +205,7 @@ func (e *errorReadCloser) Close() error {
 func TestHandlerValidate_BodyCloseError(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	reqBody := OK_VALID_JSON_CONTENT // or any valid JSON
 	req := httptest.NewRequest(http.MethodPost, "/validate", &errorReadCloser{Reader: bytes.NewBufferString(reqBody)})
@@ -232,9 +230,7 @@ func TestValidation_ErrorMarshallingValidatedResponse(t *testing.T) {
 	mockValidator := mocks.NewExtensionConfiguration(t)
 	merr := &multierror.Error{Errors: []error{errors.New("error")}}
 	mockValidator.On("Validate", mock.Anything, mock.Anything).Return("{ field: }", merr)
-	handler := NewHttpValidateHandler(log, mockValidator)
-
-	// handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, mockValidator, nil)
 
 	reqBody := ERROR_INVALID_JSON_CONTENT_MARSHALLINGVALIDATEDRESPONSE
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -262,7 +258,7 @@ func TestHandlerHealthz(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
@@ -286,7 +282,7 @@ func TestHandlerHealthz_Error(t *testing.T) {
 	logcfg := logger.DefaultConfig()
 	log, _ := logger.New(logcfg)
 
-	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, validation.NewContentConfiguration(), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := mocks.NewResponseWriter(t)
@@ -303,11 +299,7 @@ func TestValidation_Error2(t *testing.T) {
 	log, _ := logger.New(logcfg)
 
 	mockValidator := mocks.NewExtensionConfiguration(t)
-	// merr := &multierror.Error{Errors: []error{errors.New("error")}}
-	// mockValidator.On("Validate", mock.Anything, mock.Anything).Return("", merr)
-	handler := NewHttpValidateHandler(log, mockValidator)
-
-	// handler := NewHttpValidateHandler(log, validation.NewContentConfiguration())
+	handler := NewHttpValidateHandler(log, mockValidator, nil)
 
 	reqBody := ERROR_INVALID_JSON_CONTENT3
 	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewBufferString(reqBody))
@@ -328,7 +320,7 @@ func TestHandlerValidate_WriteErrorOnValidationErrorResponse(t *testing.T) {
 	mockValidator := mocks.NewExtensionConfiguration(t)
 	merr := &multierror.Error{Errors: []error{errors.New("validation error")}}
 	mockValidator.On("Validate", mock.Anything, mock.Anything).Return("", merr)
-	handler := NewHttpValidateHandler(log, mockValidator)
+	handler := NewHttpValidateHandler(log, mockValidator, nil)
 
 	w := mocks.NewResponseWriter(t)
 	w.EXPECT().Header().Return(http.Header{})

--- a/operators/extension-manager-operator/pkg/subroutines/contentconfiguration.go
+++ b/operators/extension-manager-operator/pkg/subroutines/contentconfiguration.go
@@ -62,7 +62,10 @@ type ContentConfigurationSubroutine struct {
 }
 
 func NewContentConfigurationSubroutine(validator validation.ExtensionConfiguration,
-	httpClient *http.Client, k8sReader ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) *ContentConfigurationSubroutine {
+	httpClient *http.Client, k8sReader ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) (*ContentConfigurationSubroutine, error) {
+	if registry != nil && k8sReader == nil {
+		return nil, fmt.Errorf("entity type registry requires a k8s reader")
+	}
 	transformers := []transformer.ContentConfigurationTransformer{
 		&transformer.UrlSuffixTransformer{},
 	}
@@ -72,7 +75,7 @@ func NewContentConfigurationSubroutine(validator validation.ExtensionConfigurati
 		transformer:    transformers,
 		k8sReader:      k8sReader,
 		entityRegistry: registry,
-	}
+	}, nil
 }
 
 func (r *ContentConfigurationSubroutine) GetName() string {
@@ -209,10 +212,6 @@ func ownerKey(cc *pmuiv1alpha1.ContentConfiguration) string {
 }
 
 func (r *ContentConfigurationSubroutine) initEntityTypeRegistry(ctx context.Context, log *logger.Logger) error {
-	if r.k8sReader == nil {
-		return fmt.Errorf("entity type registry requires a k8s reader but none was provided")
-	}
-
 	var ccList pmuiv1alpha1.ContentConfigurationList
 	if err := r.k8sReader.List(ctx, &ccList); err != nil {
 		log.Warn().Err(err).Msg("failed to list ContentConfigurations for entity type registry initialization, registry will be populated incrementally")

--- a/operators/extension-manager-operator/pkg/subroutines/contentconfiguration.go
+++ b/operators/extension-manager-operator/pkg/subroutines/contentconfiguration.go
@@ -22,6 +22,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-multierror"
 
 	pmuiv1alpha1 "go.platform-mesh.io/apis/ui/v1alpha1"
 	"go.platform-mesh.io/extension-manager-operator/pkg/transformer"
@@ -41,24 +45,33 @@ const (
 	ValidationConditionReasonFailed    = "ValidationFailed"
 	ConditionStatusTrue                = "True"
 	ConditionStatusFalse               = "False"
+	entityTypeFinalizerName            = "extension-manager.platform-mesh.io/entity-type-registry"
 )
 
 var _ subroutines.Processor = (*ContentConfigurationSubroutine)(nil)
+var _ subroutines.Finalizer = (*ContentConfigurationSubroutine)(nil)
 
 type ContentConfigurationSubroutine struct {
-	client      *http.Client
-	validator   validation.ExtensionConfiguration
-	transformer []transformer.ContentConfigurationTransformer
+	httpClient       *http.Client
+	validator        validation.ExtensionConfiguration
+	transformer      []transformer.ContentConfigurationTransformer
+	k8sReader        ctrlruntimeclient.Reader
+	entityRegistry   *validation.EntityTypeRegistry
+	registryInitMu   sync.Mutex
+	registryInitDone atomic.Bool
 }
 
-func NewContentConfigurationSubroutine(validator validation.ExtensionConfiguration, client *http.Client) *ContentConfigurationSubroutine {
+func NewContentConfigurationSubroutine(validator validation.ExtensionConfiguration,
+	httpClient *http.Client, k8sReader ctrlruntimeclient.Reader, registry *validation.EntityTypeRegistry) *ContentConfigurationSubroutine {
 	transformers := []transformer.ContentConfigurationTransformer{
 		&transformer.UrlSuffixTransformer{},
 	}
 	return &ContentConfigurationSubroutine{
-		client:      client,
-		validator:   validator,
-		transformer: transformers,
+		httpClient:     httpClient,
+		validator:      validator,
+		transformer:    transformers,
+		k8sReader:      k8sReader,
+		entityRegistry: registry,
 	}
 }
 
@@ -75,6 +88,19 @@ func (r *ContentConfigurationSubroutine) Process(ctx context.Context, obj ctrlru
 	}
 
 	log.Debug().Str("name", instance.Name).Msg("processing content configuration")
+
+	// Initialize entity type registry on first reconcile
+	if r.entityRegistry != nil && !r.registryInitDone.Load() {
+		r.registryInitMu.Lock()
+		if !r.registryInitDone.Load() {
+			if initErr := r.initEntityTypeRegistry(ctx, log); initErr != nil {
+				r.registryInitMu.Unlock()
+				return subroutines.OK(), initErr
+			}
+			r.registryInitDone.Store(true)
+		}
+		r.registryInitMu.Unlock()
+	}
 
 	// Download or Retrieve ContentConfiguration Json
 	contentType, rawConfig, err := r.retrieveContentConfigurationData(instance, log)
@@ -96,6 +122,33 @@ func (r *ContentConfigurationSubroutine) Process(ctx context.Context, obj ctrlru
 		return subroutines.OK(), nil
 	}
 
+	// Parse the validated JSON into a ContentConfiguration struct
+	contentConfiguration := &validation.ContentConfiguration{}
+	err = json.Unmarshal([]byte(validatedConfig), contentConfiguration)
+	if err != nil {
+		return subroutines.OK(), fmt.Errorf("failed to unmarshal contentConfiguration: %w", err)
+	}
+
+	// Validate entityType references against the parsed struct directly
+	if r.entityRegistry != nil {
+		entityTypeErrs := r.entityRegistry.Validate(*contentConfiguration)
+		if len(entityTypeErrs) > 0 {
+			merr := &multierror.Error{}
+			for _, e := range entityTypeErrs {
+				merr = multierror.Append(merr, e)
+			}
+			log.Err(merr).Msg("failed to validate entity types")
+			condition := metav1.Condition{
+				Type:    ValidationConditionType,
+				Status:  ConditionStatusFalse,
+				Reason:  ValidationConditionReasonFailed,
+				Message: merr.Error(),
+			}
+			meta.SetStatusCondition(&instance.Status.Conditions, condition)
+			return subroutines.OK(), nil
+		}
+	}
+
 	condition := metav1.Condition{
 		Type:    ValidationConditionType,
 		Status:  ConditionStatusTrue,
@@ -104,12 +157,7 @@ func (r *ContentConfigurationSubroutine) Process(ctx context.Context, obj ctrlru
 	}
 	meta.SetStatusCondition(&instance.Status.Conditions, condition)
 
-	// Transform ContentConfiguration Json
-	contentConfiguration := &validation.ContentConfiguration{}
-	err = json.Unmarshal([]byte(validatedConfig), contentConfiguration)
-	if err != nil {
-		return subroutines.OK(), fmt.Errorf("failed to unmarshal contentConfiguration: %w", err)
-	}
+	// Transform ContentConfiguration
 	for _, configurationTransformer := range r.transformer {
 		err := configurationTransformer.Transform(contentConfiguration, instance)
 		if err != nil {
@@ -125,7 +173,69 @@ func (r *ContentConfigurationSubroutine) Process(ctx context.Context, obj ctrlru
 
 	// Store resulting configuration in the status
 	instance.Status.ConfigurationResult = validatedConfig
+
+	// Update entity type registry with this CC's definitions
+	if r.entityRegistry != nil {
+		r.entityRegistry.LoadForOwner(ownerKey(instance), *contentConfiguration)
+	}
+
 	return subroutines.OK(), nil
+}
+
+func (r *ContentConfigurationSubroutine) Finalizers(_ ctrlruntimeclient.Object) []string {
+	if r.entityRegistry == nil {
+		return nil
+	}
+	return []string{entityTypeFinalizerName}
+}
+
+func (r *ContentConfigurationSubroutine) Finalize(_ context.Context, obj ctrlruntimeclient.Object) (subroutines.Result, error) {
+	if r.entityRegistry == nil {
+		return subroutines.OK(), nil
+	}
+	instance, ok := obj.(*pmuiv1alpha1.ContentConfiguration)
+	if !ok {
+		return subroutines.OK(), fmt.Errorf("expected *v1alpha1.ContentConfiguration, got %T", obj)
+	}
+	r.entityRegistry.RemoveOwner(ownerKey(instance))
+	return subroutines.OK(), nil
+}
+
+func ownerKey(cc *pmuiv1alpha1.ContentConfiguration) string {
+	if cc.UID != "" {
+		return string(cc.UID)
+	}
+	return cc.Namespace + "/" + cc.Name
+}
+
+func (r *ContentConfigurationSubroutine) initEntityTypeRegistry(ctx context.Context, log *logger.Logger) error {
+	if r.k8sReader == nil {
+		return fmt.Errorf("entity type registry requires a k8s reader but none was provided")
+	}
+
+	var ccList pmuiv1alpha1.ContentConfigurationList
+	if err := r.k8sReader.List(ctx, &ccList); err != nil {
+		log.Warn().Err(err).Msg("failed to list ContentConfigurations for entity type registry initialization, registry will be populated incrementally")
+		return nil
+	}
+
+	configs := make(map[string]validation.ContentConfiguration)
+	for i := range ccList.Items {
+		cc := &ccList.Items[i]
+		if cc.Status.ConfigurationResult == "" {
+			continue
+		}
+		var parsed validation.ContentConfiguration
+		if err := json.Unmarshal([]byte(cc.Status.ConfigurationResult), &parsed); err != nil {
+			log.Warn().Err(err).Str("name", cc.Name).Msg("failed to parse ConfigurationResult for entity type registry")
+			continue
+		}
+		configs[ownerKey(cc)] = parsed
+	}
+
+	r.entityRegistry.BulkloadWithOwners(configs)
+	log.Info().Int("entityTypes", len(r.entityRegistry.KnownTypes())).Msg("initialized entity type registry")
+	return nil
 }
 
 func (r *ContentConfigurationSubroutine) retrieveContentConfigurationData(instance *pmuiv1alpha1.ContentConfiguration, log *logger.Logger) (string, []byte, error) {
@@ -162,7 +272,7 @@ func (r *ContentConfigurationSubroutine) getRemoteConfig(url string, log *logger
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	resp, err := r.client.Do(req)
+	resp, err := r.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}

--- a/operators/extension-manager-operator/pkg/subroutines/contentconfiguration_test.go
+++ b/operators/extension-manager-operator/pkg/subroutines/contentconfiguration_test.go
@@ -59,7 +59,7 @@ func (suite *ContentConfigurationSubroutineTestSuite) SetupTest() {
 	suite.clientMock = new(mocks.Client)
 
 	// create new test object
-	suite.testObj = NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
+	suite.testObj, _ = NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
 }
 
 func (suite *ContentConfigurationSubroutineTestSuite) TestCreateAndUpdate_OK() {
@@ -321,9 +321,11 @@ func TestService_Do(t *testing.T) {
 					httpmock.NewStringResponder(tt.mockStatusCode, tt.mockResponse))
 			}
 
-			r := NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
+			r, err := NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
+			require.NoError(t, err)
 
-			body, err := r.getRemoteConfig(tt.url, log)
+			var body []byte
+			body, err = r.getRemoteConfig(tt.url, log)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -501,13 +503,6 @@ func TestProcess_EntityTypeValidation(t *testing.T) {
 			expectRegistryContains: []string{"global"},
 		},
 		{
-			name:                "registry init with nil reader returns error",
-			inlineContent:       validJSONWithEntityType("global"),
-			registry:            validation.NewEntityTypeRegistry(),
-			k8sReader:           nil,
-			expectOperatorError: true,
-		},
-		{
 			name:                 "entity type validation failure sets Valid=False condition",
 			existingCCs:          []ctrlruntimeclient.Object{},
 			inlineContent:        validJSONWithEntityType("nonexistent-type"),
@@ -599,12 +594,13 @@ func TestProcess_EntityTypeValidation(t *testing.T) {
 				reader = newFakeReader(tt.existingCCs...)
 			}
 
-			sub := NewContentConfigurationSubroutine(
+			sub, err := NewContentConfigurationSubroutine(
 				validation.NewContentConfiguration(),
 				http.DefaultClient,
 				reader,
 				tt.registry,
 			)
+			require.NoError(t, err)
 
 			cc := &pmuiv1alpha1.ContentConfiguration{
 				Spec: pmuiv1alpha1.ContentConfigurationSpec{
@@ -615,7 +611,7 @@ func TestProcess_EntityTypeValidation(t *testing.T) {
 				},
 			}
 
-			_, err := sub.Process(context.Background(), cc)
+			_, err = sub.Process(context.Background(), cc)
 
 			if tt.expectOperatorError {
 				require.NotNil(t, err, "expected an OperatorError but got nil")
@@ -655,12 +651,13 @@ func TestProcess_RegistryInitOnlyRunsOnce(t *testing.T) {
 	)
 
 	registry := validation.NewEntityTypeRegistry()
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	cc1 := &pmuiv1alpha1.ContentConfiguration{
 		Spec: pmuiv1alpha1.ContentConfigurationSpec{
@@ -671,7 +668,7 @@ func TestProcess_RegistryInitOnlyRunsOnce(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc1)
+	_, err = sub.Process(context.Background(), cc1)
 	require.Nil(t, err)
 	assert.True(t, registry.KnownTypes()["project"], "registry should contain 'project' after init")
 
@@ -689,13 +686,26 @@ func TestProcess_RegistryInitOnlyRunsOnce(t *testing.T) {
 	assert.True(t, registry.KnownTypes()["project"])
 }
 
+func TestNew_RegistryWithoutReaderReturnsError(t *testing.T) {
+	registry := validation.NewEntityTypeRegistry()
+	_, err := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		nil,
+		registry,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s reader")
+}
+
 func TestProcess_NilRegistrySkipsEntityTypeValidation(t *testing.T) {
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		nil,
 		nil,
 	)
+	require.NoError(t, err)
 
 	cc := &pmuiv1alpha1.ContentConfiguration{
 		Spec: pmuiv1alpha1.ContentConfigurationSpec{
@@ -706,7 +716,7 @@ func TestProcess_NilRegistrySkipsEntityTypeValidation(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 
 	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
@@ -718,12 +728,13 @@ func TestProcess_EntityTypeValidationFailure_PreservesExistingConfigResult(t *te
 	reader := newFakeReader()
 	registry := validation.NewEntityTypeRegistry()
 
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	existingResult := validJSONWithEntityType("global")
 	cc := &pmuiv1alpha1.ContentConfiguration{
@@ -738,7 +749,7 @@ func TestProcess_EntityTypeValidationFailure_PreservesExistingConfigResult(t *te
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 
 	assert.Equal(t, existingResult, cc.Status.ConfigurationResult)
@@ -753,12 +764,13 @@ func TestProcess_ValidCC_UpdatesRegistryWithDefinedEntityTypes(t *testing.T) {
 	reader := newFakeReader()
 	registry := validation.NewEntityTypeRegistry()
 
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	cc := &pmuiv1alpha1.ContentConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "definer", UID: "uid-definer"},
@@ -770,7 +782,7 @@ func TestProcess_ValidCC_UpdatesRegistryWithDefinedEntityTypes(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 
 	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
@@ -785,12 +797,13 @@ func TestProcess_IdempotentRegistryLoad(t *testing.T) {
 	reader := newFakeReader()
 	registry := validation.NewEntityTypeRegistry()
 
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	cc := &pmuiv1alpha1.ContentConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cc", UID: "uid-test"},
@@ -802,7 +815,7 @@ func TestProcess_IdempotentRegistryLoad(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
@@ -815,12 +828,13 @@ func TestFinalize_RemovesFromRegistry(t *testing.T) {
 	reader := newFakeReader()
 	registry := validation.NewEntityTypeRegistry()
 
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	cc := &pmuiv1alpha1.ContentConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "to-delete", UID: "uid-delete"},
@@ -832,7 +846,7 @@ func TestFinalize_RemovesFromRegistry(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 	assert.True(t, registry.KnownTypes()["ephemeral"])
 
@@ -843,12 +857,13 @@ func TestFinalize_RemovesFromRegistry(t *testing.T) {
 }
 
 func TestFinalize_NilRegistry_NoOp(t *testing.T) {
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		nil,
 		nil,
 	)
+	require.NoError(t, err)
 
 	cc := &pmuiv1alpha1.ContentConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "uid-test"},
@@ -861,12 +876,13 @@ func TestFinalize_NilRegistry_NoOp(t *testing.T) {
 
 func TestFinalizers_ReturnsFinalizerWhenRegistryEnabled(t *testing.T) {
 	registry := validation.NewEntityTypeRegistry()
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
-		nil,
+		newFakeReader(),
 		registry,
 	)
+	require.NoError(t, err)
 
 	finalizers := sub.Finalizers(nil)
 	require.Len(t, finalizers, 1)
@@ -874,12 +890,13 @@ func TestFinalizers_ReturnsFinalizerWhenRegistryEnabled(t *testing.T) {
 }
 
 func TestFinalizers_ReturnsNilWhenRegistryDisabled(t *testing.T) {
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		nil,
 		nil,
 	)
+	require.NoError(t, err)
 
 	finalizers := sub.Finalizers(nil)
 	assert.Nil(t, finalizers)
@@ -889,12 +906,13 @@ func TestProcess_SelfReferencingCC_DefinesAndUsesOwnEntityType(t *testing.T) {
 	reader := newFakeReader()
 	registry := validation.NewEntityTypeRegistry()
 
-	sub := NewContentConfigurationSubroutine(
+	sub, err := NewContentConfigurationSubroutine(
 		validation.NewContentConfiguration(),
 		http.DefaultClient,
 		reader,
 		registry,
 	)
+	require.NoError(t, err)
 
 	selfReferencingJSON := `{
 		"name": "self-ref-cc",
@@ -931,7 +949,7 @@ func TestProcess_SelfReferencingCC_DefinesAndUsesOwnEntityType(t *testing.T) {
 		},
 	}
 
-	_, err := sub.Process(context.Background(), cc)
+	_, err = sub.Process(context.Background(), cc)
 	require.Nil(t, err)
 
 	cond := getCondition(cc.Status.Conditions, ValidationConditionType)

--- a/operators/extension-manager-operator/pkg/subroutines/contentconfiguration_test.go
+++ b/operators/extension-manager-operator/pkg/subroutines/contentconfiguration_test.go
@@ -36,6 +36,9 @@ import (
 	"go.platform-mesh.io/golang-commons/logger"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type ContentConfigurationSubroutineTestSuite struct {
@@ -56,7 +59,7 @@ func (suite *ContentConfigurationSubroutineTestSuite) SetupTest() {
 	suite.clientMock = new(mocks.Client)
 
 	// create new test object
-	suite.testObj = NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient)
+	suite.testObj = NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
 }
 
 func (suite *ContentConfigurationSubroutineTestSuite) TestCreateAndUpdate_OK() {
@@ -318,7 +321,7 @@ func TestService_Do(t *testing.T) {
 					httpmock.NewStringResponder(tt.mockStatusCode, tt.mockResponse))
 			}
 
-			r := NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient)
+			r := NewContentConfigurationSubroutine(validation.NewContentConfiguration(), http.DefaultClient, nil, nil)
 
 			body, err := r.getRemoteConfig(tt.url, log)
 			if tt.expectError {
@@ -400,4 +403,539 @@ func getCondition(conditions []metav1.Condition, conditionType string) metav1.Co
 		}
 	}
 	return metav1.Condition{}
+}
+
+// validJSONWithEntityType returns a valid CC JSON that references the given entityType
+// in both nodeDefaults and a single node.
+func validJSONWithEntityType(entityType string) string {
+	return `{
+		"name": "test-cc",
+		"luigiConfigFragment": {
+			"data": {
+				"nodeDefaults": {
+					"entityType": "` + entityType + `"
+				},
+				"nodes": [
+					{
+						"entityType": "` + entityType + `",
+						"pathSegment": "home",
+						"label": "Home"
+					}
+				]
+			}
+		}
+	}`
+}
+
+// validJSONDefiningEntityType returns a valid CC JSON that defines a new entity type
+// via defineEntity under a "global" parent.
+func validJSONDefiningEntityType(defineEntityId string) string {
+	return `{
+		"name": "definer-cc",
+		"luigiConfigFragment": {
+			"data": {
+				"nodes": [
+					{
+						"entityType": "global",
+						"pathSegment": "root",
+						"label": "Root",
+						"defineEntity": {
+							"id": "` + defineEntityId + `",
+							"contextKey": "` + defineEntityId + `Id"
+						},
+						"children": []
+					}
+				]
+			}
+		}
+	}`
+}
+
+func newFakeReader(objects ...ctrlruntimeclient.Object) ctrlruntimeclient.Reader {
+	scheme := runtime.NewScheme()
+	err := pmuiv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		panic(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func TestProcess_EntityTypeValidation(t *testing.T) {
+	tests := []struct {
+		name                   string
+		existingCCs            []ctrlruntimeclient.Object
+		inlineContent          string
+		registry               *validation.EntityTypeRegistry
+		k8sReader              ctrlruntimeclient.Reader
+		expectOperatorError    bool
+		expectValidCondition   string
+		expectValidReason      string
+		expectConfigResult     bool
+		expectRegistryContains []string
+	}{
+		{
+			name: "registry init succeeds and populates from existing CCs",
+			existingCCs: []ctrlruntimeclient.Object{
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-cc"},
+					Status: pmuiv1alpha1.ContentConfigurationStatus{
+						ConfigurationResult: validJSONDefiningEntityType("project"),
+					},
+				},
+			},
+			inlineContent:          validJSONWithEntityType("project"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global", "project"},
+		},
+		{
+			name:                   "registry init with empty CC list succeeds",
+			existingCCs:            []ctrlruntimeclient.Object{},
+			inlineContent:          validJSONWithEntityType("global"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global"},
+		},
+		{
+			name:                "registry init with nil reader returns error",
+			inlineContent:       validJSONWithEntityType("global"),
+			registry:            validation.NewEntityTypeRegistry(),
+			k8sReader:           nil,
+			expectOperatorError: true,
+		},
+		{
+			name:                 "entity type validation failure sets Valid=False condition",
+			existingCCs:          []ctrlruntimeclient.Object{},
+			inlineContent:        validJSONWithEntityType("nonexistent-type"),
+			registry:             validation.NewEntityTypeRegistry(),
+			expectValidCondition: ConditionStatusFalse,
+			expectValidReason:    ValidationConditionReasonFailed,
+			expectConfigResult:   false,
+		},
+		{
+			name: "entity type validation success updates registry",
+			existingCCs: []ctrlruntimeclient.Object{
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "definer"},
+					Status: pmuiv1alpha1.ContentConfigurationStatus{
+						ConfigurationResult: validJSONDefiningEntityType("mytype"),
+					},
+				},
+			},
+			inlineContent:          validJSONWithEntityType("mytype"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global", "mytype"},
+		},
+		{
+			name: "initEntityTypeRegistry skips CC with empty ConfigurationResult",
+			existingCCs: []ctrlruntimeclient.Object{
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-result"},
+					Status:     pmuiv1alpha1.ContentConfigurationStatus{ConfigurationResult: ""},
+				},
+			},
+			inlineContent:          validJSONWithEntityType("global"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global"},
+		},
+		{
+			name: "initEntityTypeRegistry skips CC with unparseable ConfigurationResult",
+			existingCCs: []ctrlruntimeclient.Object{
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "bad-json"},
+					Status: pmuiv1alpha1.ContentConfigurationStatus{
+						ConfigurationResult: "{{not valid json at all",
+					},
+				},
+			},
+			inlineContent:          validJSONWithEntityType("global"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global"},
+		},
+		{
+			name: "initEntityTypeRegistry skips unparseable but loads valid CCs",
+			existingCCs: []ctrlruntimeclient.Object{
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "bad"},
+					Status: pmuiv1alpha1.ContentConfigurationStatus{
+						ConfigurationResult: "not json",
+					},
+				},
+				&pmuiv1alpha1.ContentConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "good"},
+					Status: pmuiv1alpha1.ContentConfigurationStatus{
+						ConfigurationResult: validJSONDefiningEntityType("team"),
+					},
+				},
+			},
+			inlineContent:          validJSONWithEntityType("team"),
+			registry:               validation.NewEntityTypeRegistry(),
+			expectValidCondition:   ConditionStatusTrue,
+			expectValidReason:      ValidationConditionReasonSuccess,
+			expectConfigResult:     true,
+			expectRegistryContains: []string{"global", "team"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reader ctrlruntimeclient.Reader
+			if tt.k8sReader != nil {
+				reader = tt.k8sReader
+			} else if tt.existingCCs != nil {
+				reader = newFakeReader(tt.existingCCs...)
+			}
+
+			sub := NewContentConfigurationSubroutine(
+				validation.NewContentConfiguration(),
+				http.DefaultClient,
+				reader,
+				tt.registry,
+			)
+
+			cc := &pmuiv1alpha1.ContentConfiguration{
+				Spec: pmuiv1alpha1.ContentConfigurationSpec{
+					InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+						Content:     tt.inlineContent,
+						ContentType: "json",
+					},
+				},
+			}
+
+			_, err := sub.Process(context.Background(), cc)
+
+			if tt.expectOperatorError {
+				require.NotNil(t, err, "expected an OperatorError but got nil")
+				return
+			}
+
+			require.Nil(t, err, "unexpected OperatorError: %v", err)
+
+			cond := getCondition(cc.Status.Conditions, ValidationConditionType)
+			assert.Equal(t, tt.expectValidCondition, string(cond.Status), "unexpected Valid condition status")
+			assert.Equal(t, tt.expectValidReason, cond.Reason, "unexpected Valid condition reason")
+
+			if tt.expectConfigResult {
+				assert.NotEmpty(t, cc.Status.ConfigurationResult, "expected ConfigurationResult to be set")
+			} else {
+				assert.Empty(t, cc.Status.ConfigurationResult, "expected ConfigurationResult to be empty")
+			}
+
+			if tt.registry != nil && len(tt.expectRegistryContains) > 0 {
+				known := tt.registry.KnownTypes()
+				for _, et := range tt.expectRegistryContains {
+					assert.True(t, known[et], "expected registry to contain entity type %q", et)
+				}
+			}
+		})
+	}
+}
+
+func TestProcess_RegistryInitOnlyRunsOnce(t *testing.T) {
+	reader := newFakeReader(
+		&pmuiv1alpha1.ContentConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "seed"},
+			Status: pmuiv1alpha1.ContentConfigurationStatus{
+				ConfigurationResult: validJSONDefiningEntityType("project"),
+			},
+		},
+	)
+
+	registry := validation.NewEntityTypeRegistry()
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	cc1 := &pmuiv1alpha1.ContentConfiguration{
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONWithEntityType("global"),
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc1)
+	require.Nil(t, err)
+	assert.True(t, registry.KnownTypes()["project"], "registry should contain 'project' after init")
+
+	cc2 := &pmuiv1alpha1.ContentConfiguration{
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONWithEntityType("global"),
+				ContentType: "json",
+			},
+		},
+	}
+	_, err = sub.Process(context.Background(), cc2)
+	require.Nil(t, err)
+
+	assert.True(t, registry.KnownTypes()["project"])
+}
+
+func TestProcess_NilRegistrySkipsEntityTypeValidation(t *testing.T) {
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		nil,
+		nil,
+	)
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONWithEntityType("nonexistent"),
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+
+	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
+	assert.Equal(t, string(ConditionStatusTrue), string(cond.Status))
+	assert.NotEmpty(t, cc.Status.ConfigurationResult)
+}
+
+func TestProcess_EntityTypeValidationFailure_PreservesExistingConfigResult(t *testing.T) {
+	reader := newFakeReader()
+	registry := validation.NewEntityTypeRegistry()
+
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	existingResult := validJSONWithEntityType("global")
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONWithEntityType("unknown-type"),
+				ContentType: "json",
+			},
+		},
+		Status: pmuiv1alpha1.ContentConfigurationStatus{
+			ConfigurationResult: existingResult,
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+
+	assert.Equal(t, existingResult, cc.Status.ConfigurationResult)
+
+	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
+	assert.Equal(t, string(ConditionStatusFalse), string(cond.Status))
+	assert.Equal(t, ValidationConditionReasonFailed, cond.Reason)
+	assert.Contains(t, cond.Message, "unknown-type")
+}
+
+func TestProcess_ValidCC_UpdatesRegistryWithDefinedEntityTypes(t *testing.T) {
+	reader := newFakeReader()
+	registry := validation.NewEntityTypeRegistry()
+
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "definer", UID: "uid-definer"},
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONDefiningEntityType("newentity"),
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+
+	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
+	assert.Equal(t, string(ConditionStatusTrue), string(cond.Status))
+
+	known := registry.KnownTypes()
+	assert.True(t, known["newentity"], "registry should contain 'newentity' after processing CC that defines it")
+	assert.True(t, known["global"], "registry should always contain 'global'")
+}
+
+func TestProcess_IdempotentRegistryLoad(t *testing.T) {
+	reader := newFakeReader()
+	registry := validation.NewEntityTypeRegistry()
+
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cc", UID: "uid-test"},
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONDefiningEntityType("project"),
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+	_, err = sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+
+	registry.RemoveOwner("uid-test")
+	assert.False(t, registry.KnownTypes()["project"], "project should be gone after single RemoveOwner")
+}
+
+func TestFinalize_RemovesFromRegistry(t *testing.T) {
+	reader := newFakeReader()
+	registry := validation.NewEntityTypeRegistry()
+
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "to-delete", UID: "uid-delete"},
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     validJSONDefiningEntityType("ephemeral"),
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+	assert.True(t, registry.KnownTypes()["ephemeral"])
+
+	result, err := sub.Finalize(context.Background(), cc)
+	require.Nil(t, err)
+	assert.True(t, result.IsContinue())
+	assert.False(t, registry.KnownTypes()["ephemeral"], "entity type should be removed after Finalize")
+}
+
+func TestFinalize_NilRegistry_NoOp(t *testing.T) {
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		nil,
+		nil,
+	)
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "uid-test"},
+	}
+
+	result, err := sub.Finalize(context.Background(), cc)
+	require.Nil(t, err)
+	assert.True(t, result.IsContinue())
+}
+
+func TestFinalizers_ReturnsFinalizerWhenRegistryEnabled(t *testing.T) {
+	registry := validation.NewEntityTypeRegistry()
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		nil,
+		registry,
+	)
+
+	finalizers := sub.Finalizers(nil)
+	require.Len(t, finalizers, 1)
+	assert.Equal(t, "extension-manager.platform-mesh.io/entity-type-registry", finalizers[0])
+}
+
+func TestFinalizers_ReturnsNilWhenRegistryDisabled(t *testing.T) {
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		nil,
+		nil,
+	)
+
+	finalizers := sub.Finalizers(nil)
+	assert.Nil(t, finalizers)
+}
+
+func TestProcess_SelfReferencingCC_DefinesAndUsesOwnEntityType(t *testing.T) {
+	reader := newFakeReader()
+	registry := validation.NewEntityTypeRegistry()
+
+	sub := NewContentConfigurationSubroutine(
+		validation.NewContentConfiguration(),
+		http.DefaultClient,
+		reader,
+		registry,
+	)
+
+	selfReferencingJSON := `{
+		"name": "self-ref-cc",
+		"luigiConfigFragment": {
+			"data": {
+				"nodes": [
+					{
+						"entityType": "global",
+						"pathSegment": "root",
+						"defineEntity": {
+							"id": "project",
+							"contextKey": "projectId"
+						},
+						"children": [
+							{
+								"entityType": "project",
+								"pathSegment": "overview",
+								"label": "Overview"
+							}
+						]
+					}
+				]
+			}
+		}
+	}`
+
+	cc := &pmuiv1alpha1.ContentConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "self-ref", UID: "uid-self-ref"},
+		Spec: pmuiv1alpha1.ContentConfigurationSpec{
+			InlineConfiguration: &pmuiv1alpha1.InlineConfiguration{
+				Content:     selfReferencingJSON,
+				ContentType: "json",
+			},
+		},
+	}
+
+	_, err := sub.Process(context.Background(), cc)
+	require.Nil(t, err)
+
+	cond := getCondition(cc.Status.Conditions, ValidationConditionType)
+	assert.Equal(t, string(ConditionStatusTrue), string(cond.Status),
+		"a CC that defines and references its own entity type should pass validation")
+	assert.NotEmpty(t, cc.Status.ConfigurationResult)
 }

--- a/operators/extension-manager-operator/pkg/validation/entitytype.go
+++ b/operators/extension-manager-operator/pkg/validation/entitytype.go
@@ -1,0 +1,204 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type EntityTypeRegistry struct {
+	mu     sync.RWMutex
+	types  map[string]int            // entity type → reference count
+	owners map[string]map[string]bool // owner key → set of entity types it contributes
+}
+
+func NewEntityTypeRegistry() *EntityTypeRegistry {
+	return &EntityTypeRegistry{
+		types:  map[string]int{"global": 1},
+		owners: make(map[string]map[string]bool),
+	}
+}
+
+func (r *EntityTypeRegistry) Bulkload(configs []ContentConfiguration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.types = map[string]int{"global": 1}
+	r.owners = make(map[string]map[string]bool)
+	for _, cc := range configs {
+		for et := range collectDefinedEntityTypes(cc) {
+			r.types[et]++
+		}
+	}
+}
+
+func (r *EntityTypeRegistry) BulkloadWithOwners(configs map[string]ContentConfiguration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.types = map[string]int{"global": 1}
+	r.owners = make(map[string]map[string]bool)
+	for owner, cc := range configs {
+		defined := collectDefinedEntityTypes(cc)
+		r.owners[owner] = defined
+		for et := range defined {
+			r.types[et]++
+		}
+	}
+}
+
+func (r *EntityTypeRegistry) LoadForOwner(owner string, cc ContentConfiguration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	newTypes := collectDefinedEntityTypes(cc)
+
+	if oldTypes, exists := r.owners[owner]; exists {
+		for et := range oldTypes {
+			if !newTypes[et] {
+				if r.types[et] <= 1 {
+					delete(r.types, et)
+				} else {
+					r.types[et]--
+				}
+			}
+		}
+	}
+
+	for et := range newTypes {
+		if r.owners[owner] == nil || !r.owners[owner][et] {
+			r.types[et]++
+		}
+	}
+
+	r.owners[owner] = newTypes
+}
+
+func (r *EntityTypeRegistry) RemoveOwner(owner string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	oldTypes, exists := r.owners[owner]
+	if !exists {
+		return
+	}
+
+	for et := range oldTypes {
+		if r.types[et] <= 1 {
+			delete(r.types, et)
+		} else {
+			r.types[et]--
+		}
+	}
+	delete(r.owners, owner)
+}
+
+// Validate checks all entityType references in a ContentConfiguration against
+// the registry. Returns errors for unknown entity types.
+func (r *EntityTypeRegistry) Validate(cc ContentConfiguration) []error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	selfDefined := collectDefinedEntityTypes(cc)
+	refs := collectReferencedEntityTypes(cc)
+	var errs []error
+	for _, ref := range refs {
+		normalized := normalizeEntityType(ref)
+		if normalized == "" {
+			continue
+		}
+		if r.types[normalized] == 0 && !selfDefined[normalized] {
+			errs = append(errs, fmt.Errorf("unknown entityType %q", ref))
+		}
+	}
+	return errs
+}
+
+// KnownTypes returns a set of known entity types (for testing).
+func (r *EntityTypeRegistry) KnownTypes() map[string]bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]bool, len(r.types))
+	for k := range r.types {
+		result[k] = true
+	}
+	return result
+}
+
+// collectDefinedEntityTypes walks all nodes in a ContentConfiguration and
+// collects the entity types defined via defineEntity segments.
+func collectDefinedEntityTypes(cc ContentConfiguration) map[string]bool {
+	types := make(map[string]bool)
+	defaultEntityType := ""
+	if cc.LuigiConfigFragment.Data.NodeDefaults != nil {
+		defaultEntityType = cc.LuigiConfigFragment.Data.NodeDefaults.EntityType
+	}
+	for _, node := range cc.LuigiConfigFragment.Data.Nodes {
+		collectDefinedEntityTypesFromNode(node, defaultEntityType, types)
+	}
+	return types
+}
+
+func collectDefinedEntityTypesFromNode(node Node, defaultEntityType string, types map[string]bool) {
+	entityType := node.EntityType
+	if entityType == "" {
+		entityType = defaultEntityType
+	}
+
+	if node.DefineEntity != nil && node.DefineEntity.Id != "" {
+		fullType := buildEntityTypeName(entityType, node.DefineEntity.Id)
+		types[fullType] = true
+	}
+
+	// Determine the entity type context for children
+	childEntityType := entityType
+	if node.DefineEntity != nil && node.DefineEntity.Id != "" {
+		childEntityType = buildEntityTypeName(entityType, node.DefineEntity.Id)
+	}
+
+	for _, child := range node.Children {
+		collectDefinedEntityTypesFromNode(child, childEntityType, types)
+	}
+}
+
+// buildEntityTypeName builds the full entity type name from a parent entity type
+// and a defineEntity id. Per the docs, "global" is excluded from the chain.
+func buildEntityTypeName(parentEntityType, defineEntityId string) string {
+	normalized := normalizeEntityType(parentEntityType)
+	if normalized == "" || normalized == "global" {
+		return defineEntityId
+	}
+	return normalized + "." + defineEntityId
+}
+
+// collectReferencedEntityTypes collects all entityType values from
+// nodeDefaults and nodes (recursively).
+func collectReferencedEntityTypes(cc ContentConfiguration) []string {
+	var refs []string
+	if cc.LuigiConfigFragment.Data.NodeDefaults != nil && cc.LuigiConfigFragment.Data.NodeDefaults.EntityType != "" {
+		refs = append(refs, cc.LuigiConfigFragment.Data.NodeDefaults.EntityType)
+	}
+	for _, node := range cc.LuigiConfigFragment.Data.Nodes {
+		collectReferencedEntityTypesFromNode(node, &refs)
+	}
+	return refs
+}
+
+func collectReferencedEntityTypesFromNode(node Node, refs *[]string) {
+	if node.EntityType != "" {
+		*refs = append(*refs, node.EntityType)
+	}
+	for _, child := range node.Children {
+		collectReferencedEntityTypesFromNode(child, refs)
+	}
+}
+
+// normalizeEntityType strips any "::" suffix (e.g. "project.overview::compound"
+// becomes "project.overview").
+func normalizeEntityType(entityType string) string {
+	if base, _, found := strings.Cut(entityType, "::"); found {
+		return base
+	}
+	return entityType
+}

--- a/operators/extension-manager-operator/pkg/validation/entitytype.go
+++ b/operators/extension-manager-operator/pkg/validation/entitytype.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validation
 
 import (
@@ -8,7 +24,7 @@ import (
 
 type EntityTypeRegistry struct {
 	mu     sync.RWMutex
-	types  map[string]int            // entity type → reference count
+	types  map[string]int             // entity type → reference count
 	owners map[string]map[string]bool // owner key → set of entity types it contributes
 }
 
@@ -146,15 +162,10 @@ func collectDefinedEntityTypesFromNode(node Node, defaultEntityType string, type
 		entityType = defaultEntityType
 	}
 
-	if node.DefineEntity != nil && node.DefineEntity.Id != "" {
-		fullType := buildEntityTypeName(entityType, node.DefineEntity.Id)
-		types[fullType] = true
-	}
-
-	// Determine the entity type context for children
 	childEntityType := entityType
-	if node.DefineEntity != nil && node.DefineEntity.Id != "" {
-		childEntityType = buildEntityTypeName(entityType, node.DefineEntity.Id)
+	if entity := node.DefineEntity; entity != nil && entity.Id != "" {
+		childEntityType = buildEntityTypeName(entityType, entity.Id)
+		types[childEntityType] = true
 	}
 
 	for _, child := range node.Children {
@@ -197,8 +208,5 @@ func collectReferencedEntityTypesFromNode(node Node, refs *[]string) {
 // normalizeEntityType strips any "::" suffix (e.g. "project.overview::compound"
 // becomes "project.overview").
 func normalizeEntityType(entityType string) string {
-	if base, _, found := strings.Cut(entityType, "::"); found {
-		return base
-	}
-	return entityType
+	return strings.SplitN(entityType, "::", 2)[0]
 }

--- a/operators/extension-manager-operator/pkg/validation/entitytype_test.go
+++ b/operators/extension-manager-operator/pkg/validation/entitytype_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validation
 
 import (

--- a/operators/extension-manager-operator/pkg/validation/entitytype_test.go
+++ b/operators/extension-manager-operator/pkg/validation/entitytype_test.go
@@ -1,0 +1,854 @@
+package validation
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEntityTypeRegistry(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+	types := registry.KnownTypes()
+
+	assert.True(t, types["global"])
+	assert.Len(t, types, 1)
+}
+
+func TestCollectDefinedEntityTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cc       ContentConfiguration
+		expected map[string]bool
+	}{
+		{
+			name: "simple defineEntity under global",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "global",
+								DefineEntity: &DefineEntity{Id: "main"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{"main": true},
+		},
+		{
+			name: "defineEntity under non-global entityType",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "project",
+								DefineEntity: &DefineEntity{Id: "custom"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{"project.custom": true},
+		},
+		{
+			name: "nested defineEntity",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "project",
+								DefineEntity: &DefineEntity{Id: "component"},
+								Children: []Node{
+									{
+										DefineEntity: &DefineEntity{Id: "overview"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"project.component":          true,
+				"project.component.overview": true,
+			},
+		},
+		{
+			name: "no defineEntity",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType: "global",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{},
+		},
+		{
+			name: "defineEntity with nodeDefaults entityType",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						NodeDefaults: &NodeDefaults{EntityType: "project"},
+						Nodes: []Node{
+							{
+								DefineEntity: &DefineEntity{Id: "custom"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{"project.custom": true},
+		},
+		{
+			name: "defineEntity with empty id is ignored",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "global",
+								DefineEntity: &DefineEntity{Id: ""},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collectDefinedEntityTypes(tt.cc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCollectReferencedEntityTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cc       ContentConfiguration
+		expected []string
+	}{
+		{
+			name: "single node",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "global"},
+						},
+					},
+				},
+			},
+			expected: []string{"global"},
+		},
+		{
+			name: "nodeDefaults and node",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						NodeDefaults: &NodeDefaults{EntityType: "project"},
+						Nodes: []Node{
+							{EntityType: "team"},
+						},
+					},
+				},
+			},
+			expected: []string{"project", "team"},
+		},
+		{
+			name: "nested children",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType: "project",
+								Children: []Node{
+									{EntityType: "project.component"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"project", "project.component"},
+		},
+		{
+			name: "empty entityType is not collected",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: ""},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collectReferencedEntityTypes(tt.cc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEntityTypeRegistry_Load(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	configs := []ContentConfiguration{
+		{
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{
+							EntityType:   "global",
+							DefineEntity: &DefineEntity{Id: "project"},
+						},
+					},
+				},
+			},
+		},
+		{
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{
+							EntityType:   "global",
+							DefineEntity: &DefineEntity{Id: "team"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	registry.Bulkload(configs)
+	types := registry.KnownTypes()
+
+	assert.True(t, types["global"])
+	assert.True(t, types["project"])
+	assert.True(t, types["team"])
+	assert.Len(t, types, 3)
+}
+
+func TestEntityTypeRegistry_Update(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{
+						EntityType:   "project",
+						DefineEntity: &DefineEntity{Id: "component"},
+					},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc)
+	types := registry.KnownTypes()
+
+	assert.True(t, types["global"])
+	assert.True(t, types["project.component"])
+	assert.Len(t, types, 2)
+}
+
+func TestEntityTypeRegistry_Remove(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{
+						EntityType:   "global",
+						DefineEntity: &DefineEntity{Id: "project"},
+					},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc)
+	require.True(t, registry.KnownTypes()["project"])
+
+	registry.RemoveOwner("uid-1")
+	assert.False(t, registry.KnownTypes()["project"])
+	assert.True(t, registry.KnownTypes()["global"])
+}
+
+func TestEntityTypeRegistry_Remove_RefCounting(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc)
+	registry.LoadForOwner("uid-2", cc)
+	require.True(t, registry.KnownTypes()["project"])
+
+	// Remove one — "project" should still be known
+	registry.RemoveOwner("uid-1")
+	assert.True(t, registry.KnownTypes()["project"])
+
+	// Validate still passes
+	errs := registry.Validate(ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{{EntityType: "project"}},
+			},
+		},
+	})
+	assert.Empty(t, errs)
+
+	// Remove the second — now "project" should be gone
+	registry.RemoveOwner("uid-2")
+	assert.False(t, registry.KnownTypes()["project"])
+
+	// Validate now fails
+	errs = registry.Validate(ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{{EntityType: "project"}},
+			},
+		},
+	})
+	assert.Len(t, errs, 1)
+}
+
+func TestEntityTypeRegistry_Validate(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+	registry.Bulkload([]ContentConfiguration{
+		{
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "team"}},
+						{EntityType: "project", DefineEntity: &DefineEntity{Id: "component"}},
+						{EntityType: "project", DefineEntity: &DefineEntity{Id: "team"}},
+					},
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name        string
+		cc          ContentConfiguration
+		expectCount int
+	}{
+		{
+			name: "all valid",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "global"},
+							{EntityType: "project"},
+							{EntityType: "team"},
+							{EntityType: "project.component"},
+							{EntityType: "project.team"},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "unknown entityType",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "nonexistent"},
+						},
+					},
+				},
+			},
+			expectCount: 1,
+		},
+		{
+			name: "compound suffix is stripped",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "project.component::compound"},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "unknown compound base",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "nonexistent::compound"},
+						},
+					},
+				},
+			},
+			expectCount: 1,
+		},
+		{
+			name: "empty entityType is skipped",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: ""},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "global is always valid",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						NodeDefaults: &NodeDefaults{EntityType: "global"},
+						Nodes: []Node{
+							{EntityType: "global"},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "multiple unknown",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "foo"},
+							{EntityType: "bar"},
+						},
+					},
+				},
+			},
+			expectCount: 2,
+		},
+		{
+			name: "self-referencing CC defines and uses own type",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "global",
+								DefineEntity: &DefineEntity{Id: "mytype"},
+								Children: []Node{
+									{EntityType: "mytype"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "self-referencing CC with nested defineEntity",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "project",
+								DefineEntity: &DefineEntity{Id: "sub"},
+								Children: []Node{
+									{EntityType: "project.sub"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "self-referencing but also uses truly unknown type",
+			cc: ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{
+								EntityType:   "global",
+								DefineEntity: &DefineEntity{Id: "mytype"},
+								Children: []Node{
+									{EntityType: "mytype"},
+									{EntityType: "doesnotexist"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := registry.Validate(tt.cc)
+			assert.Len(t, errs, tt.expectCount)
+		})
+	}
+}
+
+func TestNormalizeEntityType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"global", "global"},
+		{"project", "project"},
+		{"project.component", "project.component"},
+		{"project.overview::compound", "project.overview"},
+		{"team.overview::compound", "team.overview"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeEntityType(tt.input))
+		})
+	}
+}
+
+func TestBuildEntityTypeName(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentType     string
+		defineEntityId string
+		expected       string
+	}{
+		{"global parent", "global", "main", "main"},
+		{"empty parent", "", "main", "main"},
+		{"non-global parent", "project", "component", "project.component"},
+		{"nested parent", "project.component", "overview", "project.component.overview"},
+		{"global compound parent", "global::compound", "test", "test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildEntityTypeName(tt.parentType, tt.defineEntityId))
+		})
+	}
+}
+
+func TestEntityTypeRegistry_ConcurrentAccess(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cc := ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+						},
+					},
+				},
+			}
+			registry.LoadForOwner(fmt.Sprintf("uid-%d", i), cc)
+		}()
+		go func() {
+			defer wg.Done()
+			cc := ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "project"},
+						},
+					},
+				},
+			}
+			registry.Validate(cc)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestValidateEntityTypes_Integration(t *testing.T) {
+	cC := NewContentConfiguration()
+	registry := NewEntityTypeRegistry()
+	registry.Bulkload([]ContentConfiguration{
+		{
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "team"}},
+					},
+				},
+			},
+		},
+	})
+
+	input := []byte(`{
+		"name": "test",
+		"luigiConfigFragment": {
+			"data": {
+				"nodes": [{
+					"entityType": "project",
+					"pathSegment": "test"
+				}]
+			}
+		}
+	}`)
+
+	merr := cC.ValidateEntityTypes(input, "json", registry)
+	assert.Nil(t, merr)
+
+	invalidInput := []byte(`{
+		"name": "test",
+		"luigiConfigFragment": {
+			"data": {
+				"nodes": [{
+					"entityType": "nonexistent",
+					"pathSegment": "test"
+				}]
+			}
+		}
+	}`)
+
+	merr = cC.ValidateEntityTypes(invalidInput, "json", registry)
+	require.NotNil(t, merr)
+	assert.GreaterOrEqual(t, merr.Len(), 1)
+	assert.Contains(t, merr.Error(), "nonexistent")
+}
+
+func TestEntityTypeRegistry_LoadForOwner_Idempotent(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc)
+	registry.LoadForOwner("uid-1", cc)
+	registry.LoadForOwner("uid-1", cc)
+
+	types := registry.KnownTypes()
+	assert.True(t, types["project"])
+	assert.True(t, types["global"])
+	assert.Len(t, types, 2)
+
+	// After removing once, project should be gone
+	registry.RemoveOwner("uid-1")
+	types = registry.KnownTypes()
+	assert.False(t, types["project"])
+	assert.True(t, types["global"])
+}
+
+func TestEntityTypeRegistry_LoadForOwner_UpdateTypes(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc1 := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+				},
+			},
+		},
+	}
+
+	cc2 := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "team"}},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc1)
+	assert.True(t, registry.KnownTypes()["project"])
+
+	// Update the same owner with different types
+	registry.LoadForOwner("uid-1", cc2)
+	types := registry.KnownTypes()
+	assert.False(t, types["project"], "old type should be removed")
+	assert.True(t, types["team"], "new type should be added")
+}
+
+func TestEntityTypeRegistry_LoadForOwner_MultipleOwners(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	cc := ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+				},
+			},
+		},
+	}
+
+	registry.LoadForOwner("uid-1", cc)
+	registry.LoadForOwner("uid-2", cc)
+
+	// Both define "project", removing one should keep it
+	registry.RemoveOwner("uid-1")
+	assert.True(t, registry.KnownTypes()["project"])
+
+	// Removing the second should remove it
+	registry.RemoveOwner("uid-2")
+	assert.False(t, registry.KnownTypes()["project"])
+}
+
+func TestEntityTypeRegistry_RemoveOwner_NonExistent(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	// Should not panic
+	registry.RemoveOwner("nonexistent-uid")
+	assert.True(t, registry.KnownTypes()["global"])
+}
+
+func TestEntityTypeRegistry_BulkloadWithOwners(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	configs := map[string]ContentConfiguration{
+		"uid-1": {
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+					},
+				},
+			},
+		},
+		"uid-2": {
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "team"}},
+					},
+				},
+			},
+		},
+	}
+
+	registry.BulkloadWithOwners(configs)
+	types := registry.KnownTypes()
+	assert.True(t, types["global"])
+	assert.True(t, types["project"])
+	assert.True(t, types["team"])
+	assert.Len(t, types, 3)
+
+	// Subsequent LoadForOwner for same uid should be idempotent
+	registry.LoadForOwner("uid-1", configs["uid-1"])
+	types = registry.KnownTypes()
+	assert.Len(t, types, 3)
+
+	// Removing uid-1 should remove project
+	registry.RemoveOwner("uid-1")
+	types = registry.KnownTypes()
+	assert.False(t, types["project"])
+	assert.True(t, types["team"])
+}
+
+func TestEntityTypeRegistry_Bulkload_ClearsOwners(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	registry.LoadForOwner("uid-1", ContentConfiguration{
+		LuigiConfigFragment: LuigiConfigFragment{
+			Data: LuigiConfigData{
+				Nodes: []Node{
+					{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+				},
+			},
+		},
+	})
+
+	// Bulkload resets everything including owners
+	registry.Bulkload([]ContentConfiguration{})
+	types := registry.KnownTypes()
+	assert.Len(t, types, 1)
+	assert.True(t, types["global"])
+
+	// RemoveOwner for the old uid should be a no-op
+	registry.RemoveOwner("uid-1")
+	assert.True(t, registry.KnownTypes()["global"])
+}
+
+func TestEntityTypeRegistry_ConcurrentAccess_WithOwners(t *testing.T) {
+	registry := NewEntityTypeRegistry()
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cc := ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+						},
+					},
+				},
+			}
+			registry.LoadForOwner(fmt.Sprintf("uid-%d", i), cc)
+		}()
+		go func() {
+			defer wg.Done()
+			registry.Validate(ContentConfiguration{
+				LuigiConfigFragment: LuigiConfigFragment{
+					Data: LuigiConfigData{
+						Nodes: []Node{
+							{EntityType: "project"},
+						},
+					},
+				},
+			})
+		}()
+	}
+	wg.Wait()
+}

--- a/operators/extension-manager-operator/pkg/validation/interface.go
+++ b/operators/extension-manager-operator/pkg/validation/interface.go
@@ -20,5 +20,6 @@ import "github.com/hashicorp/go-multierror"
 
 type ExtensionConfiguration interface {
 	Validate([]byte, string) (string, *multierror.Error)
+	ValidateEntityTypes(input []byte, contentType string, registry *EntityTypeRegistry) *multierror.Error
 	WithSchema([]byte) error
 }

--- a/operators/extension-manager-operator/pkg/validation/mocks/mock_ExtensionConfiguration.go
+++ b/operators/extension-manager-operator/pkg/validation/mocks/mock_ExtensionConfiguration.go
@@ -23,6 +23,8 @@ package mocks
 import (
 	"github.com/hashicorp/go-multierror"
 	mock "github.com/stretchr/testify/mock"
+
+	validation "go.platform-mesh.io/extension-manager-operator/pkg/validation"
 )
 
 // NewExtensionConfiguration creates a new instance of ExtensionConfiguration. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -116,6 +118,56 @@ func (_c *ExtensionConfiguration_Validate_Call) Return(s1 string, error *multier
 }
 
 func (_c *ExtensionConfiguration_Validate_Call) RunAndReturn(run func(bytes []byte, s string) (string, *multierror.Error)) *ExtensionConfiguration_Validate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidateEntityTypes provides a mock function for the type ExtensionConfiguration
+func (_mock *ExtensionConfiguration) ValidateEntityTypes(input []byte, contentType string, registry *validation.EntityTypeRegistry) *multierror.Error {
+	ret := _mock.Called(input, contentType, registry)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateEntityTypes")
+	}
+
+	var r0 *multierror.Error
+	if returnFunc, ok := ret.Get(0).(func([]byte, string, *validation.EntityTypeRegistry) *multierror.Error); ok {
+		r0 = returnFunc(input, contentType, registry)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*multierror.Error)
+		}
+	}
+
+	return r0
+}
+
+// ExtensionConfiguration_ValidateEntityTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateEntityTypes'
+type ExtensionConfiguration_ValidateEntityTypes_Call struct {
+	*mock.Call
+}
+
+// ValidateEntityTypes is a helper method to define mock.On call
+//   - input []byte
+//   - contentType string
+//   - registry *validation.EntityTypeRegistry
+func (_e *ExtensionConfiguration_Expecter) ValidateEntityTypes(input interface{}, contentType interface{}, registry interface{}) *ExtensionConfiguration_ValidateEntityTypes_Call {
+	return &ExtensionConfiguration_ValidateEntityTypes_Call{Call: _e.mock.On("ValidateEntityTypes", input, contentType, registry)}
+}
+
+func (_c *ExtensionConfiguration_ValidateEntityTypes_Call) Run(run func(input []byte, contentType string, registry *validation.EntityTypeRegistry)) *ExtensionConfiguration_ValidateEntityTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]byte), args[1].(string), args[2].(*validation.EntityTypeRegistry))
+	})
+	return _c
+}
+
+func (_c *ExtensionConfiguration_ValidateEntityTypes_Call) Return(_a0 *multierror.Error) *ExtensionConfiguration_ValidateEntityTypes_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ExtensionConfiguration_ValidateEntityTypes_Call) RunAndReturn(run func([]byte, string, *validation.EntityTypeRegistry) *multierror.Error) *ExtensionConfiguration_ValidateEntityTypes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/operators/extension-manager-operator/pkg/validation/validate.go
+++ b/operators/extension-manager-operator/pkg/validation/validate.go
@@ -144,3 +144,41 @@ func convertYAMLToJSON(yamlData []byte) ([]byte, error) {
 
 	return jsonData, nil
 }
+
+func (cC *contentConfiguration) ValidateEntityTypes(input []byte, contentType string, registry *EntityTypeRegistry) *multierror.Error {
+	if registry == nil {
+		return multierror.Append(nil, fmt.Errorf("entity type registry is nil"))
+	}
+
+	rawJSON, err := toJSON(input, contentType)
+	if err != nil {
+		return multierror.Append(nil, err)
+	}
+
+	var cc ContentConfiguration
+	if err := json.Unmarshal(rawJSON, &cc); err != nil {
+		return multierror.Append(nil, fmt.Errorf("error unmarshalling content configuration: %w", err))
+	}
+
+	errs := registry.Validate(cc)
+	if len(errs) == 0 {
+		return nil
+	}
+
+	merr := &multierror.Error{}
+	for _, e := range errs {
+		merr = multierror.Append(merr, e)
+	}
+	return merr
+}
+
+func toJSON(input []byte, contentType string) ([]byte, error) {
+	switch strings.ToLower(contentType) {
+	case "json":
+		return input, nil
+	case "yaml":
+		return convertYAMLToJSON(input)
+	default:
+		return nil, ErrorNoValidator
+	}
+}

--- a/operators/extension-manager-operator/pkg/validation/validate_test.go
+++ b/operators/extension-manager-operator/pkg/validation/validate_test.go
@@ -440,3 +440,79 @@ func allErrorsContained(merr multierror.Error, expectedErrors []string) bool {
 
 	return true
 }
+
+func TestValidateEntityTypes(t *testing.T) {
+	cC := NewContentConfiguration()
+	registry := NewEntityTypeRegistry()
+	registry.Bulkload([]ContentConfiguration{
+		{
+			LuigiConfigFragment: LuigiConfigFragment{
+				Data: LuigiConfigData{
+					Nodes: []Node{
+						{EntityType: "global", DefineEntity: &DefineEntity{Id: "project"}},
+					},
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name        string
+		input       string
+		contentType string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid entity type",
+			input:       `{"name": "test", "luigiConfigFragment": {"data": {"nodes": [{"entityType": "project"}]}}}`,
+			contentType: "json",
+		},
+		{
+			name:        "unknown entity type",
+			input:       `{"name": "test", "luigiConfigFragment": {"data": {"nodes": [{"entityType": "unknown"}]}}}`,
+			contentType: "json",
+			expectError: true,
+			errorMsg:    "unknown",
+		},
+		{
+			name:        "valid YAML input",
+			input:       "name: test\nluigiConfigFragment:\n  data:\n    nodes:\n    - entityType: global\n",
+			contentType: "yaml",
+		},
+		{
+			name:        "unsupported content type",
+			input:       "test",
+			contentType: "xml",
+			expectError: true,
+			errorMsg:    "no validator found",
+		},
+		{
+			name:        "invalid JSON unmarshal",
+			input:       `{not json`,
+			contentType: "json",
+			expectError: true,
+			errorMsg:    "error unmarshalling",
+		},
+		{
+			name:        "invalid YAML",
+			input:       "!invalid: {{{",
+			contentType: "yaml",
+			expectError: true,
+			errorMsg:    "error unmarshalling",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merr := cC.ValidateEntityTypes([]byte(tt.input), tt.contentType, registry)
+			if tt.expectError {
+				assert.NotNil(t, merr)
+				assert.GreaterOrEqual(t, merr.Len(), 1)
+				assert.Contains(t, merr.Error(), tt.errorMsg)
+			} else {
+				assert.Nil(t, merr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Validate entityType references in ContentConfigurations against known entity types defined via `defineEntity` segments across all CCs in the system. Unknown entity types are reported as hard validation failures.

The feature is gated behind `--entity-type-validation-enabled` (default **false**) on both the operator and server.

Closes #75

---

Migrated from https://github.com/platform-mesh/extension-manager-operator/pull/702 — that PR was created before the monorepo existed and is now superseded by this one.