### PR TITLE
spike: marketplace visibility poc with a simplified grant lookup

### DIFF
--- a/apis/marketplace/v1alpha1/visibilitygrant_types.go
+++ b/apis/marketplace/v1alpha1/visibilitygrant_types.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1alpha1
 
 import (

--- a/services/virtual-workspaces/cmd/start.go
+++ b/services/virtual-workspaces/cmd/start.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
+	pathaware "github.com/kcp-dev/multicluster-provider/path-aware"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
@@ -119,7 +120,7 @@ var startCmd = &cobra.Command{
 			}
 		}()
 
-		grantsProvider, err := apiexport.New(providerCfg, cfg.GrantsAPIExportEndpointSliceName, apiexport.Options{
+		grantsProvider, err := pathaware.New(providerCfg, cfg.GrantsAPIExportEndpointSliceName, apiexport.Options{
 			Scheme: scheme,
 		})
 		if err != nil {

--- a/services/virtual-workspaces/config/rbac/rbac-content-visibility.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/rbac/rbac-content-visibility.platform-mesh.io.yaml
@@ -1,0 +1,67 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: visibility-content-admin
+rules:
+  - apiGroups: ["apis.kcp.io"]
+    resources: ["apiexports/content"]
+    resourceNames: ["visibility.platform-mesh.io"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: visibility-endpointslice-read
+rules:
+  - apiGroups: ["apis.kcp.io"]
+    resources: ["apiexportendpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: visibility-endpointslice-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: visibility-endpointslice-read
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: pm:platform-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: kcp-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: visibility-content-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: visibility-content-admin
+subjects:
+  # TODO: platform-admin group is deployment config, template in the chart
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: pm:platform-admins
+  # explicit for local-setup demo parity; system:kcp:admin passes the SAR
+  # via privilege anyway
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: kcp-admin

--- a/services/virtual-workspaces/config/rbac/rbac-mpp-marketplace.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/rbac/rbac-mpp-marketplace.platform-mesh.io.yaml
@@ -1,3 +1,17 @@
+# Copyright The Platform Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Maximal permission policy RBAC for the marketplace.platform-mesh.io APIExport.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/services/virtual-workspaces/config/resources/apiexport-visibility.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiexport-visibility.platform-mesh.io.yaml
@@ -15,12 +15,13 @@
 apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
-  name: marketplace.platform-mesh.io
+  name: visibility.platform-mesh.io
 spec:
+  maximalPermissionPolicy:
+    local: {}
   resources:
   - group: marketplace.platform-mesh.io
-    name: marketplaceentries
-    schema: v260623-482e10b2.marketplaceentries.marketplace.platform-mesh.io
+    name: visibilitygrants
+    schema: v260815-d5e6f5f8.visibilitygrants.marketplace.platform-mesh.io
     storage:
       crd: {}
-status: {}

--- a/services/virtual-workspaces/config/resources/apiexportendpointslice-visibility.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiexportendpointslice-visibility.platform-mesh.io.yaml
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apis.kcp.io/v1alpha2
-kind: APIExport
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExportEndpointSlice
 metadata:
-  name: marketplace.platform-mesh.io
+  name: visibility.platform-mesh.io
 spec:
-  resources:
-  - group: marketplace.platform-mesh.io
-    name: marketplaceentries
-    schema: v260623-482e10b2.marketplaceentries.marketplace.platform-mesh.io
-    storage:
-      crd: {}
-status: {}
+  export:
+    path: root:platform-mesh-system
+    name: visibility.platform-mesh.io

--- a/services/virtual-workspaces/pkg/config/config.go
+++ b/services/virtual-workspaces/pkg/config/config.go
@@ -32,6 +32,7 @@ type ServiceConfig struct {
 	ResourceAPIExportEndpointSliceName string
 
 	GrantsAPIExportEndpointSliceName string
+	VisibilityHomePattern            string
 }
 
 func NewServiceConfig() ServiceConfig {
@@ -43,6 +44,7 @@ func NewServiceConfig() ServiceConfig {
 		ResourceSchemaName:               "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io",
 		ResourceSchemaWorkspace:          "root:openmfp-system",
 		GrantsAPIExportEndpointSliceName: "marketplace.platform-mesh.io",
+		VisibilityHomePattern:            "root:orgs",
 	}
 }
 
@@ -62,4 +64,5 @@ func (c *ServiceConfig) AddFlags(fs *pflag.FlagSet) {
 		"Set the resource APIExport EndpointSlice name",
 	)
 	fs.StringVar(&c.GrantsAPIExportEndpointSliceName, "grants-apiexport-endpointslice-name", c.GrantsAPIExportEndpointSliceName, "Set the VisibilityGrant APIExport EndpointSlice name")
+	fs.StringVar(&c.VisibilityHomePattern, "visibility-home-pattern", c.VisibilityHomePattern, "Canonical home prefix for VisibilityGrant resolution:")
 }

--- a/services/virtual-workspaces/pkg/config/config.go
+++ b/services/virtual-workspaces/pkg/config/config.go
@@ -43,7 +43,7 @@ func NewServiceConfig() ServiceConfig {
 		AccountEntityName:                "core_platform-mesh_io_account",
 		ResourceSchemaName:               "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io",
 		ResourceSchemaWorkspace:          "root:openmfp-system",
-		GrantsAPIExportEndpointSliceName: "marketplace.platform-mesh.io",
+		GrantsAPIExportEndpointSliceName: "visibility.platform-mesh.io",
 		VisibilityHomePattern:            "root:orgs",
 	}
 }

--- a/services/virtual-workspaces/pkg/marketplace/server.go
+++ b/services/virtual-workspaces/pkg/marketplace/server.go
@@ -28,7 +28,6 @@ import (
 	"go.platform-mesh.io/virtual-workspaces/pkg/proxy"
 	"go.platform-mesh.io/virtual-workspaces/pkg/storage"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -42,7 +41,6 @@ import (
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	pathaware "github.com/kcp-dev/multicluster-provider/path-aware"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
-	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/virtual-workspace-framework/framework"
 	virtualworkspacesdynamic "github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic"
@@ -99,13 +97,15 @@ func BuildVirtualWorkspace(
 						return cl.GetClient(), nil
 					},
 					cfg,
-					storage.VisibleExportsFromGrants(
-						grantsProvider.Lister(),
-						func(ctx context.Context, clusterID string) (*kcpcorev1alpha1.LogicalCluster, error) {
-							return kcpClusterClient.CoreV1alpha1().LogicalClusters().
-								Cluster(logicalcluster.Name(clusterID).Path()).
-								Get(ctx, kcpcorev1alpha1.LogicalClusterName, v1.GetOptions{})
+					storage.CanonicalHome(
+						func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error) {
+							cl, err := grantsProvider.Get(ctx, multicluster.ClusterName(path.String()))
+							if err != nil {
+								return nil, err
+							}
+							return cl.GetClient(), nil
 						},
+						cfg.VisibilityHomePattern,
 					),
 				)
 

--- a/services/virtual-workspaces/pkg/marketplace/server.go
+++ b/services/virtual-workspaces/pkg/marketplace/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
+	pathaware "github.com/kcp-dev/multicluster-provider/path-aware"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
@@ -62,7 +63,7 @@ func BuildVirtualWorkspace(
 	kcpClusterClient kcpclientset.ClusterInterface,
 	virtualWorkspaceBaseURL string,
 	provider *apiexport.Provider,
-	grantsProvider *apiexport.Provider,
+	grantsProvider *pathaware.Provider,
 ) virtualrootapiserver.NamedVirtualWorkspace {
 	clusterResolver := proxy.NewClusterResolver(kcpClusterClient)
 

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
 )
 
@@ -58,6 +59,7 @@ func marketplaceTestScheme(t *testing.T) *runtime.Scheme {
 	utilruntime.Must(pmuiv1alpha1.AddToScheme(s))
 	utilruntime.Must(kcpapisv1alpha1.AddToScheme(s))
 	utilruntime.Must(pmmarketplacev1alpha1.AddToScheme(s))
+	utilruntime.Must(kcpcorev1alpha1.AddToScheme(s))
 	return s
 }
 

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -151,7 +151,7 @@ func TestMarketplace_NoExportsVisible(t *testing.T) {
 
 	bindings := fake.NewClientBuilder().WithScheme(s).Build()
 
-	list := listMarketplace(t, lister, bindings, cfg, DenyAllExports)
+	list := listMarketplace(t, lister, bindings, cfg, denyAllExports)
 
 	assert.Empty(t, list.Items, "an export must stay hidden until a visibility source names it")
 }
@@ -354,4 +354,9 @@ func TestMarketplace_ExportsWithoutMatchingProvider(t *testing.T) {
 		allowExports(orphanedExport))
 
 	assert.Empty(t, list.Items, "should skip unknown providers")
+}
+
+// denyAllExports is a placeholder for the VisibleExportsFunc.
+func denyAllExports(context.Context, string) (map[string]sets.Set[string], error) {
+	return nil, nil
 }

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -194,7 +194,7 @@ func TestMarketplace_AllExportsVisible(t *testing.T) {
 
 	require.Len(t, list.Items, 2, "every export the source names must be listed")
 
-	var names []string
+	names := make([]string, 0, len(list.Items))
 	for _, entry := range list.Items {
 		names = append(names, entry.GetName())
 	}

--- a/services/virtual-workspaces/pkg/storage/visibility.go
+++ b/services/virtual-workspaces/pkg/storage/visibility.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (

--- a/services/virtual-workspaces/pkg/storage/visibility.go
+++ b/services/virtual-workspaces/pkg/storage/visibility.go
@@ -2,11 +2,14 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	pmmarketplacev1alpha1 "go.platform-mesh.io/apis/marketplace/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	mcpcache "github.com/kcp-dev/multicluster-provider/pkg/cache"
@@ -19,6 +22,63 @@ func DenyAllExports(context.Context, string) (map[string]sets.Set[string], error
 	return nil, nil
 }
 
+func CanonicalHome(
+	clusterByPath func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error),
+	homePattern string,
+) VisibleExportsFunc {
+	return func(ctx context.Context, logicalClusterID string) (map[string]sets.Set[string], error) {
+
+		path, got := ClusterPathFrom(ctx)
+		if !got {
+			return nil, errors.New("get canonical home: no cluster path in context")
+		}
+
+		if !strings.HasPrefix(path.String(), homePattern) {
+			// TODO: test and return error
+		}
+
+		tenantPath := strings.TrimPrefix(path.String(), homePattern)
+
+		pathSegments := strings.Split(tenantPath, ":")
+		if len(pathSegments) <= 1 {
+			// todo: test and slap back
+		}
+
+		grantsHomeSegment := pathSegments[1]
+		home := fmt.Sprintf("%s:%s", homePattern, grantsHomeSegment)
+
+		// eg
+		// homeClusterPath := "root:orgs:foo-corp"
+		homePath := logicalcluster.NewPath(home)
+		homeClient, err := clusterByPath(ctx, homePath)
+		if err != nil {
+			// TODO: if err multicluster.ErrClusterNotFound => return emptyMap, nil
+			return nil, err
+		}
+
+		var grants pmmarketplacev1alpha1.VisibilityGrantList
+		err = homeClient.List(ctx, &grants)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make(map[string]sets.Set[string])
+
+		for _, grantObj := range grants.Items {
+			for _, provider := range grantObj.Spec.Providers {
+				entries, got := result[provider.ProviderClusterID]
+				if !got {
+					entries = make(sets.Set[string])
+				}
+				entries.Insert(provider.APIExports...)
+				result[provider.ProviderClusterID] = entries
+			}
+		}
+
+		return result, nil
+	}
+}
+
 func VisibleExportsFromGrants(
 	client mcpcache.Lister,
 	getLogicalCluster func(ctx context.Context, clusterID string) (*kcpcorev1alpha1.LogicalCluster, error),
@@ -26,7 +86,6 @@ func VisibleExportsFromGrants(
 	return func(ctx context.Context, logicalClusterID string) (map[string]sets.Set[string], error) {
 		// ancestors:
 		clusterIDs := make(sets.Set[string])
-
 		clusterID := logicalClusterID
 		for !clusterIDs.Has(clusterID) {
 			if clusterID == core.RootCluster.String() {

--- a/services/virtual-workspaces/pkg/storage/visibility.go
+++ b/services/virtual-workspaces/pkg/storage/visibility.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	mcpcache "github.com/kcp-dev/multicluster-provider/pkg/cache"
@@ -27,32 +28,33 @@ func CanonicalHome(
 	homePattern string,
 ) VisibleExportsFunc {
 	return func(ctx context.Context, logicalClusterID string) (map[string]sets.Set[string], error) {
-
 		path, got := ClusterPathFrom(ctx)
 		if !got {
 			return nil, errors.New("get canonical home: no cluster path in context")
 		}
 
+		result := make(map[string]sets.Set[string])
+
 		if !strings.HasPrefix(path.String(), homePattern) {
-			// TODO: test and return error
+			return result, nil
 		}
 
-		tenantPath := strings.TrimPrefix(path.String(), homePattern)
+		tenantPath := strings.TrimPrefix(path.String(), homePattern+":")
 
 		pathSegments := strings.Split(tenantPath, ":")
 		if len(pathSegments) <= 1 {
-			// todo: test and slap back
+			return result, nil
 		}
 
 		grantsHomeSegment := pathSegments[1]
 		home := fmt.Sprintf("%s:%s", homePattern, grantsHomeSegment)
 
-		// eg
-		// homeClusterPath := "root:orgs:foo-corp"
 		homePath := logicalcluster.NewPath(home)
 		homeClient, err := clusterByPath(ctx, homePath)
 		if err != nil {
-			// TODO: if err multicluster.ErrClusterNotFound => return emptyMap, nil
+			if errors.Is(err, multicluster.ErrClusterNotFound) {
+				return result, nil
+			}
 			return nil, err
 		}
 
@@ -61,8 +63,6 @@ func CanonicalHome(
 		if err != nil {
 			return nil, err
 		}
-
-		result := make(map[string]sets.Set[string])
 
 		for _, grantObj := range grants.Items {
 			for _, provider := range grantObj.Spec.Providers {

--- a/services/virtual-workspaces/pkg/storage/visibility.go
+++ b/services/virtual-workspaces/pkg/storage/visibility.go
@@ -18,15 +18,12 @@ import (
 	kcpcorev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 )
 
-// DenyAllExports is a placeholder for the VisibleExportsFunc.
-func DenyAllExports(context.Context, string) (map[string]sets.Set[string], error) {
-	return nil, nil
-}
-
 func CanonicalHome(
 	clusterByPath func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error),
 	homePattern string,
 ) VisibleExportsFunc {
+	homePattern = strings.Trim(homePattern, ":")
+
 	return func(ctx context.Context, logicalClusterID string) (map[string]sets.Set[string], error) {
 		path, got := ClusterPathFrom(ctx)
 		if !got {
@@ -35,21 +32,11 @@ func CanonicalHome(
 
 		result := make(map[string]sets.Set[string])
 
-		if !strings.HasPrefix(path.String(), homePattern) {
+		homePath, found := workspaceHome(path, homePattern)
+		if !found {
 			return result, nil
 		}
 
-		tenantPath := strings.TrimPrefix(path.String(), homePattern+":")
-
-		pathSegments := strings.Split(tenantPath, ":")
-		if len(pathSegments) <= 1 {
-			return result, nil
-		}
-
-		grantsHomeSegment := pathSegments[1]
-		home := fmt.Sprintf("%s:%s", homePattern, grantsHomeSegment)
-
-		homePath := logicalcluster.NewPath(home)
 		homeClient, err := clusterByPath(ctx, homePath)
 		if err != nil {
 			if errors.Is(err, multicluster.ErrClusterNotFound) {
@@ -77,6 +64,19 @@ func CanonicalHome(
 
 		return result, nil
 	}
+}
+
+func workspaceHome(path logicalcluster.Path, homePattern string) (logicalcluster.Path, bool) {
+	remainder, found := strings.CutPrefix(path.String(), homePattern+":")
+	if !found {
+		return logicalcluster.Path{}, false
+	}
+
+	home, _, _ := strings.Cut(remainder, ":")
+	if home == "" {
+		return logicalcluster.Path{}, false
+	}
+	return logicalcluster.NewPath(homePattern + ":" + home), true
 }
 
 func VisibleExportsFromGrants(

--- a/services/virtual-workspaces/pkg/storage/visibility_test.go
+++ b/services/virtual-workspaces/pkg/storage/visibility_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (

--- a/services/virtual-workspaces/pkg/storage/visibility_test.go
+++ b/services/virtual-workspaces/pkg/storage/visibility_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -325,4 +326,64 @@ func makeClusterMap(clusters ...*kcpcorev1alpha1.LogicalCluster) map[string]*kcp
 		result[logicalcluster.From(v).String()] = v
 	}
 	return result
+}
+
+func TestCanonicalHome_InvalidLocations(t *testing.T) {
+	scheme := marketplaceTestScheme(t)
+
+	grant := makeGrant(t, "org-foo-id", pmmarketplacev1alpha1.ProviderExports{
+		ProviderClusterID: "baz-provider-id",
+		APIExports:        []string{"buckets.baz"},
+	})
+	homeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&grant).Build()
+
+	sut := CanonicalHome(clustersByPath(map[string]ctrlruntimeclient.Client{
+		"root:orgs:foo-corp": homeClient,
+	}), "root:orgs")
+
+	tests := []struct {
+		name        string
+		requestPath string
+	}{
+		{"request from root", "root"},
+		{"request from the home pattern level", "root:orgs"},
+		{"unrelated workspace tree", "root:compute:foo-corp"},
+		{"pattern partial match", "root:orgs2:foo-corp:team1"},
+		{"sibling org without the binding", "root:orgs:unrelated-org:team1"},
+		{"empty request path", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithClusterPath(t.Context(), logicalcluster.NewPath(tc.requestPath))
+
+			result, err := sut(ctx, "some-cluster-id")
+			require.NoError(t, err, "denied locations should result in empty response and not an err")
+			assert.Empty(t, result, "grants of root:orgs:foo-corp must not return for %q", tc.requestPath)
+		})
+	}
+}
+
+func TestCanonicalHome_Errors(t *testing.T) {
+	t.Run("missing cluster path in context", func(t *testing.T) {
+		sut := CanonicalHome(clustersByPath(nil), "root:orgs")
+
+		result, err := sut(t.Context(), "some-cluster-id")
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("unexpected resolution errors propagate", func(t *testing.T) {
+		connErr := syscall.ECONNREFUSED
+		sut := CanonicalHome(func(context.Context, logicalcluster.Path) (ctrlruntimeclient.Client, error) {
+			return nil, connErr
+		}, "root:orgs")
+
+		ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp:team1"))
+
+		result, err := sut(ctx, "some-cluster-id")
+		require.ErrorIs(t, err, connErr)
+		assert.Nil(t, result)
+	})
 }

--- a/services/virtual-workspaces/pkg/storage/visibility_test.go
+++ b/services/virtual-workspaces/pkg/storage/visibility_test.go
@@ -69,35 +69,73 @@ func makeClusterFn(clusters ...*kcpcorev1alpha1.LogicalCluster) func(ctx context
 	}
 }
 
-func TestCanonicalHome_FooDbg(t *testing.T) {
+func TestCanonicalHome(t *testing.T) {
 	scheme := marketplaceTestScheme(t)
+	t.Run("grant in home workspace", func(t *testing.T) {
+		homeID := "org-foo-id"
 
-	homeID := "org-foo-id"
+		grant := makeGrant(t, homeID, pmmarketplacev1alpha1.ProviderExports{
+			ProviderClusterID: "baz-provider-id",
+			APIExports:        []string{"buckets.baz"},
+		})
+		orgClusterClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(&grant).Build()
 
-	grant := makeGrant(t, homeID, pmmarketplacev1alpha1.ProviderExports{
-		ProviderClusterID: "baz-provider-id",
-		APIExports:        []string{"buckets.baz"},
+		// todo: clean up: not unnecessary, just for showcase purposes:
+		targetClusterClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects().Build()
+		seed := map[string]ctrlruntimeclient.Client{
+			"root:orgs:foo-corp":                   orgClusterClient,
+			"root:orgs:foo-corp:engineering:team1": targetClusterClient,
+		}
+
+		ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp:engineering:team1"))
+		sut := CanonicalHome(clustersByPath(seed), "root:orgs")
+
+		result, err := sut(ctx, "team-cluster-id")
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+
+		assert.True(t, result["baz-provider-id"].Has("buckets.baz"))
 	})
-	orgClusterClient := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(&grant).Build()
+	t.Run("request from home", func(t *testing.T) {
+		grant := makeGrant(t, "org-foo-id", pmmarketplacev1alpha1.ProviderExports{
+			ProviderClusterID: "baz-provider-id",
+			APIExports:        []string{"buckets.baz"},
+		})
+		homeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(&grant).Build()
 
-	// todo: clean up: not unnecessary, just for showcase purposes:
-	targetClusterClient := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects().Build()
-	seed := map[string]ctrlruntimeclient.Client{
-		"root:orgs:foo-corp":                   orgClusterClient,
-		"root:orgs:foo-corp:engineering:team1": targetClusterClient,
-	}
+		sut := CanonicalHome(clustersByPath(map[string]ctrlruntimeclient.Client{
+			"root:orgs:foo-corp": homeClient,
+		}), "root:orgs")
 
-	ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp:engineering:team1"))
-	sut := CanonicalHome(clustersByPath(seed), "root:orgs")
+		ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp"))
 
-	result, err := sut(ctx, "team-cluster-id")
-	require.NoError(t, err)
-	require.Len(t, result, 1)
+		result, err := sut(ctx, "org-foo-id")
+		require.NoError(t, err)
+		require.Len(t, result, 1, "the org's own grants apply to the org workspace itself")
+		assert.True(t, result["baz-provider-id"].Has("buckets.baz"))
+	})
+	t.Run("home pattern with leading colon", func(t *testing.T) {
+		grant := makeGrant(t, "org-foo-id", pmmarketplacev1alpha1.ProviderExports{
+			ProviderClusterID: "baz-provider-id",
+			APIExports:        []string{"buckets.baz"},
+		})
+		homeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(&grant).Build()
 
-	assert.True(t, result["baz-provider-id"].Has("buckets.baz"))
+		sut := CanonicalHome(clustersByPath(map[string]ctrlruntimeclient.Client{
+			"root:orgs:foo-corp": homeClient,
+		}), ":root:orgs")
 
+		ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp:team1"))
+
+		result, err := sut(ctx, "team1-id")
+		require.NoError(t, err)
+		require.Len(t, result, 1, "the kubectl-ws display form (:root:orgs) must not cause a silent deny")
+		assert.True(t, result["baz-provider-id"].Has("buckets.baz"))
+	})
 }
 
 func clustersByPath(

--- a/services/virtual-workspaces/pkg/storage/visibility_test.go
+++ b/services/virtual-workspaces/pkg/storage/visibility_test.go
@@ -141,7 +141,6 @@ func TestCanonicalHome(t *testing.T) {
 func clustersByPath(
 	clusterClients map[string]ctrlruntimeclient.Client,
 ) func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error) {
-
 	return func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error) {
 		cc, got := clusterClients[path.String()]
 		if !got {

--- a/services/virtual-workspaces/pkg/storage/visibility_test.go
+++ b/services/virtual-workspaces/pkg/storage/visibility_test.go
@@ -12,7 +12,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
@@ -63,6 +65,52 @@ func makeClusterFn(clusters ...*kcpcorev1alpha1.LogicalCluster) func(ctx context
 		}
 
 		return lc, nil
+	}
+}
+
+func TestCanonicalHome_FooDbg(t *testing.T) {
+	scheme := marketplaceTestScheme(t)
+
+	homeID := "org-foo-id"
+
+	grant := makeGrant(t, homeID, pmmarketplacev1alpha1.ProviderExports{
+		ProviderClusterID: "baz-provider-id",
+		APIExports:        []string{"buckets.baz"},
+	})
+	orgClusterClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&grant).Build()
+
+	// todo: clean up: not unnecessary, just for showcase purposes:
+	targetClusterClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects().Build()
+	seed := map[string]ctrlruntimeclient.Client{
+		"root:orgs:foo-corp":                   orgClusterClient,
+		"root:orgs:foo-corp:engineering:team1": targetClusterClient,
+	}
+
+	ctx := WithClusterPath(t.Context(), logicalcluster.NewPath("root:orgs:foo-corp:engineering:team1"))
+	sut := CanonicalHome(clustersByPath(seed), "root:orgs")
+
+	result, err := sut(ctx, "team-cluster-id")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	assert.True(t, result["baz-provider-id"].Has("buckets.baz"))
+
+}
+
+func clustersByPath(
+	clusterClients map[string]ctrlruntimeclient.Client,
+) func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error) {
+
+	return func(ctx context.Context, path logicalcluster.Path) (ctrlruntimeclient.Client, error) {
+		cc, got := clusterClients[path.String()]
+		if !got {
+			// make sure the sentinel error is as expected:
+			return nil, fmt.Errorf("cluster by path %q not found: %w",
+				path.String(), multicluster.ErrClusterNotFound)
+		}
+		return cc, nil
 	}
 }
 


### PR DESCRIPTION
PoC for #241

The PR branch is diffed against the the previous iteration on purpose. They share the same CRD and signature change to `func Marketplace`.

This iteration gives up the tree walk in favor of a simpler "canonical home" location for the grants. The location is configurable but defaults to the PM org 'home' at `root:orgs`. 

Deprecated code still present on this branch for easier A/B during the PoC, will be deleted eventually. 

> (!) If no VG resources are available in the home (organization) workspace, the marketplace service defaults to a deny. The marketplace will appear empty.

## High level

VisibilityGrant (name TBD) resources are created inside the subject's organization workspace. Assuming a sensible maximal permission policy (MPP), org owners / admins cannot self-grant. 

The resource references a provider workspace by its logical cluster ID. The assumption is that this is trivial to look up (CLI) and is readily available in a frontend client context. 



## Test in the local setup

Org setup:
```sh
▶ kubectl ws tree
.
└── root
    ├── orgs
    │   ├── once # grant lives here
    │   │   └── first
    │   └── zero # should not see MP entry
    │       └── bar
    ├── platform-mesh-system
    └── providers
        ├── cert-manager-provider
        ├── httpbin-provider # logical cluster ID "1x9kmpycm73no0vg"
        ├── kro-provider
        └── system

```

Grant is created in the `:root:orgs:once` workspace:
```yaml
apiVersion: marketplace.platform-mesh.io/v1alpha1
kind: VisibilityGrant
metadata:
  name: demo-grant
spec:
  providers:
    - providerClusterID: "1x9kmpycm73no0vg"
      apiExports:
        - orchestrate.platform-mesh.io
```


Test from the org/account with the grant (should see). Note that the other two providers are not visible:
```sh
▶ KUBECONFIG="$KCP_KUBECONFIG" kubectl get marketplaceentries --server="https://kcp.api.portal.localhost:8443/services/marketplace/clusters/root:orgs:once"
NAME
orchestrate.platform-mesh.io-orchestrate.platform-mesh.io

▶ KUBECONFIG="$KCP_KUBECONFIG" kubectl get marketplaceentries --server="https://kcp.api.portal.localhost:8443/services/marketplace/clusters/root:orgs:once:first"
NAME
orchestrate.platform-mesh.io-orchestrate.platform-mesh.io

```


Neighboring org has an empty marketplace:
```sh
▶ KUBECONFIG="$FOREIGN_ORG_ACC" kubectl get marketplaceentries --server="$mkt/root:orgs:zero:bar" -owide
No resources found
```


Tried to be sneaky and list the other org's marketplace:
```sh
KUBECONFIG="$FOREIGN_ORG_ACC" kubectl get marketplaceentries --server="$mkt/root:orgs:once:first" -owide
E0824 15:29:22.852995  535861 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: the server has asked for the client to provide credentials"
```


The request never reached the marketplace VW through the frontproxy. There is **no authorization in the VW** service at the moment (TODO in code). **So this currently works more or less by accident.** 


## Implementation details

The simple CanonicalHome function snips at the cluster path string until it looks right. A pathaware provider instance then fetches the VG resources from the target workspace.

### API groups and exports

A new `APIResourceSchema` is added to a separate export in the marketplace API group. A matching APIExportEndpointSlice pointing to the export is also created.

For organizations using the Marketplace, a new default API binding for the marketplace export must be added. 
In the default Platform Mesh configuration, this is a default API binding covering all org-type accounts.

> NOTE: reusing the same export is blocked on the alpha2.APIExport migration. Reconsider reuse vs publishing as separate apiexport for that and other reasons.


### RBAC

#### PM / Content admins managing VisibilityGrants

Role:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: marketplace-content-admin
rules:
  - apiGroups: ["apis.kcp.io"]
    resources: ["apiexports/content"]
    resourceNames: ["marketplace.platform-mesh.io"]
    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```


Role Binding
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: marketplace-content-admin
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: marketplace-content-admin
subjects:
  # TODO: platform-admin group is deployment config, template in the chart
  - apiGroup: rbac.authorization.k8s.io
    kind: Group
    name: pm:platform-admins
  # example/doc for local-setup: 
  # the system:kcp:admin user is privileged.
  # will pass authz anyway (!)
  - apiGroup: rbac.authorization.k8s.io
    kind: User
    name: kcp-admin
```



TBD: apiexport endpoint slices (not included in live / local setup test)

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: marketplace-endpointslice-read
rules:
  - apiGroups: ["apis.kcp.io"]
    resources: ["apiexportendpointslices"]
    verbs: ["get", "list", "watch"]
```


#### MPP

Read-only role (subjects: `system:authenticated`):
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: marketplace-visibilitygrant-read
rules:
- apiGroups: ["marketplace.platform-mesh.io"]
  resources: ["visibilitygrants"]
  verbs: ["get", "list", "watch"]
```

Write (subjects: marketplace/PM admin groups e.g. `pm:platform-admins` etc):
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: marketplace-visibilitygrant-write
rules:
- apiGroups: ["marketplace.platform-mesh.io"]
  resources: ["visibilitygrants"]
  verbs: ["create", "update", "patch", "delete"]
```


