### PR TITLE
fix: error on mismatch between Search batch size and default openFGA batch size limit

### DIFF
--- a/services/search-service/cmd/server.go
+++ b/services/search-service/cmd/server.go
@@ -94,7 +94,7 @@ var serverCmd = &cobra.Command{
 		svc := searchservice.NewService(
 			searchIndexResolver,
 			openSearchClient,
-			fgaclient.NewAuthorizer(fgaClient),
+			fgaclient.NewAuthorizer(fgaClient, *serviceCfg),
 			metrics,
 			searchservice.ServiceConfig{
 				DefaultLimit:   serviceCfg.Search.DefaultLimit,

--- a/services/search-service/internal/clients/fga/authorizer.go
+++ b/services/search-service/internal/clients/fga/authorizer.go
@@ -25,18 +25,17 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"go.platform-mesh.io/golang-commons/logger"
+	"go.platform-mesh.io/search-service/internal/config"
 	"go.platform-mesh.io/search-service/internal/service/search"
 )
 
-// Currently 50 is the maximum batch size openFGA permits
-const batchCheckChunkSize = 50
-
 type Authorizer struct {
 	client openfgav1.OpenFGAServiceClient
+	cfg    config.ServiceConfig
 }
 
-func NewAuthorizer(client openfgav1.OpenFGAServiceClient) *Authorizer {
-	return &Authorizer{client: client}
+func NewAuthorizer(client openfgav1.OpenFGAServiceClient, cfg config.ServiceConfig) *Authorizer {
+	return &Authorizer{client: client, cfg: cfg}
 }
 
 func (a *Authorizer) FilterAuthorized(ctx context.Context, req search.AuthorizationRequest) (search.AuthorizationResult, error) {
@@ -65,7 +64,7 @@ func (a *Authorizer) FilterAuthorized(ctx context.Context, req search.Authorizat
 
 	result := search.AuthorizationResult{Allowed: allowed}
 
-	for _, chunk := range chunkRanges(len(req.Hits), batchCheckChunkSize) {
+	for _, chunk := range chunkRanges(len(req.Hits), a.cfg.BatchSize) {
 		start := chunk[0]
 		end := chunk[1]
 		items := make([]*openfgav1.BatchCheckItem, 0, end-start)

--- a/services/search-service/internal/clients/fga/authorizer.go
+++ b/services/search-service/internal/clients/fga/authorizer.go
@@ -28,7 +28,8 @@ import (
 	"go.platform-mesh.io/search-service/internal/service/search"
 )
 
-const batchCheckChunkSize = 100
+// Currently 50 is the maximum batch size openFGA permits
+const batchCheckChunkSize = 50
 
 type Authorizer struct {
 	client openfgav1.OpenFGAServiceClient

--- a/services/search-service/internal/config/config.go
+++ b/services/search-service/internal/config/config.go
@@ -54,6 +54,7 @@ type SearchConfig struct {
 type ServiceConfig struct {
 	Port                int
 	LocalDevelopmentOrg string
+	BatchSize           int
 	OpenSearch          OpenSearchConfig
 	OpenFGA             OpenFGAConfig
 	SearchIndex         SearchIndexConfig
@@ -108,6 +109,7 @@ func (c *ServiceConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.SearchIndex.Version, "searchindex-version", c.SearchIndex.Version, "SearchIndex API version")
 	fs.StringVar(&c.SearchIndex.Resource, "searchindex-resource", c.SearchIndex.Resource, "SearchIndex API resource plural")
 
+	fs.IntVar(&c.BatchSize, "batch-size", c.BatchSize, "Batch size for Authorization requests")
 	fs.IntVar(&c.Search.DefaultLimit, "search-default-limit", c.Search.DefaultLimit, "Default search result limit")
 	fs.IntVar(&c.Search.MaxLimit, "search-max-limit", c.Search.MaxLimit, "Maximum search result limit")
 	fs.IntVar(&c.Search.FetchBatchSize, "search-fetch-batch-size", c.Search.FetchBatchSize, "Batch size for OpenSearch fetches")

--- a/services/search-service/internal/config/config.go
+++ b/services/search-service/internal/config/config.go
@@ -88,6 +88,7 @@ func NewServiceConfig() *ServiceConfig {
 			FetchBatchSize: 100,
 			MaxScannedHits: 1000,
 		},
+		BatchSize: 50,
 	}
 }
 


### PR DESCRIPTION
Fixes [360](https://github.com/platform-mesh/backlog/issues/360)

On-behalf-of: @SAP florian.wuermseer@sap.com