### PR TITLE
feat: allow aggregated querying on multiple resources

### DIFF
--- a/services/search-service/internal/router/router.go
+++ b/services/search-service/internal/router/router.go
@@ -67,51 +67,52 @@ func CreateRouter(svc SearchService, mws []func(http.Handler) http.Handler) *chi
 			return
 		}
 
+		resource := strings.TrimSpace(r.URL.Query().Get("resource"))
+
 		filters, err := parseFilters(r.URL.Query())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		resp, err := svc.Search(r.Context(), search.SearchRequest{
-			Organization: rc.Organization,
-			User:         rc.User,
-			Query:        q,
-			Mode:         strings.TrimSpace(r.URL.Query().Get("mode")),
-			Resource:     strings.TrimSpace(r.URL.Query().Get("resource")),
-			Filters:      filters,
-			Limit:        limit,
-			Page:         page,
-			Cursor:       strings.TrimSpace(r.URL.Query().Get("cursor")),
-		})
-		if err != nil {
-			log := logger.LoadLoggerFromContext(r.Context())
-			status := http.StatusInternalServerError
-			switch {
-			case errors.Is(err, search.ErrInvalidRequest), errors.Is(err, search.ErrInvalidCursor):
-				status = http.StatusBadRequest
-				http.Error(w, err.Error(), status)
-			case errors.Is(err, search.ErrUnauthorized):
-				status = http.StatusUnauthorized
-				http.Error(w, http.StatusText(status), status)
-			case errors.Is(err, search.ErrForbidden):
-				status = http.StatusForbidden
-				http.Error(w, http.StatusText(status), status)
-			default:
-				http.Error(w, http.StatusText(status), status)
-			}
-			log.Error().
-				Err(err).
-				Str("path", r.URL.Path).
-				Str("organization", rc.Organization).
-				Int("statusCode", status).
-				Msg("search request failed")
+		resources := resolveResources(resource, r.URL.Query().Get("resources"), filters)
+		if resources == nil {
+			http.Error(w, "Filtering is not supported for searching across all resources.", http.StatusBadRequest)
 			return
+		}
+
+		resultSet := make(map[string]search.SearchResponse, len(resources))
+		for _, res := range resources {
+			resp, err := svc.Search(r.Context(), search.SearchRequest{
+				Organization: rc.Organization,
+				User:         rc.User,
+				Query:        q,
+				Mode:         strings.TrimSpace(r.URL.Query().Get("mode")),
+				Resource:     res,
+				Filters:      filters,
+				Limit:        limit,
+				Page:         page,
+				Cursor:       strings.TrimSpace(r.URL.Query().Get("cursor")),
+			})
+			if err != nil {
+				handleError(w, r, rc, err)
+				return
+			}
+			resultSet[res] = resp
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+
+		if len(resultSet) == 1 {
+			var result search.SearchResponse
+			for _, v := range resultSet {
+				result = v
+			}
+			_ = json.NewEncoder(w).Encode(result)
+		} else {
+			_ = json.NewEncoder(w).Encode(resultSet)
+		}
 	})
 
 	router.With(mws...).Get("/rest/v1/search/resources", func(w http.ResponseWriter, r *http.Request) {
@@ -173,6 +174,36 @@ func CreateRouter(svc SearchService, mws []func(http.Handler) http.Handler) *chi
 	})
 
 	return router
+}
+
+// resolveResources decides which resources a search should run against:
+//   - a single "resource" param wins,
+//   - otherwise a comma-separated "resources" param selects a subset,
+//   - otherwise a single empty resource lets the service search everything.
+func resolveResources(resource, resourcesParam string, filters map[string][]string) []string {
+	if resource != "" {
+		return []string{resource}
+	}
+
+	if resources := parseResources(resourcesParam); len(resources) > 0 {
+		return resources
+	}
+
+	if len(filters) != 0 {
+		return nil
+	}
+
+	return []string{""}
+}
+
+func parseResources(raw string) []string {
+	var resources []string
+	for _, res := range strings.Split(raw, ",") {
+		if res = strings.TrimSpace(res); res != "" {
+			resources = append(resources, res)
+		}
+	}
+	return resources
 }
 
 func parseOptionalLimit(raw string) (int, error) {

--- a/services/search-service/internal/router/router_test.go
+++ b/services/search-service/internal/router/router_test.go
@@ -312,7 +312,7 @@ func TestCreateRouterResourcesParam(t *testing.T) {
 	}
 
 	// Only the listed resources are searched (blanks trimmed); ListResources is never consulted.
-	var searched []string
+	searched := make([]string, 0, len(svc.reqs))
 	for _, req := range svc.reqs {
 		searched = append(searched, req.Resource)
 	}

--- a/services/search-service/internal/router/router_test.go
+++ b/services/search-service/internal/router/router_test.go
@@ -34,6 +34,7 @@ type fakeSearchService struct {
 	response search.SearchResponse
 	err      error
 	lastReq  search.SearchRequest
+	reqs     []search.SearchRequest
 
 	resourcesResp search.SearchResourcesResponse
 	resourcesErr  error
@@ -46,6 +47,7 @@ type fakeSearchService struct {
 
 func (f *fakeSearchService) Search(ctx context.Context, req search.SearchRequest) (search.SearchResponse, error) {
 	f.lastReq = req
+	f.reqs = append(f.reqs, req)
 	return f.response, f.err
 }
 
@@ -295,5 +297,56 @@ func TestCreateRouterErrorMapping(t *testing.T) {
 				t.Fatalf("expected %d, got %d body=%s", tc.status, rr.Code, strings.TrimSpace(rr.Body.String()))
 			}
 		})
+	}
+}
+
+func TestCreateRouterResourcesParam(t *testing.T) {
+	svc := &fakeSearchService{}
+	r := CreateRouter(svc, []func(http.Handler) http.Handler{withRequestContext(appcontext.RequestContext{Organization: "acme", User: "alice@example.com"})})
+	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=hello&resources=accounts,+components+,", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// Only the listed resources are searched (blanks trimmed); ListResources is never consulted.
+	var searched []string
+	for _, req := range svc.reqs {
+		searched = append(searched, req.Resource)
+	}
+	if len(searched) != 2 {
+		t.Fatalf("expected 2 resources searched, got %v", searched)
+	}
+	if svc.lastResReq.Organization != "" {
+		t.Fatalf("expected ListResources not to be called")
+	}
+
+	// Multiple resources produce a keyed result map.
+	var payload map[string]search.SearchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response is not valid json: %v", err)
+	}
+	if _, ok := payload["accounts"]; !ok {
+		t.Fatalf("missing accounts in response: %v", payload)
+	}
+	if _, ok := payload["components"]; !ok {
+		t.Fatalf("missing components in response: %v", payload)
+	}
+}
+
+func TestCreateRouterResourceParamTakesPrecedence(t *testing.T) {
+	svc := &fakeSearchService{}
+	r := CreateRouter(svc, []func(http.Handler) http.Handler{withRequestContext(appcontext.RequestContext{Organization: "acme", User: "alice@example.com"})})
+	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=hello&resource=accounts&resources=components,services", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if len(svc.reqs) != 1 || svc.reqs[0].Resource != "accounts" {
+		t.Fatalf("expected single search for accounts, got %v", svc.reqs)
 	}
 }


### PR DESCRIPTION
This allows filtering for multiple resources required for a global search. Even without any providers besides Platform Mesh Core/System the amount of resources is too large to have a feasible sized result set with separate totals. Thus, the resources query param now allows selecting multiple resources with separate collections adhering to the result count and separate totals (once #222 ) is merged.

- Backwards compatible
- New Query param `resources`
- Comma Separated

Refers to: https://github.com/platform-mesh/backlog/issues/361

On-behalf-of: @SAP florian.wuermseer@sap.com