### PR TITLE
include ProviderPermissions in Provider APIExport

### DIFF
--- a/operators/platform-mesh-operator/Taskfile.yaml
+++ b/operators/platform-mesh-operator/Taskfile.yaml
@@ -114,11 +114,13 @@ tasks:
             apigen_crds=(
                 # Add your apigen input CRDs below.
                 {{.CRD_DIRECTORY}}/providers.platform-mesh.io_providers.yaml
+                {{.CRD_DIRECTORY}}/providers.platform-mesh.io_providerpermissions.yaml
             )
             apigen_dest=(
                 # Add your apigen output paths below.
                 ./manifests/kcp/01-platform-mesh-system/apiexport-providers.platform-mesh.io.yaml
                 ./manifests/kcp/01-platform-mesh-system/apiresourceschema-providers.providers.platform-mesh.io.yaml
+                ./manifests/kcp/01-platform-mesh-system/apiresourceschema-providerpermissions.providers.platform-mesh.io.yaml
             )
 
             # NOTE: this script also applies yaml-patch files from {{.CRD_DIRECTORY}}/apigen/patches onto {{.CRD_DIRECTORY}}/apigen/out.
@@ -132,7 +134,10 @@ tasks:
                 cp "${manifest}" {{.CRD_DIRECTORY}}/apigen/crds
             done
 
+            BOILERPLATE={{.HACK}}/boilerplate/boilerplate.yaml.txt
+
             {{.APIGEN}} \
+                --header-file $BOILERPLATE \
                 --input-dir {{.CRD_DIRECTORY}}/apigen/crds \
                 --output-dir {{.CRD_DIRECTORY}}/apigen/out
 
@@ -140,7 +145,9 @@ tasks:
             for patch in ./config/crd/apigen/patches/*.yaml-patch; do
                 [[ -f "${patch}" ]] || continue
                 out="$(basename ${patch} | sed 's/-patch$//')"
-                {{.YAML_PATCH}} -o "${patch}" < "{{.CRD_DIRECTORY}}/apigen/out/${out}" > "{{.CRD_DIRECTORY}}/apigen/out/${out}.patched"
+
+                # patch the file and restore header comment
+                (cat $BOILERPLATE; echo; {{.YAML_PATCH}} -o "${patch}" < "{{.CRD_DIRECTORY}}/apigen/out/${out}") > "{{.CRD_DIRECTORY}}/apigen/out/${out}.patched"
                 mv "{{.CRD_DIRECTORY}}/apigen/out/${out}.patched" "{{.CRD_DIRECTORY}}/apigen/out/${out}"
             done
 

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiexport-providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiexport-providers.platform-mesh.io.yaml
@@ -70,8 +70,13 @@ spec:
     - delete
   resources:
   - group: providers.platform-mesh.io
+    name: providerpermissions
+    schema: v260814-b83d7328.providerpermissions.providers.platform-mesh.io
+    storage:
+      crd: {}
+  - group: providers.platform-mesh.io
     name: providers
-    schema: v260812-dee5e7d9.providers.providers.platform-mesh.io
+    schema: v260814-b83d7328.providers.providers.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providerpermissions.providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providerpermissions.providers.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260703-0c370717.providerpermissions.providers.platform-mesh.io
+  name: v260814-b83d7328.providerpermissions.providers.platform-mesh.io
 spec:
   group: providers.platform-mesh.io
   names:

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providers.providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providers.providers.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260812-dee5e7d9.providers.providers.platform-mesh.io
+  name: v260814-b83d7328.providers.providers.platform-mesh.io
 spec:
   group: providers.platform-mesh.io
   names:


### PR DESCRIPTION
More recent versions of the PM Operator need the ProviderPermissions to be present in the APIExport, otherwise the e2e tests cannot succeed. This PR belongs to the epic of merging the PM operator into the monorepo, which seemed simple but is now struggeling to be integrated into the helm-charts. So there might be more small fixes coming.