### PR TITLE
ci(ocm): use v2 OCM jobs for kro-composition-operator's image-ocm

### DIFF
--- a/.github/workflows/kro-composition-operator.yml
+++ b/.github/workflows/kro-composition-operator.yml
@@ -334,7 +334,7 @@ jobs:
   image-ocm:
     if: startsWith(github.ref, 'refs/tags/kro-composition-operator/')
     needs: [version, docker-build-push]
-    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@75f52df7bff585bcb2d794a7bbeec132354933fb # main
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@13f745553db0275a7f5ad6f6c553803a77b3594e # main
     secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:
       contents: read # Needed for actions/checkout in the reusable


### PR DESCRIPTION
Produce OCMv2 compatible image ocm component for kro-composition-operator. 

Only doing this single change in order to release a new kro image and test the OCMv2 pipeline end-2-end. Will update the other jobs if successful.