### PR TITLE
feat(ocm): add legacy image OCM job for kro-composition-operator

### DIFF
--- a/.github/workflows/kro-composition-operator.yml
+++ b/.github/workflows/kro-composition-operator.yml
@@ -353,9 +353,31 @@ jobs:
       # not the org root, to avoid cross-repo package permissions.
       ocmRegistryUrl: ghcr.io/platform-mesh/platform-mesh
 
+  image-ocm-legacy:
+    if: startsWith(github.ref, 'refs/tags/kro-composition-operator/')
+    needs: [version, docker-build-push]
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@a22e08a90be540bb7de3119310bdc8b767c887fb # main
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    permissions:
+      contents: read # Needed for actions/checkout in the reusable
+      packages: write # Needed to push the OCM component to GHCR
+    with:
+      imageReference: ghcr.io/platform-mesh/platform-mesh/kro-composition-operator:${{ needs.version.outputs.version }}
+      appVersion: ${{ needs.version.outputs.version }}
+      # The reusable job signs with "<repoName>.platform-mesh" and OCM requires
+      # that to equal the signing cert's CN. The monorepo's shared OCM cert has
+      # CN "platform-mesh.platform-mesh", so repoName must be platform-mesh. The
+      # per-component OCM component identity is preserved via componentName.
+      repoName: platform-mesh
+      componentName: github.com/platform-mesh/images/kro-composition-operator
+      commit: ${{ github.sha }}
+      # Store the OCM component under this repo (owned by its GITHUB_TOKEN),
+      # not the org root, to avoid cross-repo package permissions.
+      ocmRegistryUrl: ghcr.io/platform-mesh
+
   trivy-sbom:
     if: startsWith(github.ref, 'refs/tags/kro-composition-operator/')
-    needs: [version, docker-build-push, image-ocm]
+    needs: [version, docker-build-push, image-ocm, image-ocm-legacy]
     uses: ./.github/workflows/job-trivy-sbom.yml
     permissions:
       contents: read # Needed for actions/checkout in the reusable


### PR DESCRIPTION
That legacy component is actually the one referenced when creating the service-level OCM component in helm-charts.