### PR TITLE
fix(gateway): clean up ClusterAccess schemas on deletion

### DIFF
--- a/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller.go
@@ -47,8 +47,10 @@ import (
 )
 
 const (
-	controllerName         = "clusteraccess-schema-controller"
-	schemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
+	controllerName = "clusteraccess-schema-controller"
+
+	// SchemaCleanupFinalizer ensures the generated schema is removed before a ClusterAccess is deleted.
+	SchemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
 
 	// ConditionTypeReady indicates whether the ClusterAccess schema was
 	// successfully generated and written.
@@ -119,14 +121,14 @@ func (r *ClusterAccessReconciler) Reconcile(ctx context.Context, req mcreconcile
 	}
 
 	if !ca.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+		if controllerutil.ContainsFinalizer(ca, SchemaCleanupFinalizer) {
 			schemaPath := resolveSchemaPath(ca, clusterName)
 			if err := r.ioHandler.Delete(ctx, schemaPath); err != nil && !errors.Is(err, schemahandler.ErrNotExist) {
 				return ctrl.Result{}, fmt.Errorf("failed to clean up schema %q: %w", schemaPath, err)
 			}
 
 			patch := ctrlruntimeclient.MergeFrom(ca.DeepCopy())
-			controllerutil.RemoveFinalizer(ca, schemaCleanupFinalizer)
+			controllerutil.RemoveFinalizer(ca, SchemaCleanupFinalizer)
 			if err := c.Patch(ctx, ca, patch); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove schema cleanup finalizer: %w", err)
 			}
@@ -135,9 +137,9 @@ func (r *ClusterAccessReconciler) Reconcile(ctx context.Context, req mcreconcile
 		return ctrl.Result{}, nil
 	}
 
-	if !controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+	if !controllerutil.ContainsFinalizer(ca, SchemaCleanupFinalizer) {
 		patch := ctrlruntimeclient.MergeFrom(ca.DeepCopy())
-		controllerutil.AddFinalizer(ca, schemaCleanupFinalizer)
+		controllerutil.AddFinalizer(ca, SchemaCleanupFinalizer)
 		if err := c.Patch(ctx, ca, patch); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add schema cleanup finalizer: %w", err)
 		}

--- a/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller.go
@@ -39,6 +39,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -46,7 +47,8 @@ import (
 )
 
 const (
-	controllerName = "clusteraccess-schema-controller"
+	controllerName         = "clusteraccess-schema-controller"
+	schemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
 
 	// ConditionTypeReady indicates whether the ClusterAccess schema was
 	// successfully generated and written.
@@ -102,18 +104,44 @@ func (r *ClusterAccessReconciler) Reconcile(ctx context.Context, req mcreconcile
 	if err := c.Get(ctx, ctrlruntimeclient.ObjectKey{Name: req.Name}, ca); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("ClusterAccess resource not found, cleaning up schema", "name", req.Name)
-			// Delete the schema file if ClusterAccess is deleted
-			// Try both possible paths (resource name and path field)
+			// Resources created before the cleanup finalizer was introduced can only
+			// be cleaned up by their object name because spec.path is no longer available.
 			name := req.Name
 			if clusterName != "" {
 				name = fmt.Sprintf("%s-%s", clusterName, name)
 			}
-			if err := r.ioHandler.Delete(ctx, name); err != nil {
-				logger.Error(err, "Failed to cleanup schema")
+			if err := r.ioHandler.Delete(ctx, name); err != nil && !errors.Is(err, schemahandler.ErrNotExist) {
+				return ctrl.Result{}, fmt.Errorf("failed to clean up legacy schema %q: %w", name, err)
 			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get ClusterAccess: %w", err)
+	}
+
+	if !ca.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+			schemaPath := resolveSchemaPath(ca, clusterName)
+			if err := r.ioHandler.Delete(ctx, schemaPath); err != nil && !errors.Is(err, schemahandler.ErrNotExist) {
+				return ctrl.Result{}, fmt.Errorf("failed to clean up schema %q: %w", schemaPath, err)
+			}
+
+			patch := ctrlruntimeclient.MergeFrom(ca.DeepCopy())
+			controllerutil.RemoveFinalizer(ca, schemaCleanupFinalizer)
+			if err := c.Patch(ctx, ca, patch); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove schema cleanup finalizer: %w", err)
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(ca, schemaCleanupFinalizer) {
+		patch := ctrlruntimeclient.MergeFrom(ca.DeepCopy())
+		controllerutil.AddFinalizer(ca, schemaCleanupFinalizer)
+		if err := c.Patch(ctx, ca, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add schema cleanup finalizer: %w", err)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	result, reconcileErr := r.reconcileClusterAccess(ctx, ca, c, cl.GetConfig(), clusterName)
@@ -136,14 +164,7 @@ func (r *ClusterAccessReconciler) reconcileClusterAccess(
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Determine cluster name/path for the schema file
-	clusterName := ca.GetName()
-	if ca.Spec.Path != "" {
-		clusterName = ca.Spec.Path
-	}
-	if reqClusterName != "" {
-		clusterName = fmt.Sprintf("%s-%s", reqClusterName, clusterName)
-	}
+	clusterName := resolveSchemaPath(ca, reqClusterName)
 
 	// Build target cluster config from ClusterAccess spec
 	targetConfig, err := buildTargetClusterConfig(ctx, *ca, c, currentConfig)
@@ -237,6 +258,17 @@ func (r *ClusterAccessReconciler) SetupWithManager(mgr mcmanager.Manager, forOpt
 		WithOptions(r.opts).
 		Named(controllerName).
 		Complete(r)
+}
+
+func resolveSchemaPath(ca *pmgatewayv1alpha1.ClusterAccess, clusterName string) string {
+	name := ca.Name
+	if ca.Spec.Path != "" {
+		name = ca.Spec.Path
+	}
+	if clusterName != "" {
+		return fmt.Sprintf("%s-%s", clusterName, name)
+	}
+	return name
 }
 
 func buildTargetClusterConfig(ctx context.Context, clusterAccess pmgatewayv1alpha1.ClusterAccess, c ctrlruntimeclient.Client, currentConfig *rest.Config) (*rest.Config, error) {

--- a/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller_test.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller_test.go
@@ -20,8 +20,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,10 +34,12 @@ import (
 	"go.platform-mesh.io/kubernetes-graphql-gateway/listener"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/listener/controllers/clusteraccess"
 	"go.platform-mesh.io/kubernetes-graphql-gateway/listener/options"
+	"go.platform-mesh.io/kubernetes-graphql-gateway/listener/pkg/schemahandler"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -49,15 +54,33 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 )
 
-const testNamespace = "test-ns"
+const (
+	testNamespace          = "test-ns"
+	schemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
+)
+
+var errInjectedSchemaDelete = errors.New("injected schema deletion failure")
+
+type controllableSchemaHandler struct {
+	schemahandler.Handler
+	failDelete atomic.Bool
+}
+
+func (h *controllableSchemaHandler) Delete(ctx context.Context, clusterName string) error {
+	if h.failDelete.Load() {
+		return errInjectedSchemaDelete
+	}
+	return h.Handler.Delete(ctx, clusterName)
+}
 
 type ClusterAccessControllerTestSuite struct {
 	suite.Suite
 
-	env         *envtest.Environment
-	listenerCfg *listener.Config
-	cancel      context.CancelFunc
-	client      ctrlruntimeclient.Client
+	env           *envtest.Environment
+	listenerCfg   *listener.Config
+	cancel        context.CancelFunc
+	client        ctrlruntimeclient.Client
+	schemaHandler *controllableSchemaHandler
 
 	// Store envtest credentials for creating test secrets
 	envtestHost       string
@@ -111,11 +134,13 @@ func (suite *ClusterAccessControllerTestSuite) SetupSuite() {
 	listenerConfig, err := listener.NewConfig(completedOpts)
 	suite.Require().NoError(err, "failed to create listener config")
 
+	suite.schemaHandler = &controllableSchemaHandler{Handler: listenerConfig.SchemaHandler}
+
 	r, err := clusteraccess.NewClusterAccessReconciler(
 		suite.T().Context(),
 		listenerConfig.Manager,
 		controller.TypedOptions[mcreconcile.Request]{},
-		listenerConfig.SchemaHandler,
+		suite.schemaHandler,
 	)
 	suite.Require().NoError(err, "failed to create clusteraccess reconciler")
 
@@ -216,6 +241,69 @@ func (suite *ClusterAccessControllerTestSuite) waitForSchemaFile(name string) []
 	}, 10*time.Second, 500*time.Millisecond,
 		"expected schema file to be generated for %s", name)
 	return raw
+}
+
+func (suite *ClusterAccessControllerTestSuite) waitForSchemaFileDeleted(name string) {
+	schemaFilePath := filepath.Join(suite.listenerCfg.Options.SchemasDir, name)
+	suite.Eventually(func() bool {
+		_, err := os.Stat(schemaFilePath)
+		return os.IsNotExist(err)
+	}, 10*time.Second, 250*time.Millisecond,
+		"expected schema file to be deleted for %s", name)
+}
+
+func (suite *ClusterAccessControllerTestSuite) waitForClusterAccessDeleted(name string) {
+	suite.Eventually(func() bool {
+		err := suite.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, &pmgatewayv1alpha1.ClusterAccess{})
+		return apierrors.IsNotFound(err)
+	}, 10*time.Second, 250*time.Millisecond,
+		"expected ClusterAccess %s to be deleted", name)
+}
+
+func (suite *ClusterAccessControllerTestSuite) waitForSchemaCleanupFinalizer(name string) *pmgatewayv1alpha1.ClusterAccess {
+	clusterAccess := &pmgatewayv1alpha1.ClusterAccess{}
+	suite.Eventually(func() bool {
+		if err := suite.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, clusterAccess); err != nil {
+			return false
+		}
+		return slices.Contains(clusterAccess.Finalizers, schemaCleanupFinalizer)
+	}, 10*time.Second, 250*time.Millisecond,
+		"expected ClusterAccess %s to have schema cleanup finalizer", name)
+	return clusterAccess
+}
+
+func (suite *ClusterAccessControllerTestSuite) createKubeconfigClusterAccess(name, schemaPath string) *pmgatewayv1alpha1.ClusterAccess {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-kubeconfig",
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"kubeconfig": suite.envtestKubeconfig,
+		},
+	}
+	err := suite.client.Create(context.Background(), secret)
+	suite.Require().NoError(err, "failed to create kubeconfig secret")
+
+	clusterAccess := &pmgatewayv1alpha1.ClusterAccess{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: pmgatewayv1alpha1.ClusterAccessSpec{
+			Path: schemaPath,
+			Auth: &pmgatewayv1alpha1.AuthConfig{
+				KubeconfigSecretRef: &pmgatewayv1alpha1.SecretKeyRef{
+					SecretReference: corev1.SecretReference{
+						Name:      secret.Name,
+						Namespace: secret.Namespace,
+					},
+					Key: "kubeconfig",
+				},
+			},
+		},
+	}
+	err = suite.client.Create(context.Background(), clusterAccess)
+	suite.Require().NoError(err, "failed to create ClusterAccess")
+
+	return clusterAccess
 }
 
 // verifySchemaMetadata validates the contents of a schema file
@@ -537,4 +625,92 @@ func (suite *ClusterAccessControllerTestSuite) TestServiceAccountAuth() {
 	suite.Equal("test-sa", metadata.Auth.SAName, "SA name should match")
 	suite.Equal(testNamespace, metadata.Auth.SANamespace, "SA namespace should match")
 	suite.NotEmpty(metadata.Auth.Token, "SA auth should have generated token")
+}
+
+func (suite *ClusterAccessControllerTestSuite) TestCustomPathSchemaCleanup() {
+	const (
+		name       = "custom-path-cleanup"
+		schemaPath = "custom-schema-path"
+		schemaName = "single-" + schemaPath
+	)
+
+	suite.createKubeconfigClusterAccess(name, schemaPath)
+	suite.waitForSchemaFile(schemaName)
+	clusterAccess := suite.waitForSchemaCleanupFinalizer(name)
+
+	err := suite.client.Delete(context.Background(), clusterAccess)
+	suite.Require().NoError(err)
+
+	suite.waitForSchemaFileDeleted(schemaName)
+	suite.waitForClusterAccessDeleted(name)
+}
+
+func (suite *ClusterAccessControllerTestSuite) TestDefaultPathSchemaCleanup() {
+	const (
+		name       = "default-path-cleanup"
+		schemaName = "single-" + name
+	)
+
+	suite.createKubeconfigClusterAccess(name, "")
+	suite.waitForSchemaFile(schemaName)
+	clusterAccess := suite.waitForSchemaCleanupFinalizer(name)
+
+	err := suite.client.Delete(context.Background(), clusterAccess)
+	suite.Require().NoError(err)
+
+	suite.waitForSchemaFileDeleted(schemaName)
+	suite.waitForClusterAccessDeleted(name)
+}
+
+func (suite *ClusterAccessControllerTestSuite) TestCustomPathCleanupAllowsMissingSchema() {
+	const (
+		name       = "missing-schema-cleanup"
+		schemaPath = "missing-schema-path"
+		schemaName = "single-" + schemaPath
+	)
+
+	suite.createKubeconfigClusterAccess(name, schemaPath)
+	suite.waitForSchemaFile(schemaName)
+	clusterAccess := suite.waitForSchemaCleanupFinalizer(name)
+
+	schemaFilePath := filepath.Join(suite.listenerCfg.Options.SchemasDir, schemaName)
+	err := os.Remove(schemaFilePath)
+	suite.Require().NoError(err)
+
+	err = suite.client.Delete(context.Background(), clusterAccess)
+	suite.Require().NoError(err)
+
+	suite.waitForClusterAccessDeleted(name)
+}
+
+func (suite *ClusterAccessControllerTestSuite) TestCustomPathCleanupRetriesAfterFailure() {
+	const (
+		name       = "retry-schema-cleanup"
+		schemaPath = "retry-schema-path"
+		schemaName = "single-" + schemaPath
+	)
+
+	suite.createKubeconfigClusterAccess(name, schemaPath)
+	suite.waitForSchemaFile(schemaName)
+	clusterAccess := suite.waitForSchemaCleanupFinalizer(name)
+
+	suite.schemaHandler.failDelete.Store(true)
+	defer suite.schemaHandler.failDelete.Store(false)
+
+	err := suite.client.Delete(context.Background(), clusterAccess)
+	suite.Require().NoError(err)
+
+	suite.Eventually(func() bool {
+		current := &pmgatewayv1alpha1.ClusterAccess{}
+		if err := suite.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, current); err != nil {
+			return false
+		}
+		return !current.DeletionTimestamp.IsZero() && slices.Contains(current.Finalizers, schemaCleanupFinalizer)
+	}, 10*time.Second, 250*time.Millisecond,
+		"expected cleanup failure to retain the finalizer")
+
+	suite.schemaHandler.failDelete.Store(false)
+
+	suite.waitForSchemaFileDeleted(schemaName)
+	suite.waitForClusterAccessDeleted(name)
 }

--- a/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller_test.go
+++ b/services/kubernetes-graphql-gateway/listener/controllers/clusteraccess/clusteraccess_controller_test.go
@@ -54,10 +54,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 )
 
-const (
-	testNamespace          = "test-ns"
-	schemaCleanupFinalizer = "gateway.platform-mesh.io/schema-cleanup"
-)
+const testNamespace = "test-ns"
 
 var errInjectedSchemaDelete = errors.New("injected schema deletion failure")
 
@@ -266,7 +263,7 @@ func (suite *ClusterAccessControllerTestSuite) waitForSchemaCleanupFinalizer(nam
 		if err := suite.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, clusterAccess); err != nil {
 			return false
 		}
-		return slices.Contains(clusterAccess.Finalizers, schemaCleanupFinalizer)
+		return slices.Contains(clusterAccess.Finalizers, clusteraccess.SchemaCleanupFinalizer)
 	}, 10*time.Second, 250*time.Millisecond,
 		"expected ClusterAccess %s to have schema cleanup finalizer", name)
 	return clusterAccess
@@ -705,7 +702,7 @@ func (suite *ClusterAccessControllerTestSuite) TestCustomPathCleanupRetriesAfter
 		if err := suite.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, current); err != nil {
 			return false
 		}
-		return !current.DeletionTimestamp.IsZero() && slices.Contains(current.Finalizers, schemaCleanupFinalizer)
+		return !current.DeletionTimestamp.IsZero() && slices.Contains(current.Finalizers, clusteraccess.SchemaCleanupFinalizer)
 	}, 10*time.Second, 250*time.Millisecond,
 		"expected cleanup failure to retain the finalizer")
 

--- a/services/kubernetes-graphql-gateway/listener/pkg/schemahandler/file.go
+++ b/services/kubernetes-graphql-gateway/listener/pkg/schemahandler/file.go
@@ -19,6 +19,7 @@ package schemahandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -72,7 +73,10 @@ func (h *FileHandler) Write(_ context.Context, JSON []byte, clusterName string) 
 func (h *FileHandler) Delete(_ context.Context, clusterName string) error {
 	fileName := path.Join(h.schemasDir, clusterName)
 	if err := os.Remove(fileName); err != nil {
-		return errors.Join(ErrNotExist, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.Join(ErrNotExist, err)
+		}
+		return fmt.Errorf("failed to delete schema %q: %w", clusterName, err)
 	}
 	return nil
 }

--- a/services/kubernetes-graphql-gateway/listener/pkg/schemahandler/file_test.go
+++ b/services/kubernetes-graphql-gateway/listener/pkg/schemahandler/file_test.go
@@ -131,12 +131,14 @@ func TestDelete(t *testing.T) {
 	assert.NoError(t, err)
 
 	tests := map[string]struct {
-		clusterName string
-		expectErr   bool
+		clusterName   string
+		expectErr     bool
+		expectMissing bool
 	}{
-		"existing_file":     {clusterName: existing, expectErr: false},
-		"nested_file":       {clusterName: nested, expectErr: false},
-		"non_existent_file": {clusterName: "does/not/exist", expectErr: true},
+		"existing_file":     {clusterName: existing},
+		"nested_file":       {clusterName: nested},
+		"non_existent_file": {clusterName: "does/not/exist", expectErr: true, expectMissing: true},
+		"invalid_path":      {clusterName: "invalid\x00name", expectErr: true},
 	}
 
 	for name, tc := range tests {
@@ -144,6 +146,11 @@ func TestDelete(t *testing.T) {
 			err := handler.Delete(t.Context(), tc.clusterName)
 			if tc.expectErr {
 				assert.Error(t, err)
+				if tc.expectMissing {
+					assert.ErrorIs(t, err, schemahandler.ErrNotExist)
+				} else {
+					assert.NotErrorIs(t, err, schemahandler.ErrNotExist)
+				}
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
## Summary

- add a finalizer so the effective ClusterAccess schema path remains available during deletion
- remove schemas using the same resolved path used during generation
- retain the finalizer and retry when backend cleanup fails
- allow deletion to complete when the schema is already absent
- preserve name-based cleanup for resources created before the finalizer existed

This builds on and hardens the approach proposed in the archived [kubernetes-graphql-gateway PR #220](https://github.com/platform-mesh/kubernetes-graphql-gateway/pull/220).

Fixes #129

## Testing

- `go test ./... -count=1`
- `task lint`
- focused envtest coverage for custom paths, default paths, missing schemas, and cleanup failure/recovery