### PR TITLE
Percent-encode colons in resource names

### DIFF
--- a/services/rebac-authz-webhook/pkg/handler/contextual/builder.go
+++ b/services/rebac-authz-webhook/pkg/handler/contextual/builder.go
@@ -77,7 +77,7 @@ func BuildCheckInput(
 
 	group, objectType := BuildObjectType(gvr, singular)
 
-	object := fmt.Sprintf("%s:%s/%s", objectType, clusterName, attrs.Name)
+	object := renderObject(objectType, clusterName, attrs.Name)
 	relation := attrs.Verb
 
 	hasParent := util.ResolveOnParent(attrs.Verb)
@@ -105,14 +105,14 @@ func BuildCheckInput(
 		} else {
 			// parent the object to the namespace
 			contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
-				Object:   fmt.Sprintf("%s:%s/%s", objectType, clusterName, attrs.Name),
+				Object:   renderObject(objectType, clusterName, attrs.Name),
 				Relation: "parent",
 				User:     namespaceObject,
 			})
 		}
 	} else {
 		contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
-			Object:   fmt.Sprintf("%s:%s/%s", objectType, clusterName, attrs.Name),
+			Object:   renderObject(objectType, clusterName, attrs.Name),
 			Relation: "parent",
 			User:     accountObject,
 		})
@@ -127,6 +127,14 @@ func BuildCheckInput(
 	}
 
 	return checkInput, nil
+}
+
+// renderObject builds the FGA object key for a resource. The resource name is
+// encoded because OpenFGA requires an object to contain exactly one colon, and
+// Kubernetes names validated as path segments (ClusterRoles, Roles, and their
+// bindings) may legitimately contain colons themselves.
+func renderObject(objectType, clusterName, name string) string {
+	return fmt.Sprintf("%s:%s/%s", objectType, clusterName, util.EncodeName(name))
 }
 
 // BuildObjectType builds the FGA object type string from GVR and singular resource name.

--- a/services/rebac-authz-webhook/pkg/handler/contextual/builder_test.go
+++ b/services/rebac-authz-webhook/pkg/handler/contextual/builder_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contextual_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.platform-mesh.io/rebac-authz-webhook/pkg/clustercache"
+	"go.platform-mesh.io/rebac-authz-webhook/pkg/handler/contextual"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// rbacMapper returns a RESTMapper for a resource in rbac.authorization.k8s.io.
+// RBAC names are validated as path segments rather than DNS subdomains, so
+// they may legitimately contain colons -- ClusterRole "system:controller:foo"
+// and Role "system::leader-locking-kube-controller-manager" are both real.
+func rbacMapper(kind, plural, singular string, scope meta.RESTScope) meta.RESTMapper {
+	rm := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	gv := schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"}
+	rm.AddSpecific(
+		gv.WithKind(kind),
+		gv.WithResource(plural),
+		gv.WithResource(singular),
+		scope,
+	)
+	return rm
+}
+
+// clusterRoleMapper knows about ClusterRole, which is cluster scoped.
+func clusterRoleMapper() meta.RESTMapper {
+	return rbacMapper("ClusterRole", "clusterroles", "clusterrole", meta.RESTScopeRoot)
+}
+
+// roleMapper knows about Role, which is namespaced.
+func roleMapper() meta.RESTMapper {
+	return rbacMapper("Role", "roles", "role", meta.RESTScopeNamespace)
+}
+
+func testClusterInfo(rm meta.RESTMapper) clustercache.ClusterInfo {
+	return clustercache.ClusterInfo{
+		StoreID:         "store-id",
+		RESTMapper:      rm,
+		AccountName:     "origin-account",
+		ParentClusterID: "origin",
+	}
+}
+
+// assertSingleColon encodes OpenFGA's rule for object keys: an object must
+// contain exactly one colon, the separator between type and identifier.
+// A resource name that leaks a raw colon into the key makes OpenFGA reject
+// the whole Check request.
+func assertSingleColon(t *testing.T, object string) {
+	t.Helper()
+	assert.Equalf(t, 1, strings.Count(object, ":"),
+		"object %q must contain exactly one colon to be accepted by OpenFGA", object)
+}
+
+func TestBuildCheckInput_ColonInResourceName(t *testing.T) {
+	t.Run("cluster scoped object encodes the colon", func(t *testing.T) {
+		attrs := &authorizationv1.ResourceAttributes{
+			Group:    "rbac.authorization.k8s.io",
+			Version:  "v1",
+			Resource: "clusterroles",
+			Verb:     "get",
+			Name:     "system:controller:foo",
+		}
+
+		in, err := contextual.BuildCheckInput(attrs, "alice", "cluster-a", testClusterInfo(clusterRoleMapper()))
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"rbac_authorization_k8s_io_clusterrole:cluster-a/system%3Acontroller%3Afoo",
+			in.Object)
+		assertSingleColon(t, in.Object)
+
+		require.Len(t, in.ContextualTuples, 1)
+		assert.Equal(t,
+			"rbac_authorization_k8s_io_clusterrole:cluster-a/system%3Acontroller%3Afoo",
+			in.ContextualTuples[0].Object)
+		assertSingleColon(t, in.ContextualTuples[0].Object)
+		assert.Equal(t, "core_platform-mesh_io_account:origin/origin-account", in.ContextualTuples[0].User)
+	})
+
+	t.Run("namespaced object encodes the colon in its parent tuple", func(t *testing.T) {
+		attrs := &authorizationv1.ResourceAttributes{
+			Group:     "rbac.authorization.k8s.io",
+			Version:   "v1",
+			Resource:  "roles",
+			Verb:      "get",
+			Name:      "system::leader-locking-kube-controller-manager",
+			Namespace: "kube-system",
+		}
+
+		in, err := contextual.BuildCheckInput(attrs, "alice", "cluster-a", testClusterInfo(roleMapper()))
+		require.NoError(t, err)
+
+		const wantObject = "rbac_authorization_k8s_io_role:cluster-a/system%3A%3Aleader-locking-kube-controller-manager"
+
+		assert.Equal(t, wantObject, in.Object)
+		assertSingleColon(t, in.Object)
+
+		// The namespace is parented to the account, and the role to the
+		// namespace. Only the second tuple carries the resource name.
+		require.Len(t, in.ContextualTuples, 2)
+
+		assert.Equal(t, "core_namespace:cluster-a/kube-system", in.ContextualTuples[0].Object)
+		assert.Equal(t, "core_platform-mesh_io_account:origin/origin-account", in.ContextualTuples[0].User)
+
+		assert.Equal(t, wantObject, in.ContextualTuples[1].Object)
+		assert.Equal(t, "core_namespace:cluster-a/kube-system", in.ContextualTuples[1].User)
+		assertSingleColon(t, in.ContextualTuples[1].Object)
+	})
+
+	t.Run("colon free name is unchanged", func(t *testing.T) {
+		attrs := &authorizationv1.ResourceAttributes{
+			Group:    "rbac.authorization.k8s.io",
+			Version:  "v1",
+			Resource: "clusterroles",
+			Verb:     "get",
+			Name:     "cluster-admin",
+		}
+
+		in, err := contextual.BuildCheckInput(attrs, "alice", "cluster-a", testClusterInfo(clusterRoleMapper()))
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"rbac_authorization_k8s_io_clusterrole:cluster-a/cluster-admin",
+			in.Object)
+	})
+}

--- a/services/rebac-authz-webhook/pkg/handler/contextual/contextual.go
+++ b/services/rebac-authz-webhook/pkg/handler/contextual/contextual.go
@@ -202,7 +202,7 @@ func (c *contextualAuthorizer) handleKCPBindCheck(ctx context.Context, req autho
 
 	_, resourceObjectType := BuildObjectType(gvr, singular)
 
-	resourceToBind := fmt.Sprintf("%s:%s/%s", resourceObjectType, providerClusterName, attrs.Name)
+	resourceToBind := renderObject(resourceObjectType, providerClusterName, attrs.Name)
 	consumerAccountObject := fmt.Sprintf("core_platform-mesh_io_account:%s/%s",
 		consumerInfo.ParentClusterID,
 		consumerInfo.AccountName)

--- a/services/rebac-authz-webhook/pkg/handler/contextual/contextual_test.go
+++ b/services/rebac-authz-webhook/pkg/handler/contextual/contextual_test.go
@@ -615,6 +615,61 @@ func TestHandler(t *testing.T) {
 				)
 			},
 		},
+		{
+			name: "should encode a colon in the bound resource name",
+			req: authorization.Request{
+				SubjectAccessReview: authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User: "system:anonymous",
+						Groups: []string{
+							"system:authenticated",
+							"system:cluster:consumer-cluster-id",
+						},
+						Extra: map[string]authorizationv1.ExtraValue{
+							"authorization.kubernetes.io/cluster-name": {"provider-cluster-id"},
+						},
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:    "apis.kcp.io",
+							Version:  "v1alpha1",
+							Resource: "apiexports",
+							Verb:     "bind",
+							Name:     "system:export:foo",
+						},
+					},
+				},
+			},
+			res: authorization.Allowed(),
+			clusterCacheMocks: func(cc *mocks.ClusterCacheProvider) {
+				consumerRM := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+				consumerGV := schema.GroupVersion{
+					Group:   "apis.kcp.io",
+					Version: "v1alpha1",
+				}
+				consumerRM.AddSpecific(
+					consumerGV.WithKind("APIExport"),
+					consumerGV.WithResource("apiexports"),
+					consumerGV.WithResource("apiexport"),
+					meta.RESTScopeRoot,
+				)
+
+				cc.EXPECT().Get(multicluster.ClusterName("consumer-cluster-id")).Return(clustercache.ClusterInfo{
+					StoreID:         "consumer-store-id",
+					RESTMapper:      consumerRM,
+					AccountName:     "consumer-account",
+					ParentClusterID: "consumer-parent",
+				}, true)
+			},
+			fgaMocks: func(openfga *mocks.OpenFGAServiceClient) {
+				openfga.EXPECT().Check(mock.Anything, mock.Anything).RunAndReturn(
+					func(ctx context.Context, in *openfgav1.CheckRequest, opts ...grpc.CallOption) (*openfgav1.CheckResponse, error) {
+						assert.Equal(t, "apis_kcp_io_apiexport:provider-cluster-id/system%3Aexport%3Afoo", in.TupleKey.User)
+						return &openfgav1.CheckResponse{
+							Allowed: true,
+						}, nil
+					},
+				)
+			},
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {

--- a/services/rebac-authz-webhook/pkg/util/name.go
+++ b/services/rebac-authz-webhook/pkg/util/name.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "strings"
+
+// nameEncoder is a strings.Replacer that percent-encodes the characters that
+// OpenFGA forbids in the identifier portion of an object key.
+var nameEncoder = strings.NewReplacer(
+	"%", "%25",
+	":", "%3A",
+)
+
+// EncodeName percent-encodes the characters that OpenFGA forbids in the
+// identifier portion of an object key.
+//
+// OpenFGA requires an object to contain exactly one colon, the separator
+// between type and identifier, so a Kubernetes resource name that itself
+// contains a colon (e.g. the ClusterRole "system:controller:foo") produces an
+// object that the server rejects outright.
+//
+// Percent-encoding is used rather than a plain substitution because it is
+// injective: "system:controller:foo" and "system.controller.foo" are distinct,
+// both-legal resource names and must not map onto the same key. '%' is encoded
+// as well so the transformation stays injective for callers outside Kubernetes;
+// a Kubernetes name can never contain '%' itself.
+//
+// Names that contain neither character are returned unchanged, so keys that
+// OpenFGA already accepts today keep their current form.
+func EncodeName(name string) string {
+	return nameEncoder.Replace(name)
+}

--- a/services/rebac-authz-webhook/pkg/util/name_fuzz_test.go
+++ b/services/rebac-authz-webhook/pkg/util/name_fuzz_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// FuzzEncodeNameIsInjective asserts that distinct names never encode to the
+// same key. A lossy substitution such as replacing ':' with '.' would collapse
+// "system:controller:foo" and "system.controller.foo" onto one object, letting
+// a grant on one resource authorize access to the other.
+func FuzzEncodeNameIsInjective(f *testing.F) {
+	f.Add("system:controller:foo", "system.controller.foo")
+	f.Add("a%b:c", "a%25b%3Ac")
+	f.Add("", ":")
+	f.Add("cluster-admin", "cluster-admin")
+	f.Add("a:b", "a:b:c")
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		encA, encB := EncodeName(a), EncodeName(b)
+
+		if a != b {
+			assert.NotEqualf(t, encA, encB, "distinct names %q and %q collided", a, b)
+		}
+
+		// The encoded form must never carry a raw colon, which OpenFGA
+		// reserves as the separator between object type and identifier.
+		assert.NotContainsf(t, encA, ":", "EncodeName(%q) = %q still contains a raw colon", a, encA)
+	})
+}

--- a/services/rebac-authz-webhook/pkg/util/name_test.go
+++ b/services/rebac-authz-webhook/pkg/util/name_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeName(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "encodes a colon",
+			in:   "system:controller:foo",
+			want: "system%3Acontroller%3Afoo",
+		},
+		{
+			name: "leaves a plain name untouched",
+			in:   "test-sample",
+			want: "test-sample",
+		},
+		{
+			name: "leaves a dotted name untouched",
+			in:   "my-app.example.com",
+			want: "my-app.example.com",
+		},
+		{
+			name: "leaves an empty name untouched",
+			in:   "",
+			want: "",
+		},
+		{
+			// Kubernetes names cannot contain '%', but encoding it keeps the
+			// transformation injective for any non-k8s caller.
+			name: "escapes a literal percent before encoding colons",
+			in:   "a%b:c",
+			want: "a%25b%3Ac",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, EncodeName(test.in))
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes #293.

OpenFGA requires an object key to contain exactly one colon (separator).
Decided to go with percent-encoding instead of using the same ":" -> "." substitution currently in-place for users because this could collide and handle authorization requests for different resources incorrectly, e.g. "system:controller:foo" and "system.controller.foo" are both valid ClusterRoles.

I have only improved rebac-authz-webhook on this because there are no tuples so far that contain a colon in the resource name (OpenFGA would reject it). Colon-free resource names are ensured to encode to themselves. So there is no need to change existing object keys or tuples.

The user substitution could (or should) be handled the same but this will introduce a breaking change that will need some rekeying mechanism and also I tend to keep PRs small, focused and reviewable.