### PR TITLE
Fix for race condition between AuthorizationModel and Store on delete

### DIFF
--- a/operators/security-operator/internal/subroutine/authorization_model_dependency.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_dependency.go
@@ -1,0 +1,100 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+// authorizationModelFinalizerPrefix marks the finalizers a Store carries for
+// each AuthorizationModel that depends on it.
+const authorizationModelFinalizerPrefix = "authzmodel.core.platform-mesh.io/"
+
+// authorizationModelFinalizer returns the finalizer name for an
+// AuthorizationModel's dependency on its Store. Hashed because finalizer
+// names are capped at 63 bytes, which raw model names can exceed.
+func authorizationModelFinalizer(modelCluster, modelName string) string {
+	sum := sha256.Sum256([]byte(modelCluster + "/" + modelName))
+	// 31 bytes (62 hex chars) stays under the 63-byte cap.
+	return authorizationModelFinalizerPrefix + hex.EncodeToString(sum[:31])
+}
+
+// registerAuthorizationModelWithStore adds a finalizer marking that the
+// given AuthorizationModel depends on storeName. The API server rejects
+// this once the Store has a deletionTimestamp, so callers must not create
+// the AuthorizationModel unless this succeeds.
+//
+// storeCluster must already be formatted the way the caller's manager
+// expects.
+func registerAuthorizationModelWithStore(ctx context.Context, mgr mcmanager.Manager, storeCluster multicluster.ClusterName, storeName, modelCluster, modelName string) error {
+	cl, err := mgr.GetCluster(ctx, storeCluster)
+	if err != nil {
+		return fmt.Errorf("getting store cluster: %w", err)
+	}
+	finalizer := authorizationModelFinalizer(modelCluster, modelName)
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var store pmcorev1alpha1.Store
+		if err := cl.GetClient().Get(ctx, types.NamespacedName{Name: storeName}, &store); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(&store, finalizer) {
+			return nil
+		}
+		controllerutil.AddFinalizer(&store, finalizer)
+		return cl.GetClient().Update(ctx, &store)
+	})
+}
+
+// deregisterAuthorizationModelFromStore removes the finalizer added by
+// registerAuthorizationModelWithStore. A NotFound Store is treated as
+// already deregistered.
+func deregisterAuthorizationModelFromStore(ctx context.Context, mgr mcmanager.Manager, storeCluster multicluster.ClusterName, storeName, modelCluster, modelName string) error {
+	cl, err := mgr.GetCluster(ctx, storeCluster)
+	if err != nil {
+		return fmt.Errorf("getting store cluster: %w", err)
+	}
+	finalizer := authorizationModelFinalizer(modelCluster, modelName)
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var store pmcorev1alpha1.Store
+		err := cl.GetClient().Get(ctx, types.NamespacedName{Name: storeName}, &store)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !controllerutil.ContainsFinalizer(&store, finalizer) {
+			return nil
+		}
+		controllerutil.RemoveFinalizer(&store, finalizer)
+		return cl.GetClient().Update(ctx, &store)
+	})
+}

--- a/operators/security-operator/internal/subroutine/authorization_model_dependency_test.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_dependency_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subroutine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+func TestAuthorizationModelFinalizer(t *testing.T) {
+	assert.True(t, strings.HasPrefix(authorizationModelFinalizer("cluster1", "model1"), authorizationModelFinalizerPrefix))
+	assert.Equal(t, authorizationModelFinalizer("cluster1", "model1"), authorizationModelFinalizer("cluster1", "model1"), "must be deterministic")
+	assert.NotEqual(t, authorizationModelFinalizer("cluster1", "model1"), authorizationModelFinalizer("cluster1", "model2"), "must differ for different models")
+	assert.NotEqual(t, authorizationModelFinalizer("cluster1", "model1"), authorizationModelFinalizer("cluster2", "model1"), "must differ for different clusters")
+
+	// verify that the finalizer name isn't too long
+	longCluster := strings.Repeat("c", 100)
+	longModel := "process-test-example-com-testresources-generator-test-process"
+	segment := strings.TrimPrefix(authorizationModelFinalizer(longCluster, longModel), authorizationModelFinalizerPrefix)
+	assert.LessOrEqual(t, len(segment), 63)
+}
+
+func TestRegisterAuthorizationModelWithStore(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockSetup   func(*mocks.MockManager, *mocks.MockCluster, *mocks.MockClient)
+		expectError bool
+	}{
+		{
+			name: "error getting store cluster",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(nil, assert.AnError)
+			},
+			expectError: true,
+		},
+		{
+			name: "error getting store (e.g. NotFound because the Store or its org is terminating)",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
+					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "stores"}, "store"))
+			},
+			expectError: true,
+		},
+		{
+			name: "adds the finalizer when not already present",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{}
+					return nil
+				})
+				kc.EXPECT().Update(mock.Anything, mock.MatchedBy(func(o *pmcorev1alpha1.Store) bool {
+					return len(o.Finalizers) == 1 && o.Finalizers[0] == authorizationModelFinalizer("model-cluster", "model")
+				})).Return(nil)
+			},
+		},
+		{
+			name: "no-op when the finalizer is already present",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{
+						ObjectMeta: metav1.ObjectMeta{Finalizers: []string{authorizationModelFinalizer("model-cluster", "model")}},
+					}
+					return nil
+				})
+				// No Update expected.
+			},
+		},
+		{
+			name: "propagates the rejection when the Store is already being deleted",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{}
+					return nil
+				})
+				// The API server rejects adding a finalizer once deletionTimestamp is
+				// set; simulate that rejection (not a conflict, so no retry).
+				kc.EXPECT().Update(mock.Anything, mock.Anything).Return(
+					apierrors.NewInvalid(schema.GroupKind{Group: "core.platform-mesh.io", Kind: "Store"}, "store", nil))
+			},
+			expectError: true,
+		},
+		{
+			name: "retries once on a resourceVersion conflict then succeeds",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{}
+					return nil
+				}).Twice()
+				kc.EXPECT().Update(mock.Anything, mock.Anything).Return(
+					apierrors.NewConflict(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "stores"}, "store", assert.AnError)).Once()
+				kc.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Once()
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mgr := mocks.NewMockManager(t)
+			cl := mocks.NewMockCluster(t)
+			kc := mocks.NewMockClient(t)
+			test.mockSetup(mgr, cl, kc)
+
+			err := registerAuthorizationModelWithStore(context.Background(), mgr, "store-cluster", "store", "model-cluster", "model")
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeregisterAuthorizationModelFromStore(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockSetup   func(*mocks.MockManager, *mocks.MockCluster, *mocks.MockClient)
+		expectError bool
+	}{
+		{
+			name: "error getting store cluster",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(nil, assert.AnError)
+			},
+			expectError: true,
+		},
+		{
+			name: "store already gone: nothing to deregister",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
+					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "stores"}, "store"))
+			},
+		},
+		{
+			name: "error getting store (not NotFound)",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(assert.AnError)
+			},
+			expectError: true,
+		},
+		{
+			name: "removes the finalizer when present",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{
+						ObjectMeta: metav1.ObjectMeta{Finalizers: []string{authorizationModelFinalizer("model-cluster", "model"), "core.platform-mesh.io/fga-store"}},
+					}
+					return nil
+				})
+				kc.EXPECT().Update(mock.Anything, mock.MatchedBy(func(o *pmcorev1alpha1.Store) bool {
+					return len(o.Finalizers) == 1 && o.Finalizers[0] == "core.platform-mesh.io/fga-store"
+				})).Return(nil)
+			},
+		},
+		{
+			name: "no-op when the finalizer is not present",
+			mockSetup: func(mgr *mocks.MockManager, cl *mocks.MockCluster, kc *mocks.MockClient) {
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(cl, nil)
+				cl.EXPECT().GetClient().Return(kc)
+				kc.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "store"}, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					*o.(*pmcorev1alpha1.Store) = pmcorev1alpha1.Store{}
+					return nil
+				})
+				// No Update expected.
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mgr := mocks.NewMockManager(t)
+			cl := mocks.NewMockCluster(t)
+			kc := mocks.NewMockClient(t)
+			test.mockSetup(mgr, cl, kc)
+
+			err := deregisterAuthorizationModelFromStore(context.Background(), mgr, "store-cluster", "store", "model-cluster", "model")
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/operators/security-operator/internal/subroutine/authorization_model_generation.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_generation.go
@@ -231,7 +231,14 @@ func (a *AuthorizationModelGenerationSubroutine) Finalize(ctx context.Context, o
 		})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				// If the model does not exist, we can skip the deletion.
+				// The model was never created, but a reservation finalizer may
+				// still be on the Store — release it.
+				if derr := deregisterAuthorizationModelFromStore(ctx, a.mgr,
+					config.MultiProviderName(config.CoreProviderName, toDeleteAccountInfo.Spec.Organization.OriginClusterId), toDeleteAccountInfo.Spec.Organization.Name,
+					bindingToDelete.Status.APIExportClusterName, authModelName,
+				); derr != nil {
+					return subroutines.OK(), fmt.Errorf("releasing authorization model reservation for %s: %w", authModelName, derr)
+				}
 				log.Info().Msg(fmt.Sprintf("authorization model %s does not exist", authModelName))
 				continue
 			}
@@ -352,9 +359,20 @@ func (a *AuthorizationModelGenerationSubroutine) Process(ctx context.Context, ob
 			return subroutines.OK(), fmt.Errorf("executing model template: %w", err)
 		}
 
+		modelName := toK8sName(resourceSchema.Spec.Group, resourceSchema.Spec.Names.Plural, accountInfo.Spec.Organization.Name)
+
+		// Reserve the model on its Store before creating it, so the bind fails
+		// atomically instead of racing an org deletion.
+		if err := registerAuthorizationModelWithStore(ctx, a.mgr,
+			config.MultiProviderName(config.CoreProviderName, accountInfo.Spec.Organization.OriginClusterId), accountInfo.Spec.Organization.Name,
+			binding.Status.APIExportClusterName, modelName,
+		); err != nil {
+			return subroutines.OK(), fmt.Errorf("registering authorization model %s with store: %w", modelName, err)
+		}
+
 		model := pmcorev1alpha1.AuthorizationModel{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: toK8sName(resourceSchema.Spec.Group, resourceSchema.Spec.Names.Plural, accountInfo.Spec.Organization.Name),
+				Name: modelName,
 			},
 		}
 

--- a/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
@@ -103,12 +103,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 			mockSetup: func(manager *mocks.MockManager, lister *mocks.MockLister, cluster *mocks.MockCluster, kcpClient *mocks.MockClient) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
-				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
-					if _, ok := o.(*pmcorev1alpha1.AccountInfo); ok {
-						return nil
-					}
-					return nil
-				}).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(assert.AnError)
 			},
@@ -120,12 +115,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 			mockSetup: func(manager *mocks.MockManager, lister *mocks.MockLister, cluster *mocks.MockCluster, kcpClient *mocks.MockClient) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
-				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
-					if _, ok := o.(*pmcorev1alpha1.AccountInfo); ok {
-						return nil
-					}
-					return nil
-				}).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
@@ -150,12 +140,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 					return nil
 				}).Once()
 				// registerAuthorizationModelWithStore: fetch the Store, add its finalizer.
-				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
-					if _, ok := o.(*pmcorev1alpha1.Store); ok {
-						return nil
-					}
-					return nil
-				}).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				kcpClient.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Once()
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
 					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "things-org")).Once()

--- a/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
@@ -126,7 +126,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 					}
 					return nil
 				}).Once()
-				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
 						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
@@ -149,6 +149,14 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 					}
 					return nil
 				}).Once()
+				// registerAuthorizationModelWithStore: fetch the Store, add its finalizer.
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if _, ok := o.(*pmcorev1alpha1.Store); ok {
+						return nil
+					}
+					return nil
+				}).Once()
+				kcpClient.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Once()
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
 					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "things-org")).Once()
 				kcpClient.EXPECT().Create(mock.Anything, mock.Anything).Return(assert.AnError).Once()
@@ -171,7 +179,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
 				mockAccountInfo(kcpClient, "org", "origin")
-				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
 						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
@@ -207,7 +215,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
 				mockAccountInfo(kcpClient, "org", "origin")
-				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
 						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
@@ -280,7 +288,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
 				mockAccountInfo(kcpClient, "org", "origin")
-				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
 						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
@@ -337,7 +345,7 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
 				cluster.EXPECT().GetClient().Return(kcpClient)
 				mockAccountInfo(kcpClient, "org", "origin")
-				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(3)
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
 						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
@@ -695,6 +703,14 @@ func TestAuthorizationModelGeneration_Finalize(t *testing.T) {
 				})
 				apiExportClient.EXPECT().Delete(mock.Anything, mock.Anything).Return(
 					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "foos-org"))
+				// deregisterAuthorizationModelFromStore: the model was never created, so release
+				// any reservation left on the Store. A NotFound Store means nothing to release.
+				storeCluster := mocks.NewMockCluster(t)
+				storeClient := mocks.NewMockClient(t)
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(storeCluster, nil)
+				storeCluster.EXPECT().GetClient().Return(storeClient)
+				storeClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
+					apierrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "stores"}, "org"))
 			},
 		},
 		{

--- a/operators/security-operator/internal/subroutine/store.go
+++ b/operators/security-operator/internal/subroutine/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"google.golang.org/grpc/codes"
@@ -64,15 +65,15 @@ func (s *storeSubroutine) Finalize(ctx context.Context, obj ctrlruntimeclient.Ob
 		return subroutines.OK(), nil
 	}
 
-	authorizationModels, err := getRelatedAuthorizationModels(ctx, s.kcpHelper, store)
-	if err != nil {
-		return subroutines.OK(), err
-	}
-	if len(authorizationModels.Items) != 0 {
-		return subroutines.OK(), fmt.Errorf("found non-zero count of depending authorization models")
+	// Block deletion while any AuthorizationModel still depends on this
+	// Store, tracked via finalizers instead of a list to avoid stale reads.
+	for _, f := range store.GetFinalizers() {
+		if strings.HasPrefix(f, authorizationModelFinalizerPrefix) {
+			return subroutines.OK(), fmt.Errorf("waiting for dependent authorization model to be removed: %s", f)
+		}
 	}
 
-	_, err = s.fga.DeleteStore(ctx, &openfgav1.DeleteStoreRequest{StoreId: store.Status.StoreID})
+	_, err := s.fga.DeleteStore(ctx, &openfgav1.DeleteStoreRequest{StoreId: store.Status.StoreID})
 	if status, ok := status.FromError(err); ok && status.Code() == codes.Code(openfgav1.NotFoundErrorCode_store_id_not_found) {
 		return subroutines.OK(), nil
 	}

--- a/operators/security-operator/internal/subroutine/store_test.go
+++ b/operators/security-operator/internal/subroutine/store_test.go
@@ -32,7 +32,6 @@ import (
 	"go.platform-mesh.io/security-operator/internal/subroutine/mocks"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
@@ -194,11 +193,10 @@ func TestProcess(t *testing.T) {
 
 func TestFinalize(t *testing.T) {
 	tests := []struct {
-		name           string
-		store          *pmcorev1alpha1.Store
-		fgaMocks       func(*mocks.MockOpenFGAServiceClient)
-		kcpHelperMocks func(*mocks.MockLister)
-		expectError    bool
+		name        string
+		store       *pmcorev1alpha1.Store
+		fgaMocks    func(*mocks.MockOpenFGAServiceClient)
+		expectError bool
 	}{
 		{
 			name: "should skip reconciliation if .status.storeId is not set",
@@ -209,61 +207,28 @@ func TestFinalize(t *testing.T) {
 			},
 		},
 		{
-			name: "should deny deletion if at least authorizationModel is referencing the store",
+			name: "should deny deletion if at least one authorization model finalizer is present",
 			store: &pmcorev1alpha1.Store{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "store",
+					Name:       "store",
+					Finalizers: []string{"authzmodel.core.platform-mesh.io/somecluster.somemodel"},
 				},
 				Status: pmcorev1alpha1.StoreStatus{
 					StoreID: "id",
 				},
-			},
-			kcpHelperMocks: func(kcpHelper *mocks.MockLister) {
-				kcpHelper.EXPECT().List(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, ol ctrlruntimeclient.ObjectList, lo ...ctrlruntimeclient.ListOption) error {
-					if list, ok := ol.(*pmcorev1alpha1.AuthorizationModelList); ok {
-						list.Items = []pmcorev1alpha1.AuthorizationModel{
-							{
-								Spec: pmcorev1alpha1.AuthorizationModelSpec{
-									StoreRef: pmcorev1alpha1.WorkspaceStoreRef{
-										Name:    "store",
-										Cluster: "path",
-									},
-								},
-							},
-						}
-					}
-					return nil
-				}).Once()
 			},
 			expectError: true,
 		},
 		{
-			name: "should deny deletion the list call is failing",
+			name: "should delete the store if no authorization model finalizer is present",
 			store: &pmcorev1alpha1.Store{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "store",
+					Name:       "store",
+					Finalizers: []string{"core.platform-mesh.io/fga-store"},
 				},
 				Status: pmcorev1alpha1.StoreStatus{
 					StoreID: "id",
 				},
-			},
-			kcpHelperMocks: func(kcpHelper *mocks.MockLister) {
-				kcpHelper.EXPECT().List(mock.Anything, mock.Anything).Return(errors.New("error"))
-			},
-			expectError: true,
-		},
-		{
-			name: "should delete the store if no authorizationModel is referencing it",
-			store: &pmcorev1alpha1.Store{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "store",
-				},
-				Status: pmcorev1alpha1.StoreStatus{
-					StoreID: "id",
-				},
-			},
-			kcpHelperMocks: func(kcpHelper *mocks.MockLister) {
-				kcpHelper.EXPECT().List(mock.Anything, mock.Anything).Return(nil)
 			},
 			fgaMocks: func(fga *mocks.MockOpenFGAServiceClient) {
 				fga.EXPECT().DeleteStore(mock.Anything, &openfgav1.DeleteStoreRequest{StoreId: "id"}).Return(nil, nil)
@@ -279,9 +244,6 @@ func TestFinalize(t *testing.T) {
 					StoreID: "id",
 				},
 			},
-			kcpHelperMocks: func(kcpHelper *mocks.MockLister) {
-				kcpHelper.EXPECT().List(mock.Anything, mock.Anything).Return(nil)
-			},
 			fgaMocks: func(fga *mocks.MockOpenFGAServiceClient) {
 				fga.EXPECT().DeleteStore(mock.Anything, &openfgav1.DeleteStoreRequest{StoreId: "id"}).Return(nil, status.Error(codes.Code(openfgav1.NotFoundErrorCode_store_id_not_found), "not found"))
 			},
@@ -295,9 +257,6 @@ func TestFinalize(t *testing.T) {
 				Status: pmcorev1alpha1.StoreStatus{
 					StoreID: "id",
 				},
-			},
-			kcpHelperMocks: func(kcpHelper *mocks.MockLister) {
-				kcpHelper.EXPECT().List(mock.Anything, mock.Anything).Return(nil)
 			},
 			fgaMocks: func(fga *mocks.MockOpenFGAServiceClient) {
 				fga.EXPECT().DeleteStore(mock.Anything, &openfgav1.DeleteStoreRequest{StoreId: "id"}).Return(nil, errors.New("error"))
@@ -314,11 +273,6 @@ func TestFinalize(t *testing.T) {
 
 			manager := mocks.NewMockManager(t)
 			kcpHelper := mocks.NewMockLister(t)
-
-			// Only wire kcpHelper expectations when Finalize will actually query k8s (i.e., StoreID is set)
-			if test.store.Status.StoreID != "" && test.kcpHelperMocks != nil {
-				test.kcpHelperMocks(kcpHelper)
-			}
 
 			subroutine := subroutine.NewStoreSubroutine(fga, manager, kcpHelper)
 

--- a/operators/security-operator/internal/subroutine/tuples.go
+++ b/operators/security-operator/internal/subroutine/tuples.go
@@ -33,6 +33,8 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+
+	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 type tupleSubroutine struct {
@@ -68,8 +70,7 @@ func (t *tupleSubroutine) Finalize(ctx context.Context, obj ctrlruntimeclient.Ob
 		if apierrors.IsNotFound(err) {
 			// The Store this AuthorizationModel depended on is already gone, so its
 			// tuples and the FGA store itself are already gone too — nothing left to
-			// clean up. Without this, an AuthorizationModel whose Store was deleted
-			// first (e.g. due to a stale dependency-count read) can never finalize.
+			// clean up.
 			o.Status.ManagedTuples = nil
 			return subroutines.OK(), nil
 		}
@@ -84,6 +85,16 @@ func (t *tupleSubroutine) Finalize(ctx context.Context, obj ctrlruntimeclient.Ob
 	tm := fga.NewTupleManager(t.fga, storeID, authorizationModelID, log)
 	if err := tm.Delete(ctx, managedTuples); err != nil {
 		return subroutines.OK(), err
+	}
+
+	if o, ok := obj.(*pmcorev1alpha1.AuthorizationModel); ok {
+		// Release the Store reservation before this object's own finalizer clears.
+		if err := deregisterAuthorizationModelFromStore(ctx, t.mgr,
+			multicluster.ClusterName(o.Spec.StoreRef.Cluster), o.Spec.StoreRef.Name,
+			logicalcluster.From(o).String(), o.GetName(),
+		); err != nil {
+			return subroutines.OK(), fmt.Errorf("deregistering authorization model from store: %w", err)
+		}
 	}
 
 	switch o := obj.(type) {

--- a/operators/security-operator/internal/subroutine/tuples_test.go
+++ b/operators/security-operator/internal/subroutine/tuples_test.go
@@ -402,17 +402,74 @@ func TestTupleFinalizationWithAuthorizationModel(t *testing.T) {
 				storeClient := mocks.NewMockClient(t)
 				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(storeCluster, nil)
 				storeCluster.EXPECT().GetClient().Return(storeClient)
+				// First Get is the tuple-cleanup lookup, second is
+				// deregisterAuthorizationModelFromStore's own fetch.
 				storeClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
 					store := o.(*pmcorev1alpha1.Store)
 					*store = pmcorev1alpha1.Store{
+						ObjectMeta: metav1.ObjectMeta{
+							Finalizers: []string{"authzmodel.core.platform-mesh.io/8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0", "core.platform-mesh.io/fga-store"},
+						},
 						Status: pmcorev1alpha1.StoreStatus{
 							StoreID:              "store-id",
 							AuthorizationModelID: "auth-model-id",
 						},
 					}
 					return nil
-				})
+				}).Twice()
+				storeClient.EXPECT().Update(mock.Anything, mock.MatchedBy(func(o *pmcorev1alpha1.Store) bool {
+					return len(o.Finalizers) == 1 && o.Finalizers[0] == "core.platform-mesh.io/fga-store"
+				})).Return(nil)
 			},
+		},
+		{
+			name: "should fail to finalize when deregistering from the store errors",
+			store: &pmcorev1alpha1.AuthorizationModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						pmcorev1alpha1.StoreRefLabelKey: "store",
+					},
+				},
+				Spec: pmcorev1alpha1.AuthorizationModelSpec{
+					StoreRef: pmcorev1alpha1.WorkspaceStoreRef{
+						Name:    "store",
+						Cluster: "store-cluster",
+					},
+				},
+				Status: pmcorev1alpha1.AuthorizationModelStatus{
+					ManagedTuples: []pmcorev1alpha1.Tuple{
+						{
+							Object:   "foo",
+							Relation: "bar",
+							User:     "user4",
+						},
+					},
+				},
+			},
+			fgaMocks: func(fga *mocks.MockOpenFGAServiceClient) {
+				fga.EXPECT().Write(mock.Anything, mock.Anything).Return(nil, nil)
+			},
+			mgrMocks: func(mgr *mocks.MockManager) {
+				storeCluster := mocks.NewMockCluster(t)
+				storeClient := mocks.NewMockClient(t)
+				mgr.EXPECT().GetCluster(mock.Anything, multicluster.ClusterName("store-cluster")).Return(storeCluster, nil)
+				storeCluster.EXPECT().GetClient().Return(storeClient)
+				storeClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					store := o.(*pmcorev1alpha1.Store)
+					*store = pmcorev1alpha1.Store{
+						ObjectMeta: metav1.ObjectMeta{
+							Finalizers: []string{"authzmodel.core.platform-mesh.io/8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0"},
+						},
+						Status: pmcorev1alpha1.StoreStatus{
+							StoreID:              "store-id",
+							AuthorizationModelID: "auth-model-id",
+						},
+					}
+					return nil
+				}).Twice()
+				storeClient.EXPECT().Update(mock.Anything, mock.Anything).Return(assert.AnError)
+			},
+			expectError: true,
 		},
 		{
 			name: "should finalize successfully when the referenced Store is already gone",
@@ -450,6 +507,7 @@ func TestTupleFinalizationWithAuthorizationModel(t *testing.T) {
 			},
 		},
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fga := mocks.NewMockOpenFGAServiceClient(t)

--- a/operators/security-operator/internal/test/integration/authorization_model_generation_test.go
+++ b/operators/security-operator/internal/test/integration/authorization_model_generation_test.go
@@ -55,13 +55,16 @@ func (suite *IntegrationSuite) TestAuthorizationModelGeneration_Process() {
 		testAccount = "test-account"
 	)
 
-	_, testOrgPath := envtest.NewWorkspaceFixture(suite.T(), cli, orgsPath, envtest.WithName(testOrgName), envtest.WithType(core.RootCluster.Path(), "org"))
+	testOrgWorkspace, testOrgPath := envtest.NewWorkspaceFixture(suite.T(), cli, orgsPath, envtest.WithName(testOrgName), envtest.WithType(core.RootCluster.Path(), "org"))
+
+	// the Store must exist in the org's own workspace before a bind can happen
+	suite.createTestStore(ctx, cli.Cluster(testOrgPath), testOrgName, suite.T())
 
 	_, testAccountPath := envtest.NewWorkspaceFixture(suite.T(), cli, testOrgPath, envtest.WithName(testAccount), envtest.WithType(core.RootCluster.Path(), "account"))
 
 	testAccountClient := cli.Cluster(testAccountPath)
 
-	suite.createAccountInfo(ctx, testAccountClient, testAccount, testOrgName, testAccountPath, testOrgPath, suite.T())
+	suite.createAccountInfo(ctx, testAccountClient, testAccount, testOrgName, testOrgWorkspace.Spec.Cluster, testAccountPath, testOrgPath, suite.T())
 
 	_ = suite.createTestAPIBinding(ctx, testAccountClient, apiExportName, suite.platformMeshSysPath.String(), apiExportName)
 
@@ -73,7 +76,7 @@ func (suite *IntegrationSuite) TestAuthorizationModelGeneration_Process() {
 	}, 10*time.Second, 200*time.Millisecond, "authorizationModel should be created by controller")
 
 	suite.Assert().Equal(testOrgName, model.Spec.StoreRef.Name)
-	suite.Assert().Equal(testOrgPath.String(), model.Spec.StoreRef.Cluster)
+	suite.Assert().Equal(testOrgWorkspace.Spec.Cluster, model.Spec.StoreRef.Cluster)
 }
 
 func (suite *IntegrationSuite) TestAuthorizationModelGeneration_Finalize() {
@@ -96,8 +99,11 @@ func (suite *IntegrationSuite) TestAuthorizationModelGeneration_Finalize() {
 		testOrgName      = "generator-test-finalize"
 	)
 
-	_, testOrgPath := envtest.NewWorkspaceFixture(suite.T(), cli, orgsPath, envtest.WithName(testOrgName), envtest.WithType(core.RootCluster.Path(), "org"))
+	testOrgWorkspace, testOrgPath := envtest.NewWorkspaceFixture(suite.T(), cli, orgsPath, envtest.WithName(testOrgName), envtest.WithType(core.RootCluster.Path(), "org"))
 	testClient := cli.Cluster(testOrgPath)
+
+	// the Store must exist in the org's own workspace before a bind can happen
+	suite.createTestStore(ctx, testClient, testOrgName, suite.T())
 
 	suite.createAccount(ctx, testClient, testAccount1Name, pmcorev1alpha1.AccountTypeAccount, suite.T())
 	suite.createAccount(ctx, testClient, testAccount2Name, pmcorev1alpha1.AccountTypeAccount, suite.T())
@@ -108,8 +114,8 @@ func (suite *IntegrationSuite) TestAuthorizationModelGeneration_Finalize() {
 	testAccount1Client := cli.Cluster(testAccount1Path)
 	testAccount2Client := cli.Cluster(testAccount2Path)
 
-	suite.createAccountInfo(ctx, testAccount1Client, testAccount1Name, testOrgName, testAccount1Path, testOrgPath, suite.T())
-	suite.createAccountInfo(ctx, testAccount2Client, testAccount2Name, testOrgName, testAccount2Path, testOrgPath, suite.T())
+	suite.createAccountInfo(ctx, testAccount1Client, testAccount1Name, testOrgName, testOrgWorkspace.Spec.Cluster, testAccount1Path, testOrgPath, suite.T())
+	suite.createAccountInfo(ctx, testAccount2Client, testAccount2Name, testOrgName, testOrgWorkspace.Spec.Cluster, testAccount2Path, testOrgPath, suite.T())
 
 	apiBinding1 := suite.createTestAPIBinding(ctx, testAccount1Client, apiExportName, suite.platformMeshSysPath.String(), apiExportName)
 	apiBinding2 := suite.createTestAPIBinding(ctx, testAccount2Client, apiExportName, suite.platformMeshSysPath.String(), apiExportName)

--- a/operators/security-operator/internal/test/integration/suite_test.go
+++ b/operators/security-operator/internal/test/integration/suite_test.go
@@ -354,7 +354,25 @@ func (suite *IntegrationSuite) createAccount(ctx context.Context, client ctrlrun
 	t.Logf("created account '%s' (type: %s)", accountName, accountType)
 }
 
-func (suite *IntegrationSuite) createAccountInfo(ctx context.Context, accountClient ctrlruntimeclient.Client, accountName, orgName string, accountPath, orgPath logicalcluster.Path, t *testing.T) {
+// createTestStore creates a minimal Store, which must exist before an
+// AuthorizationModel can bind to it.
+func (suite *IntegrationSuite) createTestStore(ctx context.Context, storeClusterClient ctrlruntimeclient.Client, storeName string, t *testing.T) {
+	store := &pmcorev1alpha1.Store{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storeName,
+		},
+	}
+	err := storeClusterClient.Create(ctx, store)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		suite.Require().NoError(err)
+	}
+	t.Logf("created store '%s'", storeName)
+}
+
+// orgClusterID is the raw logical cluster ID the org workspace is stored
+// under (not its path) - must match wherever createTestStore created the
+// Store.
+func (suite *IntegrationSuite) createAccountInfo(ctx context.Context, accountClient ctrlruntimeclient.Client, accountName, orgName, orgClusterID string, accountPath, orgPath logicalcluster.Path, t *testing.T) {
 	accountInfo := &pmcorev1alpha1.AccountInfo{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "account",
@@ -363,7 +381,7 @@ func (suite *IntegrationSuite) createAccountInfo(ctx context.Context, accountCli
 			Organization: pmcorev1alpha1.AccountLocation{
 				Name:               orgName,
 				GeneratedClusterId: orgPath.String(),
-				OriginClusterId:    orgPath.String(),
+				OriginClusterId:    orgClusterID,
 				Path:               orgPath.String(),
 				Type:               pmcorev1alpha1.AccountTypeOrg,
 			},


### PR DESCRIPTION
## Summary
Follow up on the [previous fix](https://github.com/platform-mesh/platform-mesh/pull/272) - that one just made the stuck deletion recoverable, but MJ was right that it didn't fix the actual race.

Problem: Store checks if anything still uses it before deleting itself, but that check can be outdated by the time it actually deletes. So it can delete while something new just started depending on it.

Fix: before an AuthorizationModel gets created, it now has to register itself on the Store first, using a finalizer. Kubernetes won't let you add a finalizer to something that's already being deleted, it just rejects it. So now if the Store is going away, the bind fails right there instead of racing it. Store's own check is now just reading its own finalizers, no more querying across workspaces.

## Fixes
[#2421](https://github.com/platform-mesh/helm-charts/issues/2421)

## Test plan
- [x] new unit tests for the register/deregister part
- [x] updated existing tests where the call sequence actually changed, didn't weaken any of them
- [x] ran the real e2e suite (actual kcp, no mocks) - this caught 2 real bugs during dev, both fixed
- [x] checked directly against a live API server that the finalizer rejection actually happens
- [x] reproduced the race condition pre-fix , 0 orphans after the fix across repeated attempts, on a clean cluster rebuilt from scratch