### PR TITLE
feat: separate kubeconfigs for resource-broker

### DIFF
--- a/operators/resource-broker/main.go
+++ b/operators/resource-broker/main.go
@@ -47,6 +47,21 @@ var (
 		"",
 		"Kubeconfig for the compute cluster. If not set, the local config is used.",
 	)
+	fCoordKubeconfig = flag.String(
+		"coord-kubeconfig",
+		"",
+		"Kubeconfig for the coordination workspace. Falls back to kcp-kubeconfig if not set.",
+	)
+	fVerificationKubeconfig = flag.String(
+		"verification-kubeconfig",
+		"",
+		"Kubeconfig for the verification tree root. Falls back to kcp-kubeconfig if not set.",
+	)
+	fStagingKubeconfig = flag.String(
+		"staging-kubeconfig",
+		"",
+		"Kubeconfig for the staging tree root. Falls back to kcp-kubeconfig if not set.",
+	)
 
 	fAcceptAPI = flag.String(
 		"acceptapi",
@@ -127,12 +142,33 @@ func main() {
 		os.Exit(1)
 	}
 
+	coordConfig, err := loadKubeconfig(*fCoordKubeconfig, kcpConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to load coord kubeconfig", "path", *fCoordKubeconfig)
+		os.Exit(1)
+	}
+
+	verificationConfig, err := loadKubeconfig(*fVerificationKubeconfig, kcpConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to load verification kubeconfig", "path", *fVerificationKubeconfig)
+		os.Exit(1)
+	}
+
+	stagingConfig, err := loadKubeconfig(*fStagingKubeconfig, kcpConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to load staging kubeconfig", "path", *fStagingKubeconfig)
+		os.Exit(1)
+	}
+
 	brk, err := broker.New(broker.Options{
 		Log: setupLog.WithName("broker"),
 
-		LocalConfig:   local,
-		KcpConfig:     kcpConfig,
-		ComputeConfig: computeConfig,
+		LocalConfig:        local,
+		KcpConfig:          kcpConfig,
+		ComputeConfig:      computeConfig,
+		CoordConfig:        coordConfig,
+		VerificationConfig: verificationConfig,
+		StagingConfig:      stagingConfig,
 
 		AcceptAPIName: *fAcceptAPI,
 

--- a/operators/resource-broker/pkg/broker/broker.go
+++ b/operators/resource-broker/pkg/broker/broker.go
@@ -86,6 +86,18 @@ type Options struct {
 	// Required.
 	ComputeConfig *rest.Config
 
+	// CoordConfig is the base config for the coordination workspace.
+	// If nil, derived from KcpConfig.
+	CoordConfig *rest.Config
+
+	// VerificationConfig is the base config for the verification tree.
+	// If nil, uses KcpConfig.
+	VerificationConfig *rest.Config
+
+	// StagingConfig is the base config for the staging tree.
+	// If nil, uses KcpConfig.
+	StagingConfig *rest.Config
+
 	// AcceptAPIName is the name of the APIExportEndpointSlice serving
 	// AcceptAPIs. All other APIExportEndpointSlices in the broker workspace
 	// serve brokered resources.
@@ -163,9 +175,36 @@ func New(opts Options) (*Broker, error) {
 		return nil, fmt.Errorf("building scheme: %w", err)
 	}
 
-	wcf, err := workspaceClientFunc(opts.KcpConfig, scheme)
+	// Provider client func - for provider workspace access (AcceptAPIs, APIExports)
+	providerWcf, err := workspaceClientFunc(opts.KcpConfig, scheme)
 	if err != nil {
-		return nil, fmt.Errorf("building workspace client factory: %w", err)
+		return nil, fmt.Errorf("building provider workspace client factory: %w", err)
+	}
+
+	// Verification client func
+	verificationCfg := opts.VerificationConfig
+	if verificationCfg == nil {
+		verificationCfg = opts.KcpConfig
+	}
+	verificationWcf, err := workspaceClientFunc(verificationCfg, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("building verification workspace client factory: %w", err)
+	}
+
+	// Staging client func
+	stagingCfg := opts.StagingConfig
+	if stagingCfg == nil {
+		stagingCfg = opts.KcpConfig
+	}
+	stagingWcf, err := workspaceClientFunc(stagingCfg, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("building staging workspace client factory: %w", err)
+	}
+
+	// Coordination config for cluster path derivation
+	coordBaseCfg := opts.CoordConfig
+	if coordBaseCfg == nil {
+		coordBaseCfg = opts.KcpConfig
 	}
 
 	multiProvider := multi.New(multi.Options{})
@@ -177,16 +216,16 @@ func New(opts Options) (*Broker, error) {
 
 	b := &Broker{log: opts.Log, mgr: mgr}
 
-	acceptAPIProvider, err := setupAcceptAPI(mgr, multiProvider, opts, scheme, wcf)
+	acceptAPIProvider, err := setupAcceptAPI(mgr, multiProvider, opts, scheme, verificationWcf)
 	if err != nil {
 		return nil, fmt.Errorf("setting up acceptapi controller: %w", err)
 	}
 
-	if err := setupCoordination(mgr, multiProvider, opts, scheme, wcf); err != nil {
+	if err := setupCoordination(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, coordBaseCfg); err != nil {
 		return nil, fmt.Errorf("setting up coordination controllers: %w", err)
 	}
 
-	if err := setupDiscovery(mgr, multiProvider, opts, scheme, wcf, acceptAPIProvider); err != nil {
+	if err := setupDiscovery(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, acceptAPIProvider); err != nil {
 		return nil, fmt.Errorf("setting up discovery controller: %w", err)
 	}
 
@@ -209,7 +248,7 @@ func providerClusters(name string) mcbuilder.ClusterFilterFunc {
 
 // setupAcceptAPI wires the AcceptAPI reconciler on the AcceptAPI virtual
 // workspace and returns the provider for listing AcceptAPIs.
-func setupAcceptAPI(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, wcf workspaceClientFn) (*apiexport.Provider, error) {
+func setupAcceptAPI(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, verificationWcf workspaceClientFn) (*apiexport.Provider, error) {
 	provider, err := apiexport.New(opts.KcpConfig, opts.AcceptAPIName, apiexport.Options{Scheme: scheme})
 	if err != nil {
 		return nil, fmt.Errorf("creating acceptapi provider: %w", err)
@@ -219,10 +258,10 @@ func setupAcceptAPI(mgr mcmanager.Manager, multiProvider *multi.Provider, opts O
 	}
 
 	reconciler, err := acceptapi.NewReconciler(mgr, acceptapi.Options{
-		VerificationTreeRoot: opts.VerificationTreeRoot,
-		WorkspaceClientFunc:  wcf,
-		ClusterFilter:        providerClusters(AcceptAPIProviderName),
-		RequeueInterval:      opts.RequeueInterval,
+		VerificationTreeRoot:   opts.VerificationTreeRoot,
+		VerificationClientFunc: verificationWcf,
+		ClusterFilter:          providerClusters(AcceptAPIProviderName),
+		RequeueInterval:        opts.RequeueInterval,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating acceptapi reconciler: %w", err)
@@ -236,8 +275,8 @@ func setupAcceptAPI(mgr mcmanager.Manager, multiProvider *multi.Provider, opts O
 
 // setupCoordination wires the Assignment and StagingWorkspace reconcilers on
 // the coordination workspace.
-func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, wcf workspaceClientFn) error {
-	coordConfig, err := configForClusterPath(opts.KcpConfig, opts.CoordinationWorkspace)
+func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, stagingWcf, providerWcf workspaceClientFn, coordBaseCfg *rest.Config) error {
+	coordConfig, err := configForClusterPath(coordBaseCfg, opts.CoordinationWorkspace)
 	if err != nil {
 		return fmt.Errorf("building coordination config: %w", err)
 	}
@@ -257,10 +296,11 @@ func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opt
 	filter := providerClusters(CoordinationClusterName)
 
 	stagingReconciler, err := stagingworkspace.NewReconciler(mgr, stagingworkspace.Options{
-		StagingTreeRoot:     opts.StagingTreeRoot,
-		WorkspaceClientFunc: wcf,
-		ClusterFilter:       filter,
-		RequeueInterval:     opts.RequeueInterval,
+		StagingTreeRoot:    opts.StagingTreeRoot,
+		StagingClientFunc:  stagingWcf,
+		ProviderClientFunc: providerWcf,
+		ClusterFilter:      filter,
+		RequeueInterval:    opts.RequeueInterval,
 	})
 	if err != nil {
 		return fmt.Errorf("creating stagingworkspace reconciler: %w", err)
@@ -275,12 +315,12 @@ func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opt
 	}
 
 	migrationReconciler, err := migration.NewReconciler(mgr, migration.Options{
-		ComputeClient:       computeClient,
-		WorkspaceClientFunc: wcf,
-		StagingTreeRoot:     opts.StagingTreeRoot,
-		StageNamespace:      opts.StageNamespace,
-		ClusterFilter:       filter,
-		RequeueInterval:     opts.RequeueInterval,
+		ComputeClient:     computeClient,
+		StagingClientFunc: stagingWcf,
+		StagingTreeRoot:   opts.StagingTreeRoot,
+		StageNamespace:    opts.StageNamespace,
+		ClusterFilter:     filter,
+		RequeueInterval:   opts.RequeueInterval,
 	})
 	if err != nil {
 		return fmt.Errorf("creating migration reconciler: %w", err)
@@ -295,8 +335,8 @@ func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opt
 // setupDiscovery wires the discovery controller watching
 // APIExportEndpointSlices in the broker workspace. Each slice except the
 // AcceptAPI one gets a provider and controllers for its brokered resources.
-func setupDiscovery(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, wcf workspaceClientFn, acceptAPIProvider *apiexport.Provider) error {
-	coordinationClient, err := wcf(opts.CoordinationWorkspace)
+func setupDiscovery(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, stagingWcf, providerWcf workspaceClientFn, acceptAPIProvider *apiexport.Provider) error {
+	coordinationClient, err := stagingWcf(opts.CoordinationWorkspace)
 	if err != nil {
 		return fmt.Errorf("building coordination client: %w", err)
 	}
@@ -315,9 +355,9 @@ func setupDiscovery(mgr mcmanager.Manager, multiProvider *multi.Provider, opts O
 		kcpConfig:     opts.KcpConfig,
 		scheme:        scheme,
 		acceptAPIName: opts.AcceptAPIName,
-		wcf:           wcf,
+		wcf:           providerWcf,
 		providers:     multiProvider,
-		register:      registerBrokeredResource(mgr, opts, wcf, coordinationClient, acceptAPIProvider),
+		register:      registerBrokeredResource(mgr, opts, stagingWcf, providerWcf, coordinationClient, acceptAPIProvider),
 	}
 
 	slicesForExport := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {

--- a/operators/resource-broker/pkg/broker/broker.go
+++ b/operators/resource-broker/pkg/broker/broker.go
@@ -201,10 +201,14 @@ func New(opts Options) (*Broker, error) {
 		return nil, fmt.Errorf("building staging workspace client factory: %w", err)
 	}
 
-	// Coordination config for cluster path derivation
-	coordBaseCfg := opts.CoordConfig
-	if coordBaseCfg == nil {
-		coordBaseCfg = opts.KcpConfig
+	// Coordination config and client func
+	coordCfg := opts.CoordConfig
+	if coordCfg == nil {
+		coordCfg = opts.KcpConfig
+	}
+	coordWcf, err := workspaceClientFunc(coordCfg, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("building coordination workspace client factory: %w", err)
 	}
 
 	multiProvider := multi.New(multi.Options{})
@@ -221,11 +225,11 @@ func New(opts Options) (*Broker, error) {
 		return nil, fmt.Errorf("setting up acceptapi controller: %w", err)
 	}
 
-	if err := setupCoordination(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, coordBaseCfg); err != nil {
+	if err := setupCoordination(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, coordCfg); err != nil {
 		return nil, fmt.Errorf("setting up coordination controllers: %w", err)
 	}
 
-	if err := setupDiscovery(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, acceptAPIProvider); err != nil {
+	if err := setupDiscovery(mgr, multiProvider, opts, scheme, stagingWcf, providerWcf, coordWcf, acceptAPIProvider); err != nil {
 		return nil, fmt.Errorf("setting up discovery controller: %w", err)
 	}
 
@@ -335,8 +339,8 @@ func setupCoordination(mgr mcmanager.Manager, multiProvider *multi.Provider, opt
 // setupDiscovery wires the discovery controller watching
 // APIExportEndpointSlices in the broker workspace. Each slice except the
 // AcceptAPI one gets a provider and controllers for its brokered resources.
-func setupDiscovery(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, stagingWcf, providerWcf workspaceClientFn, acceptAPIProvider *apiexport.Provider) error {
-	coordinationClient, err := stagingWcf(opts.CoordinationWorkspace)
+func setupDiscovery(mgr mcmanager.Manager, multiProvider *multi.Provider, opts Options, scheme *runtime.Scheme, stagingWcf, providerWcf, coordWcf workspaceClientFn, acceptAPIProvider *apiexport.Provider) error {
+	coordinationClient, err := coordWcf(opts.CoordinationWorkspace)
 	if err != nil {
 		return fmt.Errorf("building coordination client: %w", err)
 	}

--- a/operators/resource-broker/pkg/broker/discovery.go
+++ b/operators/resource-broker/pkg/broker/discovery.go
@@ -195,7 +195,7 @@ func storageVersion(resourceSchema *kcpapisv1alpha1.APIResourceSchema) string {
 
 // registerBrokeredResource returns a func creating and registering a brokered
 // resource controller with the manager.
-func registerBrokeredResource(mgr mcmanager.Manager, opts Options, wcf workspaceClientFn, coordinationClient ctrlruntimeclient.Client, acceptAPIProvider *apiexport.Provider) func(slice string, info resourceInfo) error {
+func registerBrokeredResource(mgr mcmanager.Manager, opts Options, stagingWcf, providerWcf workspaceClientFn, coordinationClient ctrlruntimeclient.Client, acceptAPIProvider *apiexport.Provider) func(slice string, info resourceInfo) error {
 	return func(slice string, info resourceInfo) error {
 		name := brokeredresource.ControllerNamePrefix + slice + "-" + info.GVR.Resource
 		if info.GVR.Group != "" {
@@ -203,15 +203,16 @@ func registerBrokeredResource(mgr mcmanager.Manager, opts Options, wcf workspace
 		}
 
 		reconciler, err := brokeredresource.NewReconciler(mgr, brokeredresource.Options{
-			GVK:                 info.GVK,
-			GVR:                 info.GVR,
-			StagingTreeRoot:     opts.StagingTreeRoot,
-			WorkspaceClientFunc: wcf,
-			CoordinationClient:  coordinationClient,
-			ListAcceptAPIs:      listAcceptAPIs(acceptAPIProvider.Lister()),
-			ControllerName:      name,
-			ClusterFilter:       providerClusters(slice),
-			RequeueInterval:     opts.RequeueInterval,
+			GVK:                info.GVK,
+			GVR:                info.GVR,
+			StagingTreeRoot:    opts.StagingTreeRoot,
+			StagingClientFunc:  stagingWcf,
+			ProviderClientFunc: providerWcf,
+			CoordinationClient: coordinationClient,
+			ListAcceptAPIs:     listAcceptAPIs(acceptAPIProvider.Lister()),
+			ControllerName:     name,
+			ClusterFilter:      providerClusters(slice),
+			RequeueInterval:    opts.RequeueInterval,
 		})
 		if err != nil {
 			return fmt.Errorf("creating reconciler: %w", err)

--- a/operators/resource-broker/pkg/controller/broker/acceptapi/binding_verified.go
+++ b/operators/resource-broker/pkg/controller/broker/acceptapi/binding_verified.go
@@ -129,7 +129,7 @@ func (s *bindingVerifiedSubroutine) Finalize(ctx context.Context, obj ctrlruntim
 }
 
 func (s *bindingVerifiedSubroutine) treeRootClient() (ctrlruntimeclient.Client, error) {
-	cl, err := s.opts.WorkspaceClientFunc(s.opts.VerificationTreeRoot)
+	cl, err := s.opts.VerificationClientFunc(s.opts.VerificationTreeRoot)
 	if err != nil {
 		return nil, fmt.Errorf("building client for tree root %q: %w", s.opts.VerificationTreeRoot, err)
 	}
@@ -194,7 +194,7 @@ func (s *bindingVerifiedSubroutine) ensureWorkspace(ctx context.Context, acceptA
 // ensureBinding ensures an APIBinding for the APIExport in the AcceptaPI exists in the vrification workspace and is bound successfully.
 func (s *bindingVerifiedSubroutine) ensureBinding(ctx context.Context, acceptAPI *pmbrokerv1alpha1.AcceptAPI, wsName, providerCluster string) (subroutines.Result, error) {
 	wsPath := s.opts.VerificationTreeRoot + ":" + wsName
-	wsClient, err := s.opts.WorkspaceClientFunc(wsPath)
+	wsClient, err := s.opts.VerificationClientFunc(wsPath)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for workspace %q: %w", wsPath, err)
 	}

--- a/operators/resource-broker/pkg/controller/broker/acceptapi/binding_verified_test.go
+++ b/operators/resource-broker/pkg/controller/broker/acceptapi/binding_verified_test.go
@@ -63,7 +63,7 @@ func testSubroutine(t *testing.T, treeObjs, wsObjs []ctrlruntimeclient.Object) (
 	s := &bindingVerifiedSubroutine{opts: Options{
 		VerificationTreeRoot: testTreeRoot,
 		RequeueInterval:      time.Second,
-		WorkspaceClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+		VerificationClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
 			if path == testTreeRoot {
 				return treeClient, nil
 			}

--- a/operators/resource-broker/pkg/controller/broker/acceptapi/reconciler.go
+++ b/operators/resource-broker/pkg/controller/broker/acceptapi/reconciler.go
@@ -45,16 +45,17 @@ const (
 )
 
 // Options configures the AcceptAPI reconciler. Client construction is
-// the operator's concern: the reconciler only asks WorkspaceClientFunc
+// the operator's concern: the reconciler only asks VerificationClientFunc
 // for clients by workspace path.
 type Options struct {
 	// VerificationTreeRoot is the kcp workspace path under which the broker creates its verification workspaces.
 	// Required.
 	VerificationTreeRoot string
 
-	// WorkspaceClientFunc returns a client scoped to the workspace with the given path.
+	// VerificationClientFunc returns a client scoped to the workspace with the given path
+	// within the verification tree.
 	// Required.
-	WorkspaceClientFunc func(path string) (ctrlruntimeclient.Client, error)
+	VerificationClientFunc func(path string) (ctrlruntimeclient.Client, error)
 
 	// ClusterFilter restricts which provider clusters the controller engages.
 	// Optional, defaults to engaging all clusters.
@@ -76,8 +77,8 @@ func NewReconciler(mgr mcmanager.Manager, opts Options) (*Reconciler, error) {
 	if opts.VerificationTreeRoot == "" {
 		return nil, errors.New("options: VerificationTreeRoot is required")
 	}
-	if opts.WorkspaceClientFunc == nil {
-		return nil, errors.New("options: WorkspaceClientFunc is required")
+	if opts.VerificationClientFunc == nil {
+		return nil, errors.New("options: VerificationClientFunc is required")
 	}
 	if opts.RequeueInterval <= 0 {
 		opts.RequeueInterval = DefaultRequeueInterval

--- a/operators/resource-broker/pkg/controller/broker/acceptapi/reconciler_test.go
+++ b/operators/resource-broker/pkg/controller/broker/acceptapi/reconciler_test.go
@@ -53,21 +53,21 @@ func TestNewReconcilerValidation(t *testing.T) {
 	}{
 		{
 			name:    "missing tree root",
-			opts:    Options{WorkspaceClientFunc: clientFunc},
+			opts:    Options{VerificationClientFunc: clientFunc},
 			wantErr: "VerificationTreeRoot is required",
 		},
 		{
-			name: "missing workspace client func",
+			name: "missing verification client func",
 			opts: Options{
 				VerificationTreeRoot: "root:platform",
 			},
-			wantErr: "WorkspaceClientFunc is required",
+			wantErr: "VerificationClientFunc is required",
 		},
 		{
-			name: "tree root and workspace client func",
+			name: "tree root and verification client func",
 			opts: Options{
-				VerificationTreeRoot: "root:platform",
-				WorkspaceClientFunc:  clientFunc,
+				VerificationTreeRoot:   "root:platform",
+				VerificationClientFunc: clientFunc,
 			},
 		},
 	}

--- a/operators/resource-broker/pkg/controller/brokeredresource/assignment.go
+++ b/operators/resource-broker/pkg/controller/brokeredresource/assignment.go
@@ -202,7 +202,7 @@ func (s *assignmentSubroutine) ensureBound(ctx context.Context, assignment *pmco
 }
 
 func (s *assignmentSubroutine) validate(ctx context.Context, consumerCluster string, assignment *pmcoordbrokerv1alpha1.Assignment, u *unstructured.Unstructured) (subroutines.Result, error) {
-	providerClient, err := s.opts.WorkspaceClientFunc(assignment.Status.ProviderCluster)
+	providerClient, err := s.opts.ProviderClientFunc(assignment.Status.ProviderCluster)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for provider cluster %q: %w", assignment.Status.ProviderCluster, err)
 	}
@@ -330,7 +330,7 @@ func (s *assignmentSubroutine) finishMigration(ctx context.Context, assignment *
 
 	from := migration.Spec.FromStagingWorkspace
 	if from != "" && from != migration.Spec.StagingWorkspace {
-		fromClient, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot + ":" + from)
+		fromClient, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot + ":" + from)
 		if err != nil {
 			return subroutines.Result{}, fmt.Errorf("building client for staging workspace %q: %w", from, err)
 		}
@@ -466,7 +466,7 @@ func (s *assignmentSubroutine) createAssignment(ctx context.Context, name, consu
 
 // resolveAPIExportName reads the APIExport name from the AcceptAPI in the provider workspace.
 func (s *assignmentSubroutine) resolveAPIExportName(ctx context.Context, providerCluster, acceptAPIName string) (string, error) {
-	providerClient, err := s.opts.WorkspaceClientFunc(providerCluster)
+	providerClient, err := s.opts.ProviderClientFunc(providerCluster)
 	if err != nil {
 		return "", fmt.Errorf("building client for provider cluster %q: %w", providerCluster, err)
 	}

--- a/operators/resource-broker/pkg/controller/brokeredresource/copy.go
+++ b/operators/resource-broker/pkg/controller/brokeredresource/copy.go
@@ -183,7 +183,7 @@ func stagingClient(ctx context.Context, opts Options, consumerCluster string, u 
 		return nil, subroutines.Pending(opts.RequeueInterval, "waiting for assignment to be bound"), nil
 	}
 
-	cl, err := opts.WorkspaceClientFunc(opts.StagingTreeRoot + ":" + assignment.Status.StagingWorkspace)
+	cl, err := opts.StagingClientFunc(opts.StagingTreeRoot + ":" + assignment.Status.StagingWorkspace)
 	if err != nil {
 		return nil, subroutines.Result{}, fmt.Errorf("building client for staging workspace %q: %w", assignment.Status.StagingWorkspace, err)
 	}
@@ -244,7 +244,7 @@ func (s *copySubroutine) copyToMigrationTarget(ctx context.Context, migration *p
 		return subroutines.Pending(s.opts.RequeueInterval, "waiting for migration target staging workspace"), nil
 	}
 
-	targetClient, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot + ":" + migration.Spec.StagingWorkspace)
+	targetClient, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot + ":" + migration.Spec.StagingWorkspace)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for staging workspace %q: %w", migration.Spec.StagingWorkspace, err)
 	}

--- a/operators/resource-broker/pkg/controller/brokeredresource/migration_test.go
+++ b/operators/resource-broker/pkg/controller/brokeredresource/migration_test.go
@@ -62,7 +62,18 @@ func testMigrationOptions(t *testing.T, clients *migrationTestClients, refs []Ac
 		StagingTreeRoot:    testTreeRoot,
 		CoordinationClient: clients.coordination,
 		RequeueInterval:    DefaultRequeueInterval,
-		WorkspaceClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+		StagingClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+			switch path {
+			case testTreeRoot + ":" + testStagingName:
+				return clients.staging, nil
+			case testTreeRoot + ":" + testTargetStagingName:
+				return clients.target, nil
+			default:
+				t.Fatalf("unexpected staging client path %q", path)
+				return nil, nil
+			}
+		},
+		ProviderClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
 			switch path {
 			case testProviderCluster:
 				return clients.provider, nil
@@ -70,14 +81,10 @@ func testMigrationOptions(t *testing.T, clients *migrationTestClients, refs []Ac
 				if clients.otherProvider != nil {
 					return clients.otherProvider, nil
 				}
-				t.Fatalf("unexpected workspace client path %q", path)
+				t.Fatalf("unexpected provider client path %q", path)
 				return nil, nil
-			case testTreeRoot + ":" + testStagingName:
-				return clients.staging, nil
-			case testTreeRoot + ":" + testTargetStagingName:
-				return clients.target, nil
 			default:
-				t.Fatalf("unexpected workspace client path %q", path)
+				t.Fatalf("unexpected provider client path %q", path)
 				return nil, nil
 			}
 		},

--- a/operators/resource-broker/pkg/controller/brokeredresource/reconciler.go
+++ b/operators/resource-broker/pkg/controller/brokeredresource/reconciler.go
@@ -72,9 +72,14 @@ type Options struct {
 	// Required.
 	StagingTreeRoot string
 
-	// WorkspaceClientFunc returns a client scoped to the workspace with the given path.
+	// StagingClientFunc returns a client scoped to the workspace with the given path
+	// within the staging tree.
 	// Required.
-	WorkspaceClientFunc func(path string) (ctrlruntimeclient.Client, error)
+	StagingClientFunc func(path string) (ctrlruntimeclient.Client, error)
+
+	// ProviderClientFunc returns a client scoped to a provider workspace with the given path.
+	// Required.
+	ProviderClientFunc func(path string) (ctrlruntimeclient.Client, error)
 
 	// CoordinationClient is a client for the coordination cluster holding Assignments.
 	// Required.
@@ -124,8 +129,11 @@ func NewReconciler(mgr mcmanager.Manager, opts Options) (*Reconciler, error) {
 	if opts.StagingTreeRoot == "" {
 		return nil, errors.New("options: StagingTreeRoot is required")
 	}
-	if opts.WorkspaceClientFunc == nil {
-		return nil, errors.New("options: WorkspaceClientFunc is required")
+	if opts.StagingClientFunc == nil {
+		return nil, errors.New("options: StagingClientFunc is required")
+	}
+	if opts.ProviderClientFunc == nil {
+		return nil, errors.New("options: ProviderClientFunc is required")
 	}
 	if opts.CoordinationClient == nil {
 		return nil, errors.New("options: CoordinationClient is required")

--- a/operators/resource-broker/pkg/controller/brokeredresource/reconciler_test.go
+++ b/operators/resource-broker/pkg/controller/brokeredresource/reconciler_test.go
@@ -80,6 +80,7 @@ func testFakeClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimec
 type testClients struct {
 	coordination ctrlruntimeclient.Client
 	staging      ctrlruntimeclient.Client
+	provider     ctrlruntimeclient.Client
 }
 
 func testOptions(t *testing.T, clients testClients, refs []AcceptAPIRef) Options {
@@ -89,9 +90,12 @@ func testOptions(t *testing.T, clients testClients, refs []AcceptAPIRef) Options
 		GVR:                testGVR,
 		StagingTreeRoot:    testTreeRoot,
 		CoordinationClient: clients.coordination,
-		WorkspaceClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+		StagingClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
 			assert.Equal(t, testTreeRoot+":"+testStagingName, path)
 			return clients.staging, nil
+		},
+		ProviderClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+			return clients.provider, nil
 		},
 		ListAcceptAPIs: func(_ context.Context) ([]AcceptAPIRef, error) {
 			return refs, nil
@@ -166,6 +170,7 @@ func TestNewReconcilerValidation(t *testing.T) {
 		return testOptions(t, testClients{
 			coordination: testFakeClient(t),
 			staging:      testFakeClient(t),
+			provider:     testFakeClient(t),
 		}, nil)
 	}
 
@@ -190,9 +195,14 @@ func TestNewReconcilerValidation(t *testing.T) {
 			wantErr: "StagingTreeRoot is required",
 		},
 		{
-			name:    "missing workspace client func",
-			mutate:  func(o *Options) { o.WorkspaceClientFunc = nil },
-			wantErr: "WorkspaceClientFunc is required",
+			name:    "missing staging client func",
+			mutate:  func(o *Options) { o.StagingClientFunc = nil },
+			wantErr: "StagingClientFunc is required",
+		},
+		{
+			name:    "missing provider client func",
+			mutate:  func(o *Options) { o.ProviderClientFunc = nil },
+			wantErr: "ProviderClientFunc is required",
 		},
 		{
 			name:    "missing coordination client",
@@ -262,6 +272,7 @@ func TestControllerNameOverride(t *testing.T) {
 	clients := testClients{
 		coordination: testFakeClient(t),
 		staging:      testFakeClient(t),
+		provider:     testFakeClient(t),
 	}
 
 	opts := testOptions(t, clients, nil)

--- a/operators/resource-broker/pkg/controller/coordbroker/migration/cutover.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/migration/cutover.go
@@ -56,7 +56,7 @@ func (s *cutoverSubroutine) Process(ctx context.Context, obj ctrlruntimeclient.O
 		return subroutines.Pending(s.opts.RequeueInterval, "waiting for stages to complete"), nil
 	}
 
-	stagingClient, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot + ":" + migration.Spec.StagingWorkspace)
+	stagingClient, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot + ":" + migration.Spec.StagingWorkspace)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for staging workspace %q: %w", migration.Spec.StagingWorkspace, err)
 	}

--- a/operators/resource-broker/pkg/controller/coordbroker/migration/reconciler.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/migration/reconciler.go
@@ -54,9 +54,10 @@ type Options struct {
 	// Required.
 	ComputeClient ctrlruntimeclient.Client
 
-	// WorkspaceClientFunc returns a client scoped to the workspace with the given path.
+	// StagingClientFunc returns a client scoped to the workspace with the given path
+	// within the staging tree.
 	// Required.
-	WorkspaceClientFunc func(path string) (ctrlruntimeclient.Client, error)
+	StagingClientFunc func(path string) (ctrlruntimeclient.Client, error)
 
 	// StagingTreeRoot is the workspace path staging workspaces are
 	// created under.
@@ -89,8 +90,8 @@ func NewReconciler(mgr mcmanager.Manager, opts Options) (*Reconciler, error) {
 	if opts.ComputeClient == nil {
 		return nil, errors.New("options: ComputeClient is required")
 	}
-	if opts.WorkspaceClientFunc == nil {
-		return nil, errors.New("options: WorkspaceClientFunc is required")
+	if opts.StagingClientFunc == nil {
+		return nil, errors.New("options: StagingClientFunc is required")
 	}
 	if opts.StagingTreeRoot == "" {
 		return nil, errors.New("options: StagingTreeRoot is required")

--- a/operators/resource-broker/pkg/controller/coordbroker/migration/reconciler_test.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/migration/reconciler_test.go
@@ -95,14 +95,14 @@ func testOptions(t *testing.T, clients *testClients) Options {
 		StagingTreeRoot: testTreeRoot,
 		StageNamespace:  DefaultStageNamespace,
 		RequeueInterval: time.Second,
-		WorkspaceClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+		StagingClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
 			switch path {
 			case testTreeRoot + ":" + testFromStagingName:
 				return clients.fromStaging, nil
 			case testTreeRoot + ":" + testToStagingName:
 				return clients.toStaging, nil
 			default:
-				t.Fatalf("unexpected workspace client path %q", path)
+				t.Fatalf("unexpected staging client path %q", path)
 				return nil, nil
 			}
 		},
@@ -185,9 +185,9 @@ func TestNewReconcilerValidation(t *testing.T) {
 			wantErr: "options: ComputeClient is required",
 		},
 		{
-			name:    "missing workspace client func",
-			mutate:  func(opts *Options) { opts.WorkspaceClientFunc = nil },
-			wantErr: "options: WorkspaceClientFunc is required",
+			name:    "missing staging client func",
+			mutate:  func(opts *Options) { opts.StagingClientFunc = nil },
+			wantErr: "options: StagingClientFunc is required",
 		},
 		{
 			name:    "missing staging tree root",

--- a/operators/resource-broker/pkg/controller/coordbroker/migration/stages.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/migration/stages.go
@@ -227,7 +227,7 @@ func (s *stagesSubroutine) copyRelatedResources(ctx context.Context, wsName stri
 		return subroutines.OK(), nil
 	}
 
-	stagingClient, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot + ":" + wsName)
+	stagingClient, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot + ":" + wsName)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for staging workspace %q: %w", wsName, err)
 	}
@@ -341,7 +341,7 @@ func (s *stagesSubroutine) stagingCopies(ctx context.Context, migration *pmcoord
 			continue
 		}
 
-		stagingClient, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot + ":" + ref.workspace)
+		stagingClient, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot + ":" + ref.workspace)
 		if err != nil {
 			return nil, fmt.Errorf("building client for staging workspace %q: %w", ref.workspace, err)
 		}

--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/binding_ready.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/binding_ready.go
@@ -53,7 +53,7 @@ func (s *bindingReadySubroutine) Process(ctx context.Context, obj ctrlruntimecli
 	}
 
 	wsPath := s.opts.StagingTreeRoot + ":" + sw.Name
-	wsClient, err := s.opts.WorkspaceClientFunc(wsPath)
+	wsClient, err := s.opts.StagingClientFunc(wsPath)
 	if err != nil {
 		return subroutines.Result{}, fmt.Errorf("building client for workspace %q: %w", wsPath, err)
 	}
@@ -92,7 +92,7 @@ func (s *bindingReadySubroutine) Process(ctx context.Context, obj ctrlruntimecli
 
 // providerPermissionClaims mirrors the provider APIExport's permission claims as accepted claims.
 func (s *bindingReadySubroutine) providerPermissionClaims(ctx context.Context, sw *pmcoordbrokerv1alpha1.StagingWorkspace) ([]kcpapisv1alpha2.AcceptablePermissionClaim, error) {
-	providerClient, err := s.opts.WorkspaceClientFunc(sw.Spec.ProviderCluster)
+	providerClient, err := s.opts.ProviderClientFunc(sw.Spec.ProviderCluster)
 	if err != nil {
 		return nil, fmt.Errorf("building client for provider cluster %q: %w", sw.Spec.ProviderCluster, err)
 	}

--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/reconciler.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/reconciler.go
@@ -49,9 +49,14 @@ type Options struct {
 	// Required.
 	StagingTreeRoot string
 
-	// WorkspaceClientFunc returns a client scoped to the workspace with the given path.
+	// StagingClientFunc returns a client scoped to the workspace with the given path
+	// within the staging tree.
 	// Required.
-	WorkspaceClientFunc func(path string) (ctrlruntimeclient.Client, error)
+	StagingClientFunc func(path string) (ctrlruntimeclient.Client, error)
+
+	// ProviderClientFunc returns a client scoped to a provider workspace with the given path.
+	// Required.
+	ProviderClientFunc func(path string) (ctrlruntimeclient.Client, error)
 
 	// ClusterFilter restricts which provider clusters the controller engages.
 	// Optional, defaults to engaging all clusters.
@@ -73,8 +78,11 @@ func NewReconciler(mgr mcmanager.Manager, opts Options) (*Reconciler, error) {
 	if opts.StagingTreeRoot == "" {
 		return nil, errors.New("options: StagingTreeRoot is required")
 	}
-	if opts.WorkspaceClientFunc == nil {
-		return nil, errors.New("options: WorkspaceClientFunc is required")
+	if opts.StagingClientFunc == nil {
+		return nil, errors.New("options: StagingClientFunc is required")
+	}
+	if opts.ProviderClientFunc == nil {
+		return nil, errors.New("options: ProviderClientFunc is required")
 	}
 	if opts.RequeueInterval <= 0 {
 		opts.RequeueInterval = DefaultRequeueInterval

--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/reconciler_test.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/reconciler_test.go
@@ -78,15 +78,14 @@ func testOptions(t *testing.T, treeObjs, stagingObjs, providerObjs []ctrlruntime
 	opts := Options{
 		StagingTreeRoot: testTreeRoot,
 		RequeueInterval: time.Second,
-		WorkspaceClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
-			switch path {
-			case testTreeRoot:
+		StagingClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+			if path == testTreeRoot {
 				return clients.tree, nil
-			case testProviderCluster:
-				return clients.provider, nil
-			default:
-				return clients.staging, nil
 			}
+			return clients.staging, nil
+		},
+		ProviderClientFunc: func(path string) (ctrlruntimeclient.Client, error) {
+			return clients.provider, nil
 		},
 	}
 	return opts, clients
@@ -102,17 +101,22 @@ func TestNewReconcilerValidation(t *testing.T) {
 	}{
 		{
 			name:    "missing staging tree root",
-			opts:    Options{WorkspaceClientFunc: clientFunc},
+			opts:    Options{StagingClientFunc: clientFunc, ProviderClientFunc: clientFunc},
 			wantErr: true,
 		},
 		{
-			name:    "missing workspace client func",
-			opts:    Options{StagingTreeRoot: testTreeRoot},
+			name:    "missing staging client func",
+			opts:    Options{StagingTreeRoot: testTreeRoot, ProviderClientFunc: clientFunc},
+			wantErr: true,
+		},
+		{
+			name:    "missing provider client func",
+			opts:    Options{StagingTreeRoot: testTreeRoot, StagingClientFunc: clientFunc},
 			wantErr: true,
 		},
 		{
 			name: "valid options",
-			opts: Options{StagingTreeRoot: testTreeRoot, WorkspaceClientFunc: clientFunc},
+			opts: Options{StagingTreeRoot: testTreeRoot, StagingClientFunc: clientFunc, ProviderClientFunc: clientFunc},
 		},
 	}
 

--- a/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready.go
+++ b/operators/resource-broker/pkg/controller/coordbroker/stagingworkspace/workspace_ready.go
@@ -143,7 +143,7 @@ func (s *workspaceReadySubroutine) Finalize(ctx context.Context, obj ctrlruntime
 }
 
 func (s *workspaceReadySubroutine) treeRootClient() (ctrlruntimeclient.Client, error) {
-	cl, err := s.opts.WorkspaceClientFunc(s.opts.StagingTreeRoot)
+	cl, err := s.opts.StagingClientFunc(s.opts.StagingTreeRoot)
 	if err != nil {
 		return nil, fmt.Errorf("building client for tree root %q: %w", s.opts.StagingTreeRoot, err)
 	}


### PR DESCRIPTION
On-behalf-of: @SAP aleh.yarshou@sap.com

This pr addresses this issue https://github.com/platform-mesh/platform-mesh/issues/207

 **Goal**: 

Allow the resource-broker to use separate kubeconfigs for different kcp workspace trees (coordination, verification,
  staging) instead of a single shared kubeconfig.

  **Changes**:
  - Added 3 new CLI flags: `-coord-kubeconfig`, `-verification-kubeconfig`, `-staging-kubeconfig`
  - Split the single `WorkspaceClientFunc` into purpose-specific client factories
  - Each falls back to `-kcp-kubeconfig` if not provided (backward compatible)