### PR TITLE
fix deployment helper dealing with boilerplate-only YAML strings

### DIFF
--- a/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
@@ -208,7 +208,12 @@ func (r *DeploymentSubroutine) renderTemplateFile(path string, tmplVars map[stri
 		if err := yaml.Unmarshal([]byte(doc), &objMap); err != nil {
 			return nil, errors.Wrap(err, "Failed to unmarshal rendered YAML from template %s (size: %d bytes)", path, len(doc))
 		}
-		objs = append(objs, &unstructured.Unstructured{Object: objMap})
+
+		// Some templates will, once rendered, leave behind only their boilerplate comment,
+		// which will not trigger the emptiness check above.
+		if objMap != nil {
+			objs = append(objs, &unstructured.Unstructured{Object: objMap})
+		}
 	}
 	return objs, nil
 }


### PR DESCRIPTION
Right now, since we added boilerplates to everything, the PM operator fails:

> 2026-08-18T14:50:32Z ERR workspace/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go:118 > Failed to render and apply templates error="Failed to apply rendered manifest from template: /operator/gotemplates/infra/infra/appproject.yaml (/): Object 'Kind' is missing in 'unstructured object has no kind'" service=/workspace/golang-commons/logger/logger.go subroutine=DeploymentSubroutine type=infra

This is because it never expected a rendered template to be anything but either YAML or empty, but not just a giant comment. This PR makes sure we only keep non-empty objects going forward.