### PR TITLE
fix(apis): correct fuzz target paths

### DIFF
--- a/apis/Taskfile.yaml
+++ b/apis/Taskfile.yaml
@@ -64,8 +64,8 @@ tasks:
     vars:
       FUZZTIME: '{{.FUZZTIME | default "30s"}}'
     cmds:
-      - go test ./terminal/ -run=^$ -fuzz=FuzzTerminalRoundTrip -fuzztime={{.FUZZTIME}} -count=1
-      - go test ./marketplace/ -run=^$ -fuzz=FuzzMarketplaceEntryRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./terminal/... -run=^$ -fuzz=FuzzTerminalRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./marketplace/... -run=^$ -fuzz=FuzzMarketplaceEntryRoundTrip -fuzztime={{.FUZZTIME}} -count=1
       - go test ./deploy/v1alpha1/ -run=^$ -fuzz=FuzzPlatformMeshRoundTrip -fuzztime={{.FUZZTIME}} -count=1
       - go test ./deploy/v1alpha1/ -run=^$ -fuzz='FuzzModuleRoundTrip$' -fuzztime={{.FUZZTIME}} -count=1
       - go test ./deploy/v1alpha1/ -run=^$ -fuzz=FuzzModuleSetupRoundTrip -fuzztime={{.FUZZTIME}} -count=1


### PR DESCRIPTION
The ./terminal/ and  ./marketplace/ paths point to directories with no go files. The tests never ran.

On-behalf-of: @SAP <b.marinov@sap.com>