### PR TITLE
Fix failing provider deletion

### DIFF
--- a/operators/security-operator/internal/subroutine/tuples.go
+++ b/operators/security-operator/internal/subroutine/tuples.go
@@ -28,6 +28,7 @@ import (
 	"go.platform-mesh.io/security-operator/internal/fga"
 	"go.platform-mesh.io/subroutines"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -64,6 +65,14 @@ func (t *tupleSubroutine) Finalize(ctx context.Context, obj ctrlruntimeclient.Ob
 		err = storeCluster.GetClient().Get(ctx, types.NamespacedName{
 			Name: o.Spec.StoreRef.Name,
 		}, &store)
+		if apierrors.IsNotFound(err) {
+			// The Store this AuthorizationModel depended on is already gone, so its
+			// tuples and the FGA store itself are already gone too — nothing left to
+			// clean up. Without this, an AuthorizationModel whose Store was deleted
+			// first (e.g. due to a stale dependency-count read) can never finalize.
+			o.Status.ManagedTuples = nil
+			return subroutines.OK(), nil
+		}
 		if err != nil {
 			return subroutines.OK(), err
 		}

--- a/operators/security-operator/internal/subroutine/tuples_test.go
+++ b/operators/security-operator/internal/subroutine/tuples_test.go
@@ -28,7 +28,9 @@ import (
 	"go.platform-mesh.io/security-operator/internal/subroutine"
 	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
@@ -410,6 +412,41 @@ func TestTupleFinalizationWithAuthorizationModel(t *testing.T) {
 					}
 					return nil
 				})
+			},
+		},
+		{
+			name: "should finalize successfully when the referenced Store is already gone",
+			store: &pmcorev1alpha1.AuthorizationModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						pmcorev1alpha1.StoreRefLabelKey: "store",
+					},
+				},
+				Spec: pmcorev1alpha1.AuthorizationModelSpec{
+					StoreRef: pmcorev1alpha1.WorkspaceStoreRef{
+						Name:    "store",
+						Cluster: "store-cluster",
+					},
+				},
+				Status: pmcorev1alpha1.AuthorizationModelStatus{
+					ManagedTuples: []pmcorev1alpha1.Tuple{
+						{
+							Object:   "foo",
+							Relation: "bar",
+							User:     "user4",
+						},
+					},
+				},
+			},
+			// No fgaMocks: OpenFGA must NOT be called when the Store is already gone.
+			mgrMocks: func(mgr *mocks.MockManager) {
+				storeCluster := mocks.NewMockCluster(t)
+				storeClient := mocks.NewMockClient(t)
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(storeCluster, nil)
+				storeCluster.EXPECT().GetClient().Return(storeClient)
+				storeClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
+					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "stores"}, "store"),
+				)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Provider workspace deletion could hang forever: AuthorizationModel's fga-tuples finalizer looks up its Store to clean up FGA tuples, and if the Store is already gone it kept erroring and retrying instead of finishing
- Now treats a NotFound Store as "already cleaned up" and lets the finalizer clear

## Reproduction
- Reproduced: the permanent hang. Built a real provider (via provider-quickstart) + real consumer account, bound them, then orphaned the consumer's Store so the AuthorizationModel's StoreRef pointed at nothing. Provider deletion got stuck in "Deleting" for 13+ min straight with zero recovery, confirmed via security-operator logs showing the exact `Store ... not found` error repeating on every retry.
- Not reproduced: the "platform console becomes unresponsive" part from the original report. Portal endpoint stayed responsive (200 OK, ~10-15ms) the whole 13 min window in every test. Might need more scale (many stuck objects) or a different code path than what I tested - still open.

## Test plan
- [x] added unit test covering the NotFound path (asserts OpenFGA is never called)
- [x] full security-operator test suite passes
- [x] reproduced the hang on a local kind cluster (orphaned Store, provider delete stuck 13+ min with no recovery), rebuilt+redeployed with the fix, same scenario now deletes in ~10s
