### PR TITLE
Fix dependency handling for disabled components in pm-operator

### DIFF
--- a/operators/platform-mesh-operator/gotemplates/infra/infra/opentelemetry-operator/helmrelease.yaml
+++ b/operators/platform-mesh-operator/gotemplates/infra/infra/opentelemetry-operator/helmrelease.yaml
@@ -31,8 +31,12 @@ spec:
     kind: OCIRepository
     name: {{ .opentelemetryOperator.name }}
     namespace: {{ .helmReleaseNamespace }}
+{{- if .certManager.enabled }}
   dependsOn:
     - name: {{ .certManager.name }}
+{{- else }}
+  dependsOn: []
+{{- end }}
   interval: {{ .opentelemetryOperator.interval }}
   releaseName: {{ .opentelemetryOperator.name }}
   targetNamespace: {{ .opentelemetryOperator.targetNamespace }}

--- a/operators/platform-mesh-operator/gotemplates/infra/infra/traefik/helmrelease.yaml
+++ b/operators/platform-mesh-operator/gotemplates/infra/infra/traefik/helmrelease.yaml
@@ -31,8 +31,12 @@ spec:
     kind: OCIRepository
     name: {{ .traefik.name }}
     namespace: {{ .helmReleaseNamespace }}
+{{- if .traefikCRDs.enabled }}
   dependsOn:
     - name: {{ .traefikCRDs.name }}
+{{- else }}
+  dependsOn: []
+{{- end }}
   interval: {{ .traefik.interval }}
   releaseName: {{ .traefik.name }}
   targetNamespace: {{ .traefik.targetNamespace }}

--- a/operators/platform-mesh-operator/pkg/subroutines/dependency_pruning_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/dependency_pruning_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.platform-mesh.io/golang-commons/logger"
+	"go.platform-mesh.io/golang-commons/logger/testlogger"
+	"go.platform-mesh.io/platform-mesh-operator/internal/config"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// disabledDependencyProfileYAML has observability wanted but cert-manager off, and
+// opentelemetry-operator off too — the second link of the chain, where a service depends
+// directly on an infra HelmRelease.
+const disabledDependencyProfileYAML = `
+infra:
+  certManager:
+    enabled: false
+    name: cert-manager
+  prometheusOperatorCRDs:
+    enabled: true
+    name: prometheus-operator-crds
+  opentelemetryOperator:
+    enabled: false
+    name: opentelemetry-operator
+components:
+  services:
+    observability:
+      enabled: true
+      dependsOn:
+      - name: prometheus-operator-crds
+        namespace: test-ns
+      - name: opentelemetry-operator
+        namespace: test-ns
+      values: {}
+    portal:
+      enabled: true
+      dependsOn:
+      - name: keycloak-operator
+      values: {}
+    keycloak-operator:
+      enabled: false
+      values: {}
+`
+
+func (s *TemplateVarsTestSuite) Test_buildComponentsTemplateVars_DropsDependenciesOnDisabledComponents() {
+	sub, inst := s.newSubroutineWithProfile(disabledDependencyProfileYAML, config.RemoteClusterConfig{})
+
+	result, err := sub.buildComponentsTemplateVars(context.Background(), inst, apiextensionsv1.JSON{})
+	s.Require().NoError(err)
+
+	values := result["values"].(map[string]any)
+	services := values["services"].(map[string]any)
+
+	observability := services["observability"].(map[string]any)
+	s.Equal([]any{
+		map[string]any{"name": "prometheus-operator-crds", "namespace": "test-ns"},
+	}, observability["dependsOn"],
+		"the disabled opentelemetry-operator must be dropped, the enabled CRD release kept")
+
+	portal := services["portal"].(map[string]any)
+	s.Empty(portal["dependsOn"],
+		"a namespace-less dependency on a disabled component service must be dropped too")
+}
+
+// Components can move their releases elsewhere while infra stays in the instance namespace.
+// The disabled-set keys must follow the infra render, or the pruning matches nothing.
+func (s *TemplateVarsTestSuite) Test_buildComponentsTemplateVars_ResolvesInfraNamespaceIndependently() {
+	profile := `
+infra:
+  opentelemetryOperator:
+    enabled: false
+    name: opentelemetry-operator
+components:
+  deploymentNamespace: components-ns
+  services:
+    observability:
+      enabled: true
+      dependsOn:
+      - name: opentelemetry-operator
+        namespace: test-ns
+      values: {}
+`
+	sub, inst := s.newSubroutineWithProfile(profile, config.RemoteClusterConfig{})
+
+	result, err := sub.buildComponentsTemplateVars(context.Background(), inst, apiextensionsv1.JSON{})
+	s.Require().NoError(err)
+
+	s.Equal("components-ns", result["deploymentNamespace"], "components keep their own namespace")
+
+	services := result["values"].(map[string]any)["services"].(map[string]any)
+	s.Empty(services["observability"].(map[string]any)["dependsOn"],
+		"the infra release lives in the instance namespace, so the dependency on it must still be dropped")
+}
+
+func (s *TemplateVarsTestSuite) Test_buildComponentsTemplateVars_KeepsDependenciesOnEnabledComponents() {
+	profile := `
+infra:
+  prometheusOperatorCRDs:
+    enabled: true
+    name: prometheus-operator-crds
+  opentelemetryOperator:
+    enabled: true
+    name: opentelemetry-operator
+components:
+  services:
+    observability:
+      enabled: true
+      dependsOn:
+      - name: prometheus-operator-crds
+        namespace: test-ns
+      - name: opentelemetry-operator
+        namespace: test-ns
+      values: {}
+`
+	sub, inst := s.newSubroutineWithProfile(profile, config.RemoteClusterConfig{})
+
+	result, err := sub.buildComponentsTemplateVars(context.Background(), inst, apiextensionsv1.JSON{})
+	s.Require().NoError(err)
+
+	services := result["values"].(map[string]any)["services"].(map[string]any)
+	observability := services["observability"].(map[string]any)
+	s.Len(observability["dependsOn"], 2, "nothing may be dropped while every dependency is enabled")
+}
+
+// testLogger keeps the pruner's warnings out of the test output but still inspectable.
+func testLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	return testlogger.New().HideLogOutput().Logger
+}
+
+// dep builds a dependsOn entry as it arrives from the profile YAML.
+func dep(name, namespace string) map[string]any {
+	entry := map[string]any{"name": name}
+	if namespace != "" {
+		entry["namespace"] = namespace
+	}
+	return entry
+}
+
+func Test_disabledHelmReleases(t *testing.T) {
+	infraProfile := map[string]any{
+		"deploymentTechnology": "fluxcd", // not a component, must be ignored
+		"ocm": map[string]any{ // no name/enabled pair, must be ignored
+			"component": map[string]any{"name": "platform-mesh"},
+		},
+		"certManager":           map[string]any{"enabled": false, "name": "cert-manager"},
+		"opentelemetryOperator": map[string]any{"enabled": true, "name": "opentelemetry-operator"},
+		"traefikCRDs":           map[string]any{"name": "traefik-crds"}, // enabled absent == off
+	}
+	services := map[string]any{
+		"observability":     map[string]any{"enabled": true},
+		"keycloak-operator": map[string]any{"enabled": false},
+		"cnpg-operator":     map[string]any{"enabled": true, "skipHelmRelease": true},
+	}
+
+	disabled := disabledHelmReleases(infraProfile, services, "infra-ns", "components-ns")
+
+	assert.Contains(t, disabled, "infra-ns/cert-manager")
+	assert.Contains(t, disabled, "infra-ns/traefik-crds", "a component without an enabled flag is not rendered")
+	assert.Contains(t, disabled, "components-ns/keycloak-operator")
+	assert.Contains(t, disabled, "components-ns/cnpg-operator", "skipHelmRelease means no HelmRelease is rendered")
+
+	assert.NotContains(t, disabled, "infra-ns/opentelemetry-operator")
+	assert.NotContains(t, disabled, "components-ns/observability")
+	assert.Len(t, disabled, 4)
+}
+
+func Test_pruneDisabledDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		services map[string]any
+		disabled map[string]struct{}
+		expect   map[string][]any
+	}{
+		{
+			name: "drops a dependency on a disabled infra component",
+			services: map[string]any{
+				"observability": map[string]any{
+					"enabled": true,
+					"dependsOn": []any{
+						dep("prometheus-operator-crds", "platform-mesh-system"),
+						dep("opentelemetry-operator", "platform-mesh-system"),
+					},
+				},
+			},
+			disabled: map[string]struct{}{"platform-mesh-system/opentelemetry-operator": {}},
+			expect: map[string][]any{
+				"observability": {dep("prometheus-operator-crds", "platform-mesh-system")},
+			},
+		},
+		{
+			name: "drops a dependency that omits the namespace, defaulting to the release namespace",
+			services: map[string]any{
+				"infra": map[string]any{
+					"enabled":   true,
+					"dependsOn": []any{dep("keycloak-operator", "")},
+				},
+			},
+			disabled: map[string]struct{}{"platform-mesh-system/keycloak-operator": {}},
+			expect:   map[string][]any{"infra": {}},
+		},
+		{
+			name: "keeps a dependency in a different namespace",
+			services: map[string]any{
+				"infra": map[string]any{
+					"enabled":   true,
+					"dependsOn": []any{dep("keycloak-operator", "other-ns")},
+				},
+			},
+			disabled: map[string]struct{}{"platform-mesh-system/keycloak-operator": {}},
+			expect:   map[string][]any{"infra": {dep("keycloak-operator", "other-ns")}},
+		},
+		{
+			name: "keeps a dependency on an unknown target",
+			services: map[string]any{
+				"infra": map[string]any{
+					"enabled":   true,
+					"dependsOn": []any{dep("some-external-release", "platform-mesh-system")},
+				},
+			},
+			disabled: map[string]struct{}{"platform-mesh-system/keycloak-operator": {}},
+			expect:   map[string][]any{"infra": {dep("some-external-release", "platform-mesh-system")}},
+		},
+		{
+			name: "leaves a service without dependencies untouched",
+			services: map[string]any{
+				"observability": map[string]any{"enabled": true},
+			},
+			disabled: map[string]struct{}{"platform-mesh-system/opentelemetry-operator": {}},
+			expect:   map[string][]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pruneDisabledDependencies(tt.services, tt.disabled, "platform-mesh-system", testLogger(t))
+
+			for service, want := range tt.expect {
+				cfg := tt.services[service].(map[string]any)
+				got, found := cfg["dependsOn"]
+				require.True(t, found, "dependsOn key must be preserved for %s", service)
+				assert.Equal(t, want, got)
+			}
+			for service := range tt.services {
+				if _, tracked := tt.expect[service]; !tracked {
+					_, found := tt.services[service].(map[string]any)["dependsOn"]
+					assert.False(t, found, "no dependsOn key must be invented for %s", service)
+				}
+			}
+		})
+	}
+}
+
+func Test_pruneDisabledDependencies_MalformedInput(t *testing.T) {
+	services := map[string]any{
+		"not-a-map":       "string instead of config",
+		"wrong-type":      map[string]any{"dependsOn": "should-be-a-list"},
+		"entry-not-a-map": map[string]any{"dependsOn": []any{"bare-string"}},
+		"entry-without-name": map[string]any{"dependsOn": []any{map[string]any{
+			"namespace": "platform-mesh-system",
+		}}},
+	}
+	disabled := map[string]struct{}{"platform-mesh-system/anything": {}}
+
+	assert.NotPanics(t, func() {
+		pruneDisabledDependencies(services, disabled, "platform-mesh-system", testLogger(t))
+	})
+
+	// Malformed entries are left exactly as they were rather than silently reshaped.
+	assert.Equal(t, "should-be-a-list", services["wrong-type"].(map[string]any)["dependsOn"])
+	assert.Equal(t, []any{"bare-string"}, services["entry-not-a-map"].(map[string]any)["dependsOn"])
+}

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment.go
@@ -391,11 +391,7 @@ func (r *DeploymentSubroutine) templateVarsFromProfileInfra(ctx context.Context,
 	}
 
 	// Ensure helmReleaseNamespace is set: prefer deploymentNamespace, then existing helmReleaseNamespace, then inst.Namespace
-	if deployNs, ok := tmplVars["deploymentNamespace"].(string); ok && deployNs != "" {
-		tmplVars["helmReleaseNamespace"] = deployNs
-	} else if _, ok := tmplVars["helmReleaseNamespace"]; !ok {
-		tmplVars["helmReleaseNamespace"] = inst.Namespace
-	}
+	tmplVars["helmReleaseNamespace"] = infraHelmReleaseNamespace(tmplVars, inst.Namespace)
 
 	return tmplVars, nil
 }
@@ -535,8 +531,9 @@ func (r *DeploymentSubroutine) buildRuntimeTemplateVars(ctx context.Context, ins
 func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, inst *pmcorev1alpha1.PlatformMesh, templateVars apiextensionsv1.JSON) (map[string]any, error) {
 	log := logger.LoadLoggerFromContext(ctx).ChildLogger("subroutine", r.GetName())
 
-	// Load components profile from ConfigMap
-	_, componentsProfileYaml, err := r.loadProfileSections(ctx, inst)
+	// The infra section is needed too: services may depend on infra HelmReleases, which
+	// carry their own enabled flags.
+	infraProfileYaml, componentsProfileYaml, err := r.loadProfileSections(ctx, inst)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to load profile from ConfigMap")
 	}
@@ -545,6 +542,11 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 	var componentsProfileMap map[string]any
 	if err := yaml.Unmarshal([]byte(componentsProfileYaml), &componentsProfileMap); err != nil {
 		return nil, errors.Wrap(err, "Failed to parse components profile as YAML")
+	}
+
+	var infraProfileMap map[string]any
+	if err := yaml.Unmarshal([]byte(infraProfileYaml), &infraProfileMap); err != nil {
+		return nil, errors.Wrap(err, "Failed to parse infra profile as YAML")
 	}
 
 	// Parse templateVars JSON into a map
@@ -556,6 +558,15 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 	} else {
 		templateVarsMap = make(map[string]any)
 	}
+
+	// Resolve the infra namespace the same way templateVarsFromProfileInfra does. Must happen
+	// before templateVarsMap is merged with the components profile below, otherwise component
+	// keys leak into the infra resolution.
+	infraVars, err := merge.MergeMaps(infraProfileMap, templateVarsMap, log)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to merge infra profile with templateVars")
+	}
+	infraNamespace := infraHelmReleaseNamespace(infraVars, inst.Namespace)
 
 	// Merge components profile (base) with templateVars (overrides)
 	// templateVars take precedence over profile values
@@ -649,19 +660,26 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 		return nil, errors.Wrap(err, "Failed to merge services from PlatformMesh.spec.Values with profile-components.yaml services")
 	}
 
+	// deploymentNamespace: where deployment CRs live (configurable via profile)
+	componentsNamespace := inst.Namespace
+	if deployNs, ok := values["deploymentNamespace"].(string); ok && deployNs != "" {
+		componentsNamespace = deployNs
+	}
+
+	// Drop dependencies on switched-off components: they are never rendered, so Flux would
+	// hold the dependent release in DependencyNotReady forever. Also keeps calculateSyncWaves
+	// below from ordering against a service that does not exist.
+	disabled := disabledHelmReleases(infraProfileMap, mergedServices, infraNamespace, componentsNamespace)
+	pruneDisabledDependencies(mergedServices, disabled, componentsNamespace, log)
+
 	// Put the merged services back into values
 	values["services"] = mergedServices
 
 	// Root data passed to component gotemplates
 	data := map[string]any{
-		"values":           values,
-		"releaseNamespace": inst.Namespace,
-	}
-	// deploymentNamespace: where deployment CRs live (configurable via profile)
-	if deployNs, ok := values["deploymentNamespace"].(string); ok && deployNs != "" {
-		data["deploymentNamespace"] = deployNs
-	} else {
-		data["deploymentNamespace"] = inst.Namespace
+		"values":              values,
+		"releaseNamespace":    inst.Namespace,
+		"deploymentNamespace": componentsNamespace,
 	}
 
 	// Add kubeConfig fields for remote PlatformMesh support

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment_funcs_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment_funcs_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
@@ -583,10 +584,23 @@ func (s *TemplateVarsTestSuite) SetupSuite() {
 // newSubroutineWithProfile creates a DeploymentSubroutine backed by a fake
 // clientRuntime that already contains a profile ConfigMap for the given inst.
 func (s *TemplateVarsTestSuite) newSubroutineWithProfile(profileYAML string, remoteRuntime config.RemoteClusterConfig) (*DeploymentSubroutine, *pmcorev1alpha1.PlatformMesh) {
+	return newSubroutineWithProfile(s.T(), profileYAML, "test-pm", "test-ns", remoteRuntime)
+}
+
+// newSubroutineWithProfile creates a DeploymentSubroutine backed by a fake clientRuntime
+// that already contains a profile ConfigMap for the instance it returns. Package-level so
+// both the suite and plain Test_ functions can stand up the same subroutine.
+func newSubroutineWithProfile(t *testing.T, profileYAML, name, namespace string, remoteRuntime config.RemoteClusterConfig) (*DeploymentSubroutine, *pmcorev1alpha1.PlatformMesh) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, pmcorev1alpha1.AddToScheme(scheme))
+
 	inst := &pmcorev1alpha1.PlatformMesh{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pm",
-			Namespace: "test-ns",
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: pmcorev1alpha1.PlatformMeshSpec{},
 	}
@@ -602,22 +616,16 @@ func (s *TemplateVarsTestSuite) newSubroutineWithProfile(profileYAML string, rem
 	}
 
 	fakeClient := fake.NewClientBuilder().
-		WithScheme(s.scheme).
+		WithScheme(scheme).
 		WithObjects(inst, cm).
 		Build()
 
-	operatorCfg := &config.OperatorConfig{
-		RemoteRuntime: remoteRuntime,
-	}
-	cfg := &pmconfig.CommonServiceConfig{}
-
-	sub := &DeploymentSubroutine{
+	return &DeploymentSubroutine{
 		clientRuntime: fakeClient,
 		clientInfra:   fakeClient,
-		cfg:           cfg,
-		cfgOperator:   operatorCfg,
-	}
-	return sub, inst
+		cfg:           &pmconfig.CommonServiceConfig{},
+		cfgOperator:   &config.OperatorConfig{RemoteRuntime: remoteRuntime},
+	}, inst
 }
 
 // minimalProfileYAML is a valid profile with empty infra and components sections.

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -210,6 +211,113 @@ func (r *DeploymentSubroutine) renderTemplateFile(path string, tmplVars map[stri
 		objs = append(objs, &unstructured.Unstructured{Object: objMap})
 	}
 	return objs, nil
+}
+
+// helmReleaseKey identifies a HelmRelease the way Flux resolves a spec.dependsOn entry.
+func helmReleaseKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// dependencyKey returns the HelmRelease a dependsOn entry points at, or false if the entry
+// has no usable name.
+func dependencyKey(entry any, defaultNamespace string) (string, bool) {
+	dep, ok := entry.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	name, ok := dep["name"].(string)
+	if !ok || name == "" {
+		return "", false
+	}
+	namespace, ok := dep["namespace"].(string)
+	if !ok || namespace == "" {
+		// Flux resolves a namespace-less dependency in the HelmRelease's own namespace.
+		namespace = defaultNamespace
+	}
+	return helmReleaseKey(namespace, name), true
+}
+
+// infraHelmReleaseNamespace resolves where the infra HelmReleases are rendered:
+// deploymentNamespace, then helmReleaseNamespace, then the fallback. The infra render and the
+// dependency pruning must agree here, so both call this with the infra profile merged with
+// templateVars and inst.Namespace as fallback. Anything else and the pruning stops matching.
+func infraHelmReleaseNamespace(infraVars map[string]any, fallback string) string {
+	if deployNs, ok := infraVars["deploymentNamespace"].(string); ok && deployNs != "" {
+		return deployNs
+	}
+	if hrNs, ok := infraVars["helmReleaseNamespace"].(string); ok && hrNs != "" {
+		return hrNs
+	}
+	return fallback
+}
+
+// disabledHelmReleases collects the HelmReleases we deliberately do not render, keyed as
+// Flux resolves dependsOn. Mirrors the template gates: infra components are gated on
+// "<component>.enabled" (missing flag counts as off), services additionally on
+// skipHelmRelease.
+func disabledHelmReleases(infraProfile, services map[string]any, infraNamespace, componentsNamespace string) map[string]struct{} {
+	disabled := make(map[string]struct{})
+
+	for _, component := range infraProfile {
+		config, ok := component.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Only entries with a release name describe a HelmRelease.
+		name, ok := config["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		if isZeroValue(config["enabled"]) {
+			disabled[helmReleaseKey(infraNamespace, name)] = struct{}{}
+		}
+	}
+
+	for service, serviceConfig := range services {
+		config, ok := serviceConfig.(map[string]any)
+		if !ok {
+			continue
+		}
+		if isZeroValue(config["enabled"]) || !isZeroValue(config["skipHelmRelease"]) {
+			disabled[helmReleaseKey(componentsNamespace, service)] = struct{}{}
+		}
+	}
+
+	return disabled
+}
+
+// pruneDisabledDependencies drops dependsOn entries pointing at a disabled component. Flux
+// waits in DependencyNotReady until a dependency exists and is ready, so an entry we never
+// render stalls the dependent release forever.
+//
+// Only provably disabled targets go. An unknown name might be someone else's HelmRelease, and
+// dropping a typo silently would hide a real misconfiguration.
+func pruneDisabledDependencies(services map[string]any, disabled map[string]struct{}, defaultNamespace string, log *logger.Logger) {
+	for service, serviceConfig := range services {
+		config, ok := serviceConfig.(map[string]any)
+		if !ok {
+			continue
+		}
+		dependsOn, ok := config["dependsOn"].([]any)
+		if !ok {
+			continue
+		}
+
+		config["dependsOn"] = slices.DeleteFunc(slices.Clone(dependsOn), func(entry any) bool {
+			key, resolvable := dependencyKey(entry, defaultNamespace)
+			if !resolvable {
+				return false
+			}
+			if _, isDisabled := disabled[key]; !isDisabled {
+				return false
+			}
+			log.Warn().
+				Str("service", service).
+				Str("dependency", key).
+				Msg("Dropping dependsOn entry: the dependency is disabled and is never deployed")
+			return true
+		})
+	}
 }
 
 // helper: functions for Helm-like templates in components gotemplates

--- a/operators/platform-mesh-operator/pkg/subroutines/disabled_component_scenarios_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/disabled_component_scenarios_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutines
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	"go.platform-mesh.io/platform-mesh-operator/internal/config"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// What happens when a component is switched off? These render every FluxCD HelmRelease the
+// operator would create, from the profile we actually ship, and check nothing is left waiting
+// on a release that is never deployed.
+
+// shippedProfilePath is what the kind e2e suite applies — the closest thing in-tree to a
+// production config.
+const shippedProfilePath = "../../test/e2e/kind/yaml/platform-mesh-resource/default-profile.yaml"
+
+// platformMeshNamespace is where the CR lives in a real install. The shipped profile writes
+// explicit "namespace: platform-mesh-system" dependsOn entries, so this has to match.
+const platformMeshNamespace = "platform-mesh-system"
+
+func loadShippedProfile(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(shippedProfilePath)
+	require.NoError(t, err)
+
+	var cm corev1.ConfigMap
+	require.NoError(t, yaml.Unmarshal(raw, &cm))
+	profile, ok := cm.Data[profileConfigMapKey]
+	require.True(t, ok, "%s must contain key %s", shippedProfilePath, profileConfigMapKey)
+	return profile
+}
+
+// componentSection: infra components sit under infra, services under components.services.
+func componentSection(t *testing.T, profile map[string]any, section string) map[string]any {
+	t.Helper()
+	if section == "infra" {
+		infra, ok := profile["infra"].(map[string]any)
+		require.True(t, ok, "profile must have an infra section")
+		return infra
+	}
+	components, ok := profile["components"].(map[string]any)
+	require.True(t, ok, "profile must have a components section")
+	services, ok := components["services"].(map[string]any)
+	require.True(t, ok, "profile must have components.services")
+	return services
+}
+
+// disableComponent flips <section>.<component>.enabled to false, as an operator would.
+func disableComponent(t *testing.T, profileYAML, section, component string) string {
+	t.Helper()
+	var profile map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(profileYAML), &profile))
+
+	cfg, ok := componentSection(t, profile, section)[component].(map[string]any)
+	require.True(t, ok, "%s.%s must exist in the shipped profile", section, component)
+	cfg["enabled"] = false
+
+	out, err := yaml.Marshal(profile)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// componentNames lists every component in a section, so we can sweep all of them.
+func componentNames(t *testing.T, profileYAML, section string) []string {
+	t.Helper()
+	var profile map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(profileYAML), &profile))
+
+	names := []string{}
+	for name, cfg := range componentSection(t, profile, section) {
+		if _, ok := cfg.(map[string]any); ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func newSubroutineForProfile(t *testing.T, profileYAML, namespace string) (*DeploymentSubroutine, *pmcorev1alpha1.PlatformMesh) {
+	t.Helper()
+	return newSubroutineWithProfile(t, profileYAML, "platform-mesh", namespace, config.RemoteClusterConfig{})
+}
+
+// renderedGraph maps each rendered HelmRelease to the releases it depends on.
+type renderedGraph map[string][]string
+
+// renderHelmReleaseGraph renders every FluxCD HelmRelease for a profile: infra plus services.
+func renderHelmReleaseGraph(t *testing.T, sub *DeploymentSubroutine, inst *pmcorev1alpha1.PlatformMesh) renderedGraph {
+	t.Helper()
+	ctx := context.Background()
+
+	log := testLogger(t)
+	graph := renderedGraph{}
+
+	collect := func(path string, vars map[string]any) {
+		objs, err := sub.renderTemplateFile(path, vars, log)
+		require.NoError(t, err, "rendering %s", path)
+		for _, obj := range objs {
+			if obj.GetKind() != "HelmRelease" {
+				continue
+			}
+			namespace := obj.GetNamespace()
+
+			deps := []string{}
+			spec, _ := obj.Object["spec"].(map[string]any)
+			if raw, ok := spec["dependsOn"].([]any); ok {
+				for _, entry := range raw {
+					// Same resolution the operator applies when it prunes.
+					if key, resolvable := dependencyKey(entry, namespace); resolvable {
+						deps = append(deps, key)
+					}
+				}
+			}
+			graph[helmReleaseKey(namespace, obj.GetName())] = deps
+		}
+	}
+
+	// Infra components, using the operator's own file selection for a FluxCD profile.
+	infraVars, err := sub.templateVarsFromProfileInfra(ctx, inst, apiextensionsv1.JSON{}, sub.cfgOperator)
+	require.NoError(t, err)
+	skipFile := deploymentTechFileFilter(deploymentTechFluxCD, log)
+
+	infraDir := filepath.Join("..", "..", "gotemplates", "infra", "infra")
+	components, err := os.ReadDir(infraDir)
+	require.NoError(t, err)
+	for _, component := range components {
+		if !component.IsDir() {
+			continue
+		}
+		componentDir := filepath.Join(infraDir, component.Name())
+		files, err := ListFiles(componentDir)
+		require.NoError(t, err)
+		for _, file := range files {
+			if skipFile(file) {
+				continue
+			}
+			collect(filepath.Join(componentDir, file), infraVars)
+		}
+	}
+
+	// Component services: gotemplates/components/infra/helmreleases.yaml
+	componentVars, err := sub.buildComponentsTemplateVars(ctx, inst, apiextensionsv1.JSON{})
+	require.NoError(t, err)
+	collect(filepath.Join("..", "..", "gotemplates", "components", "infra", "helmreleases.yaml"), componentVars)
+
+	return graph
+}
+
+// The core invariant: every declared dependency must be a release we actually render.
+func assertNoDanglingDependencies(t *testing.T, graph renderedGraph) {
+	t.Helper()
+	for release, deps := range graph {
+		for _, dep := range deps {
+			_, exists := graph[dep]
+			assert.True(t, exists,
+				"HelmRelease %s depends on %s, which is never rendered — it would hang in DependencyNotReady", release, dep)
+		}
+	}
+}
+
+func Test_ShippedProfile_HasNoDanglingDependencies(t *testing.T) {
+	sub, inst := newSubroutineForProfile(t, loadShippedProfile(t), platformMeshNamespace)
+	graph := renderHelmReleaseGraph(t, sub, inst)
+
+	require.NotEmpty(t, graph, "the shipped profile must render HelmReleases")
+	assertNoDanglingDependencies(t, graph)
+
+	// The gates only pay off if the dependency survives while the target is enabled.
+	ns := platformMeshNamespace
+	assert.Contains(t, graph[helmReleaseKey(ns, "opentelemetry-operator")], helmReleaseKey(ns, "cert-manager"))
+	assert.Contains(t, graph[helmReleaseKey(ns, "traefik")], helmReleaseKey(ns, "traefik-crds"))
+}
+
+// Switching a component off must never leave another release waiting on it.
+func Test_DisablingComponent_LeavesRemainingStackDeployable(t *testing.T) {
+	ns := platformMeshNamespace
+	tests := []struct {
+		name      string
+		section   string
+		component string
+		absent    string // release that must no longer be rendered
+		dependent string // release that must survive without it ("" to skip)
+		keptDep   string // dependency of that dependent that must remain ("" to skip)
+	}{
+		{
+			name:    "cert-manager off while the observability stack is wanted",
+			section: "infra", component: "certManager",
+			absent: "cert-manager", dependent: "opentelemetry-operator",
+		},
+		{
+			name:    "traefik CRDs managed outside the platform",
+			section: "infra", component: "traefikCRDs",
+			absent: "traefik-crds", dependent: "traefik",
+		},
+		{
+			name:    "otel operator off: a service depending on an infra release",
+			section: "infra", component: "opentelemetryOperator",
+			absent: "opentelemetry-operator", dependent: "observability", keptDep: "prometheus-operator-crds",
+		},
+		{
+			name:    "cluster already runs Prometheus, so its CRDs come from elsewhere",
+			section: "infra", component: "prometheusOperatorCRDs",
+			absent: "prometheus-operator-crds", dependent: "observability", keptDep: "opentelemetry-operator",
+		},
+		{
+			name:    "traefik off entirely",
+			section: "infra", component: "traefik",
+			absent: "traefik",
+		},
+		{
+			name:    "cluster already runs the whole observability stack",
+			section: "components", component: "observability",
+			absent: "observability",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := disableComponent(t, loadShippedProfile(t), tt.section, tt.component)
+			sub, inst := newSubroutineForProfile(t, profile, ns)
+			graph := renderHelmReleaseGraph(t, sub, inst)
+
+			assert.NotContains(t, graph, helmReleaseKey(ns, tt.absent),
+				"a disabled component must not be rendered")
+			require.NotEmpty(t, graph, "the rest of the platform must still render")
+
+			if tt.dependent != "" {
+				require.Contains(t, graph, helmReleaseKey(ns, tt.dependent),
+					"the dependent must still be deployed")
+				assert.NotContains(t, graph[helmReleaseKey(ns, tt.dependent)], helmReleaseKey(ns, tt.absent),
+					"the dependent must not wait for a release that is never deployed")
+			}
+			if tt.keptDep != "" {
+				assert.Contains(t, graph[helmReleaseKey(ns, tt.dependent)], helmReleaseKey(ns, tt.keptDep),
+					"dependencies that are still enabled must survive")
+			}
+			assertNoDanglingDependencies(t, graph)
+		})
+	}
+}
+
+// The cases above are hand-picked; this sweeps every component in the profile, so anything
+// added later is covered without remembering to add a case.
+func Test_DisablingAnySingleComponent_LeavesNoDanglingDependencies(t *testing.T) {
+	profile := loadShippedProfile(t)
+
+	for _, section := range []string{"infra", "components"} {
+		for _, component := range componentNames(t, profile, section) {
+			t.Run(section+"/"+component, func(t *testing.T) {
+				sub, inst := newSubroutineForProfile(t,
+					disableComponent(t, profile, section, component), platformMeshNamespace)
+				assertNoDanglingDependencies(t, renderHelmReleaseGraph(t, sub, inst))
+			})
+		}
+	}
+}


### PR DESCRIPTION
Fixes #258 

By further investigation I've also found that traefik has the same flaw with its crds. 

- Infra templates gate their inline `dependsOn` on the dependency being enabled
  (opentelemetry-operator → cert-manager, traefik → traefik-crds).
- Profile-driven dependencies are pruned in `buildComponentsTemplateVars`, so it
  covers `spec.Values` overrides and both the FluxCD and ArgoCD paths.