### PR TITLE
Skip DCO checks on PRs with "[REBASE] " prefix in the PR title

### DIFF
--- a/.github/workflows/verify-all.yml
+++ b/.github/workflows/verify-all.yml
@@ -74,6 +74,7 @@ jobs:
       # The DCO app gates pull requests but not the merge queue, and running it
       # here means `task verify` locally catches the same thing before pushing.
       - run: task dco BASE=${BASE}
+        if: ${{ !startsWith(github.event.pull_request.title, '[REBASE] ') }}
       - run: task lint
       - run: task tidy-check
       # Missing headers are fixed locally with `task boilerplate-fix`.


### PR DESCRIPTION
These PRs are expected to contain commits from different authors, and DCO won't be able to find matches with commit author.