### PR TITLE
fix(virtual-workspaces): scope marketplace exports to the providers cluster

### DIFF
--- a/services/virtual-workspaces/pkg/marketplace/server.go
+++ b/services/virtual-workspaces/pkg/marketplace/server.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
@@ -82,7 +84,17 @@ func BuildVirtualWorkspace(
 					return nil, err
 				}
 
-				marketplaceFilter := storage.Marketplace(provider, cfg)
+				marketplaceFilter := storage.Marketplace(
+					provider.Lister(),
+					func(ctx context.Context, name string) (ctrlruntimeclient.Client, error) {
+						cl, err := provider.Get(ctx, multicluster.ClusterName(name))
+						if err != nil {
+							return nil, err
+						}
+						return cl.GetClient(), nil
+					},
+					cfg,
+				)
 
 				storageProvider := storage.CreateStorageProviderFunc(
 					dynamicClient,

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -202,102 +201,79 @@ func Marketplace(
 	clusterClient func(context.Context, string) (ctrlruntimeclient.Client, error),
 	cfg config.ServiceConfig,
 ) forwardingregistry.StorageWrapper {
-	return forwardingregistry.StorageWrapperFunc(
-		func(groupResource schema.GroupResource, storage *forwardingregistry.StoreFuncs) {
-			storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-				cluster := genericapirequest.ClusterFrom(ctx)
+	return forwardingregistry.StorageWrapperFunc(func(resource schema.GroupResource, storage *forwardingregistry.StoreFuncs) {
+		storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+			cluster := genericapirequest.ClusterFrom(ctx)
 
-				cl, err := clusterClient(ctx, cluster.Name.String())
-				if err != nil {
-					return nil, fmt.Errorf("failed to get cluster from provider: %w", err)
-				}
-
-				// Get APIBindings for this specific cluster
-				installedAPIBindings := &kcpapisv1alpha1.APIBindingList{}
-				if err := cl.List(ctx, installedAPIBindings); err != nil {
-					return nil, fmt.Errorf("failed to list apibindings: %w", err)
-				}
-
-				var providerList pmuiv1alpha1.ProviderMetadataList
-				if err := lister.List(ctx, &providerList); err != nil {
-					return nil, fmt.Errorf("failed to list providermetadatas: %w", err)
-				}
-
-				var exportList kcpapisv1alpha1.APIExportList
-
-				req, err := labels.NewRequirement(cfg.ContentForLabel, selection.Exists, nil)
-				if err != nil {
-					return nil, fmt.Errorf("constructing label requirement: %w", err)
-				}
-				err = lister.List(ctx, &exportList, &ctrlruntimeclient.ListOptions{
-					LabelSelector: labels.NewSelector().Add(*req),
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to list apiexports: %w", err)
-				}
-
-				results, err := buildMarketplaceEntries(providerList, exportList.Items, installedAPIBindings, cfg)
-				if err != nil {
-					return nil, err
-				}
-				return &results, nil
-			}
-		})
-}
-
-func buildMarketplaceEntries(
-	providers pmuiv1alpha1.ProviderMetadataList,
-	apiExports []kcpapisv1alpha1.APIExport,
-	bindings *kcpapisv1alpha1.APIBindingList,
-	cfg config.ServiceConfig,
-) (unstructured.UnstructuredList, error) {
-	byProvider := make(map[string][]kcpapisv1alpha1.APIExport)
-	for _, v := range apiExports {
-		byProvider[v.Labels[cfg.ContentForLabel]] = append(byProvider[v.Labels[cfg.ContentForLabel]], v)
-	}
-
-	var results unstructured.UnstructuredList
-	results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
-	// For each provider, find matching APIExports across all shards
-	for _, providerMeta := range providers.Items {
-		exports := byProvider[providerMeta.GetName()]
-		for _, export := range exports {
-			if len(export.Spec.LatestResourceSchemas) == 0 {
-				continue
-			}
-
-			idx := slices.IndexFunc(bindings.Items, func(item kcpapisv1alpha1.APIBinding) bool {
-				return item.Spec.Reference.Export.Name == export.Name &&
-					item.Status.APIExportClusterName == export.Annotations["kcp.io/cluster"]
-			})
-
-			var apiBindingName string
-			if idx != -1 {
-				apiBindingName = bindings.Items[idx].Name
-			}
-
-			providerMeta.ManagedFields = nil // clear managed fields to declutter the output
-			export.ManagedFields = nil
-
-			unstructuredEntry, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pmmarketplacev1alpha1.MarketplaceEntry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%s", export.Name, providerMeta.Name), // TODO: we might need to fix the name length to not exceed the kubernetes limit
-				},
-				Spec: pmmarketplacev1alpha1.MarketplaceEntrySpec{
-					ProviderMetadata: *providerMeta.DeepCopy(),
-					APIExport:        *export.DeepCopy(),
-					APIBindingName:   apiBindingName,
-				},
-			})
+			cl, err := clusterClient(ctx, cluster.Name.String())
 			if err != nil {
-				return unstructured.UnstructuredList{}, fmt.Errorf(
-					"failed to convert marketplace entry to unstructured for export %s and provider %s: %w", export.Name, providerMeta.Name, err)
+				return nil, fmt.Errorf("failed to get cluster from provider: %w", err)
 			}
 
-			us := unstructured.Unstructured{Object: unstructuredEntry}
-			us.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntry"))
-			results.Items = append(results.Items, us)
+			// Get APIBindings for this specific cluster
+			installedAPIBindings := &kcpapisv1alpha1.APIBindingList{}
+			if err := cl.List(ctx, installedAPIBindings); err != nil {
+				return nil, fmt.Errorf("failed to list apibindings: %w", err)
+			}
+
+			var providerList pmuiv1alpha1.ProviderMetadataList
+			if err := lister.List(ctx, &providerList); err != nil {
+				return nil, fmt.Errorf("failed to list providermetadatas: %w", err)
+			}
+
+			var results unstructured.UnstructuredList
+			results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
+
+			// For each provider, find matching APIExports across all shards
+			for _, provider := range providerList.Items {
+				exportList := &kcpapisv1alpha1.APIExportList{}
+
+				if err := lister.List(ctx, exportList, &ctrlruntimeclient.ListOptions{
+					LabelSelector: labels.SelectorFromValidatedSet(map[string]string{
+						cfg.ContentForLabel: provider.GetName(),
+					}),
+				}); err != nil {
+					return nil, fmt.Errorf("failed to list apiexports for provider %s: %w", provider.GetName(), err)
+				}
+
+				for _, export := range exportList.Items {
+					if len(export.Spec.LatestResourceSchemas) == 0 {
+						continue
+					}
+
+					idx := slices.IndexFunc(installedAPIBindings.Items, func(item kcpapisv1alpha1.APIBinding) bool {
+						return item.Spec.Reference.Export.Name == export.Name &&
+							item.Status.APIExportClusterName == export.Annotations["kcp.io/cluster"]
+					})
+
+					var apiBindingName string
+					if idx != -1 {
+						apiBindingName = installedAPIBindings.Items[idx].Name
+					}
+
+					provider.ManagedFields = nil // clear managed fields to declutter the output
+					export.ManagedFields = nil
+
+					unstructuredEntry, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pmmarketplacev1alpha1.MarketplaceEntry{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-%s", export.Name, provider.Name), // TODO: we might need to fix the name length to not exceed the kubernetes limit
+						},
+						Spec: pmmarketplacev1alpha1.MarketplaceEntrySpec{
+							ProviderMetadata: *provider.DeepCopy(),
+							APIExport:        *export.DeepCopy(),
+							APIBindingName:   apiBindingName,
+						},
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to convert marketplace entry to unstructured for export %s and provider %s: %w", export.Name, provider.Name, err)
+					}
+
+					us := unstructured.Unstructured{Object: unstructuredEntry}
+					us.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntry"))
+					results.Items = append(results.Items, us)
+				}
+			}
+			return &results, nil
 		}
-	}
-	return results, nil
+	})
 }

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -223,19 +224,28 @@ func Marketplace(provider *apiexport.Provider, cfg config.ServiceConfig) forward
 			var results unstructured.UnstructuredList
 			results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
 
+			var exportList kcpapisv1alpha1.APIExportList
+
+			req, err := labels.NewRequirement(cfg.ContentForLabel, selection.Exists, nil)
+			if err != nil {
+				return nil, fmt.Errorf("constructing label requirement: %w", err)
+			}
+			err = lister.List(ctx, &exportList, &ctrlruntimeclient.ListOptions{
+				LabelSelector: labels.NewSelector().Add(*req),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list apiexports: %w", err)
+			}
+
+			byProvider := make(map[string][]kcpapisv1alpha1.APIExport)
+			for _, v := range exportList.Items {
+				byProvider[v.Labels[cfg.ContentForLabel]] = append(byProvider[v.Labels[cfg.ContentForLabel]], v)
+			}
+
 			// For each provider, find matching APIExports across all shards
 			for _, provider := range providerList.Items {
-				exportList := &kcpapisv1alpha1.APIExportList{}
-
-				if err := lister.List(ctx, exportList, &ctrlruntimeclient.ListOptions{
-					LabelSelector: labels.SelectorFromValidatedSet(map[string]string{
-						cfg.ContentForLabel: provider.GetName(),
-					}),
-				}); err != nil {
-					return nil, fmt.Errorf("failed to list apiexports for provider %s: %w", provider.GetName(), err)
-				}
-
-				for _, export := range exportList.Items {
+				exports := byProvider[provider.GetName()]
+				for _, export := range exports {
 					if len(export.Spec.LatestResourceSchemas) == 0 {
 						continue
 					}

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -37,11 +37,10 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/logicalcluster/v3"
-	"github.com/kcp-dev/multicluster-provider/apiexport"
+	mcpcache "github.com/kcp-dev/multicluster-provider/pkg/cache"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
 )
@@ -198,91 +197,107 @@ func ContentConfigurationLookup(client dynamic.ClusterInterface, cfg config.Serv
 	})
 }
 
-func Marketplace(provider *apiexport.Provider, cfg config.ServiceConfig) forwardingregistry.StorageWrapper {
-	return forwardingregistry.StorageWrapperFunc(func(resource schema.GroupResource, storage *forwardingregistry.StoreFuncs) {
-		storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-			cluster := genericapirequest.ClusterFrom(ctx)
+func Marketplace(
+	lister mcpcache.Lister,
+	clusterClient func(context.Context, string) (ctrlruntimeclient.Client, error),
+	cfg config.ServiceConfig,
+) forwardingregistry.StorageWrapper {
+	return forwardingregistry.StorageWrapperFunc(
+		func(groupResource schema.GroupResource, storage *forwardingregistry.StoreFuncs) {
+			storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+				cluster := genericapirequest.ClusterFrom(ctx)
 
-			cl, err := provider.Get(ctx, multicluster.ClusterName(cluster.Name.String()))
-			if err != nil {
-				return nil, fmt.Errorf("failed to get cluster from provider: %w", err)
+				cl, err := clusterClient(ctx, cluster.Name.String())
+				if err != nil {
+					return nil, fmt.Errorf("failed to get cluster from provider: %w", err)
+				}
+
+				// Get APIBindings for this specific cluster
+				installedAPIBindings := &kcpapisv1alpha1.APIBindingList{}
+				if err := cl.List(ctx, installedAPIBindings); err != nil {
+					return nil, fmt.Errorf("failed to list apibindings: %w", err)
+				}
+
+				var providerList pmuiv1alpha1.ProviderMetadataList
+				if err := lister.List(ctx, &providerList); err != nil {
+					return nil, fmt.Errorf("failed to list providermetadatas: %w", err)
+				}
+
+				var exportList kcpapisv1alpha1.APIExportList
+
+				req, err := labels.NewRequirement(cfg.ContentForLabel, selection.Exists, nil)
+				if err != nil {
+					return nil, fmt.Errorf("constructing label requirement: %w", err)
+				}
+				err = lister.List(ctx, &exportList, &ctrlruntimeclient.ListOptions{
+					LabelSelector: labels.NewSelector().Add(*req),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to list apiexports: %w", err)
+				}
+
+				results, err := buildMarketplaceEntries(providerList, exportList.Items, installedAPIBindings, cfg)
+				if err != nil {
+					return nil, err
+				}
+				return &results, nil
+			}
+		})
+}
+
+func buildMarketplaceEntries(
+	providers pmuiv1alpha1.ProviderMetadataList,
+	apiExports []kcpapisv1alpha1.APIExport,
+	bindings *kcpapisv1alpha1.APIBindingList,
+	cfg config.ServiceConfig,
+) (unstructured.UnstructuredList, error) {
+	byProvider := make(map[string][]kcpapisv1alpha1.APIExport)
+	for _, v := range apiExports {
+		byProvider[v.Labels[cfg.ContentForLabel]] = append(byProvider[v.Labels[cfg.ContentForLabel]], v)
+	}
+
+	var results unstructured.UnstructuredList
+	results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
+	// For each provider, find matching APIExports across all shards
+	for _, providerMeta := range providers.Items {
+		exports := byProvider[providerMeta.GetName()]
+		for _, export := range exports {
+			if len(export.Spec.LatestResourceSchemas) == 0 {
+				continue
 			}
 
-			// Get APIBindings for this specific cluster
-			installedAPIBindings := &kcpapisv1alpha1.APIBindingList{}
-			if err := cl.GetClient().List(ctx, installedAPIBindings); err != nil {
-				return nil, fmt.Errorf("failed to list apibindings: %w", err)
+			idx := slices.IndexFunc(bindings.Items, func(item kcpapisv1alpha1.APIBinding) bool {
+				return item.Spec.Reference.Export.Name == export.Name &&
+					item.Status.APIExportClusterName == export.Annotations["kcp.io/cluster"]
+			})
+
+			var apiBindingName string
+			if idx != -1 {
+				apiBindingName = bindings.Items[idx].Name
 			}
 
-			lister := provider.Lister()
+			providerMeta.ManagedFields = nil // clear managed fields to declutter the output
+			export.ManagedFields = nil
 
-			var providerList pmuiv1alpha1.ProviderMetadataList
-			if err := lister.List(ctx, &providerList); err != nil {
-				return nil, fmt.Errorf("failed to list providermetadatas: %w", err)
-			}
-
-			var results unstructured.UnstructuredList
-			results.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntryList"))
-
-			var exportList kcpapisv1alpha1.APIExportList
-
-			req, err := labels.NewRequirement(cfg.ContentForLabel, selection.Exists, nil)
-			if err != nil {
-				return nil, fmt.Errorf("constructing label requirement: %w", err)
-			}
-			err = lister.List(ctx, &exportList, &ctrlruntimeclient.ListOptions{
-				LabelSelector: labels.NewSelector().Add(*req),
+			unstructuredEntry, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pmmarketplacev1alpha1.MarketplaceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s", export.Name, providerMeta.Name), // TODO: we might need to fix the name length to not exceed the kubernetes limit
+				},
+				Spec: pmmarketplacev1alpha1.MarketplaceEntrySpec{
+					ProviderMetadata: *providerMeta.DeepCopy(),
+					APIExport:        *export.DeepCopy(),
+					APIBindingName:   apiBindingName,
+				},
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to list apiexports: %w", err)
+				return unstructured.UnstructuredList{}, fmt.Errorf(
+					"failed to convert marketplace entry to unstructured for export %s and provider %s: %w", export.Name, providerMeta.Name, err)
 			}
 
-			byProvider := make(map[string][]kcpapisv1alpha1.APIExport)
-			for _, v := range exportList.Items {
-				byProvider[v.Labels[cfg.ContentForLabel]] = append(byProvider[v.Labels[cfg.ContentForLabel]], v)
-			}
-
-			// For each provider, find matching APIExports across all shards
-			for _, provider := range providerList.Items {
-				exports := byProvider[provider.GetName()]
-				for _, export := range exports {
-					if len(export.Spec.LatestResourceSchemas) == 0 {
-						continue
-					}
-
-					idx := slices.IndexFunc(installedAPIBindings.Items, func(item kcpapisv1alpha1.APIBinding) bool {
-						return item.Spec.Reference.Export.Name == export.Name &&
-							item.Status.APIExportClusterName == export.Annotations["kcp.io/cluster"]
-					})
-
-					var apiBindingName string
-					if idx != -1 {
-						apiBindingName = installedAPIBindings.Items[idx].Name
-					}
-
-					provider.ManagedFields = nil // clear managed fields to declutter the output
-					export.ManagedFields = nil
-
-					unstructuredEntry, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pmmarketplacev1alpha1.MarketplaceEntry{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: fmt.Sprintf("%s-%s", export.Name, provider.Name), // TODO: we might need to fix the name length to not exceed the kubernetes limit
-						},
-						Spec: pmmarketplacev1alpha1.MarketplaceEntrySpec{
-							ProviderMetadata: *provider.DeepCopy(),
-							APIExport:        *export.DeepCopy(),
-							APIBindingName:   apiBindingName,
-						},
-					})
-					if err != nil {
-						return nil, fmt.Errorf("failed to convert marketplace entry to unstructured for export %s and provider %s: %w", export.Name, provider.Name, err)
-					}
-
-					us := unstructured.Unstructured{Object: unstructuredEntry}
-					us.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntry"))
-					results.Items = append(results.Items, us)
-				}
-			}
-			return &results, nil
+			us := unstructured.Unstructured{Object: unstructuredEntry}
+			us.SetGroupVersionKind(pmmarketplacev1alpha1.SchemeGroupVersion.WithKind("MarketplaceEntry"))
+			results.Items = append(results.Items, us)
 		}
-	})
+	}
+	return results, nil
 }

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -236,14 +236,18 @@ func Marketplace(
 					return nil, fmt.Errorf("failed to list apiexports for provider %s: %w", provider.GetName(), err)
 				}
 
+				providerClusterID := logicalcluster.From(&provider)
 				for _, export := range exportList.Items {
+					if logicalcluster.From(&export) != providerClusterID {
+						continue
+					}
 					if len(export.Spec.LatestResourceSchemas) == 0 {
 						continue
 					}
 
 					idx := slices.IndexFunc(installedAPIBindings.Items, func(item kcpapisv1alpha1.APIBinding) bool {
 						return item.Spec.Reference.Export.Name == export.Name &&
-							item.Status.APIExportClusterName == export.Annotations["kcp.io/cluster"]
+							item.Status.APIExportClusterName == logicalcluster.From(&export).String()
 					})
 
 					var apiBindingName string

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -65,7 +65,7 @@ func makeProviderMeta() *pmuiv1alpha1.ProviderMetadata {
 
 // makeDefaultExport with default values.
 func makeDefaultExport(cfg config.ServiceConfig) *kcpapisv1alpha1.APIExport {
-	return makeExport(cfg, testExportName, testOrgClusterID, testProviderName)
+	return makeExport(cfg, testExportName, testProviderClusterID, testProviderName)
 }
 
 // makeExport returns an APIExport with the given name and provider label.

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -65,16 +65,16 @@ func makeProviderMeta() *pmuiv1alpha1.ProviderMetadata {
 
 // makeDefaultExport with default values.
 func makeDefaultExport(cfg config.ServiceConfig) *kcpapisv1alpha1.APIExport {
-	return makeExport(cfg, testExportName, testProviderName)
+	return makeExport(cfg, testExportName, testOrgClusterID, testProviderName)
 }
 
 // makeExport returns an APIExport with the given name and provider label.
-func makeExport(cfg config.ServiceConfig, name, provider string) *kcpapisv1alpha1.APIExport {
+func makeExport(cfg config.ServiceConfig, name, clusterID, provider string) *kcpapisv1alpha1.APIExport {
 	return &kcpapisv1alpha1.APIExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
+			Annotations: map[string]string{"kcp.io/cluster": clusterID},
 			Labels:      map[string]string{cfg.ContentForLabel: provider},
-			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
 		},
 		Spec: kcpapisv1alpha1.APIExportSpec{
 			LatestResourceSchemas: []string{"v260810" + name},
@@ -167,7 +167,7 @@ func TestMarketplace_ExportsWithoutMatchingProvider(t *testing.T) {
 	cfg := config.NewServiceConfig()
 	s := marketplaceTestScheme(t)
 
-	orphanedExport := makeExport(cfg, testExportName, "unknown-provider")
+	orphanedExport := makeExport(cfg, testExportName, "foocluster-123", "unknown-provider")
 
 	lister := fake.NewClientBuilder().
 		WithScheme(s).

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -57,9 +57,14 @@ func marketplaceTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func makeProviderMeta() *pmuiv1alpha1.ProviderMetadata {
+func makeProviderMeta(clusterID string) *pmuiv1alpha1.ProviderMetadata {
 	return &pmuiv1alpha1.ProviderMetadata{
-		ObjectMeta: metav1.ObjectMeta{Name: testProviderName},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testProviderName,
+			Annotations: map[string]string{
+				"kcp.io/cluster": clusterID,
+			},
+		},
 	}
 }
 
@@ -112,13 +117,42 @@ func listMarketplace(
 	return list
 }
 
+func TestMarketplace_ExportsFromForeignCluster(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	const (
+		providerClusterID = "id-one"
+		otherClusterID    = "id-two"
+	)
+
+	providerExport := makeExport(cfg, "foo-one", providerClusterID, testProviderName)
+	// any workspace can define its own content-for label values:
+	otherExport := makeExport(cfg, "foo-two", otherClusterID, testProviderName)
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(providerClusterID), providerExport, otherExport).
+		Build()
+
+	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)
+
+	require.Len(t, list.Items, 1)
+
+	exportCluster, found, err := unstructured.NestedString(
+		list.Items[0].Object, "spec", "apiExport", "metadata", "annotations", "kcp.io/cluster")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, providerClusterID, exportCluster)
+}
+
 func TestMarketplace_ExportsOfKnownProviders(t *testing.T) {
 	cfg := config.NewServiceConfig()
 	s := marketplaceTestScheme(t)
 
 	lister := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(makeProviderMeta(), makeDefaultExport(cfg)).
+		WithObjects(makeProviderMeta(testProviderClusterID), makeDefaultExport(cfg)).
 		Build()
 
 	bindings := fake.NewClientBuilder().WithScheme(s).Build()
@@ -136,7 +170,7 @@ func TestMarketplace_InstalledBinding(t *testing.T) {
 
 	lister := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(makeProviderMeta(), makeDefaultExport(cfg)).
+		WithObjects(makeProviderMeta(testProviderClusterID), makeDefaultExport(cfg)).
 		Build()
 
 	bindings := fake.NewClientBuilder().
@@ -171,7 +205,7 @@ func TestMarketplace_ExportsWithoutMatchingProvider(t *testing.T) {
 
 	lister := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(makeProviderMeta(), orphanedExport).
+		WithObjects(makeProviderMeta("whatever"), orphanedExport).
 		Build()
 
 	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pmuiv1alpha1 "go.platform-mesh.io/apis/ui/v1alpha1"
+	"go.platform-mesh.io/virtual-workspaces/pkg/config"
+
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
+)
+
+// Default provider and cluster values.
+const (
+	testOrgClusterID      = "acme-org-cluster-id"
+	testProviderClusterID = "abcd-provider-cluster-id"
+	testProviderName      = "abcd"
+	testExportName        = "widgets.abcd.io"
+)
+
+func marketplaceTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(pmuiv1alpha1.AddToScheme(s))
+	utilruntime.Must(kcpapisv1alpha1.AddToScheme(s))
+	return s
+}
+
+func makeProviderMeta() *pmuiv1alpha1.ProviderMetadata {
+	return &pmuiv1alpha1.ProviderMetadata{
+		ObjectMeta: metav1.ObjectMeta{Name: testProviderName},
+	}
+}
+
+// makeDefaultExport with default values.
+func makeDefaultExport(cfg config.ServiceConfig) *kcpapisv1alpha1.APIExport {
+	return makeExport(cfg, testExportName, testProviderName)
+}
+
+// makeExport returns an APIExport with the given name and provider label.
+func makeExport(cfg config.ServiceConfig, name, provider string) *kcpapisv1alpha1.APIExport {
+	return &kcpapisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      map[string]string{cfg.ContentForLabel: provider},
+			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
+		},
+		Spec: kcpapisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"v260810" + name},
+		},
+	}
+}
+
+// listMarketplace decorates and runs the Marketplace func.
+func listMarketplace(
+	t *testing.T,
+	lister ctrlruntimeclient.Client,
+	bindings ctrlruntimeclient.Client,
+	cfg config.ServiceConfig,
+) *unstructured.UnstructuredList {
+	t.Helper()
+
+	getClusterClient := func(context.Context, string) (ctrlruntimeclient.Client, error) {
+		return bindings, nil
+	}
+
+	var funcs forwardingregistry.StoreFuncs
+	Marketplace(lister, getClusterClient, cfg).
+		Decorate(schema.GroupResource{}, &funcs)
+
+	ctx := genericapirequest.WithCluster(t.Context(), genericapirequest.Cluster{
+		Name: logicalcluster.Name(testOrgClusterID),
+	})
+
+	obj, err := funcs.ListerFunc(ctx, &internalversion.ListOptions{})
+	require.NoError(t, err)
+
+	list, ok := obj.(*unstructured.UnstructuredList)
+	require.True(t, ok, "lister returned %T, want *unstructured.UnstructuredList", obj)
+
+	return list
+}
+
+func TestMarketplace_ExportsOfKnownProviders(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(), makeDefaultExport(cfg)).
+		Build()
+
+	bindings := fake.NewClientBuilder().WithScheme(s).Build()
+
+	list := listMarketplace(t, lister, bindings, cfg)
+
+	require.Len(t, list.Items, 1)
+	// convention might change, max len etc:
+	assert.Equal(t, testExportName+"-"+testProviderName, list.Items[0].GetName())
+}
+
+func TestMarketplace_InstalledBinding(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(), makeDefaultExport(cfg)).
+		Build()
+
+	bindings := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&kcpapisv1alpha1.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "widgets-binding"},
+			Spec: kcpapisv1alpha1.APIBindingSpec{
+				Reference: kcpapisv1alpha1.BindingReference{
+					Export: &kcpapisv1alpha1.ExportBindingReference{Name: testExportName},
+				},
+			},
+			Status: kcpapisv1alpha1.APIBindingStatus{
+				APIExportClusterName: testProviderClusterID,
+			},
+		}).
+		Build()
+
+	list := listMarketplace(t, lister, bindings, cfg)
+
+	require.Len(t, list.Items, 1)
+	name, found, err := unstructured.NestedString(list.Items[0].Object, "spec", "apiBindingName")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "widgets-binding", name)
+}
+
+func TestMarketplace_ExportsWithoutMatchingProvider(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	orphanedExport := makeExport(cfg, testExportName, "unknown-provider")
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(), orphanedExport).
+		Build()
+
+	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)
+
+	assert.Empty(t, list.Items, "should skip unknown providers")
+}


### PR DESCRIPTION
When selecting the APIExports for the marketplace entry, we filter  by the content-for label:
- APIExport.labels["content-for"] == provider.meta.name

Given two APIExports in different workspaces (A and B) having:
- different names, specs;
- the same "content-for" label value

Listing the APIExports by provider A returns both A and B APIExports.

This results is a second entry for the B APIExport under the provider A ProviderMetadata entry. The marketplace would then show B's export as part of the provider A entry.

Fix / missing criteria:
- Match APIExports by the cluster ID from the annotation;
- Filter out unrelated APIExports.

**Note:** The first commits included some light refactoring to enable testing. I reverted some changes to the code to make sure im fixing an existing bug. 

The test reproducing the bug is `TestMarketplace_ExportsFromForeignCluster`.

Edit: related to #241