### PR TITLE
fix(search-service): return 401 for invalid JWTs

### DIFF
--- a/services/search-service/README.md
+++ b/services/search-service/README.md
@@ -119,11 +119,11 @@ Use `--is-local=true` for local development to match the local behavior of `kube
 
 When enabled:
 
-- org context is still derived from host (`localhost` is mapped to `--local-development-org`)
-- JWT claims are still parsed for user/tenant context
-- kcp org token validation (`ValidateTokenForOrg`) is bypassed
+- org context is set to `--local-development-org`
+- JWT claims are parsed for user/tenant context
+- kcp JWT validation is bypassed
 
-This is intended for local/dev usage only. Keep `--is-local=false` for production-like environments.
+This is intended for local/dev usage only. Tokens are not signature- or claims-validated in this mode. Keep `--is-local=false` for production-like environments.
 
 ### Configuration flags
 
@@ -148,8 +148,8 @@ Main runtime flags (with defaults):
 - `--search-max-limit` (default: `100`)
 - `--search-fetch-batch-size` (default: `100`)
 - `--search-max-scanned-hits` (default: `1000`)
-- `--is-local` (default: `false`) enables local development behavior in auth middleware
-- `--local-development-org` (default: env `SEARCH_LOCAL_ORG`, fallback `local`) org used when host is `localhost`
+- `--is-local` (default: `false`) uses the configured local organization and bypasses kcp JWT validation
+- `--local-development-org` (default: env `SEARCH_LOCAL_ORG`, fallback `local`) org used when `--is-local=true`
 
 Global flags from `golang-commons` are also available (e.g. logging and kubeconfig related flags).
 
@@ -161,8 +161,10 @@ go test ./...
 
 ## Security Notes
 
-- JWT signature validation is expected to happen upstream (gateway/mesh).
-- The service consumes parsed claims from context (`mail`, fallback `sub`).
+- With `--is-local=false`, every search API request requires a valid bearer JWT. Missing, malformed, expired, or otherwise invalid tokens return `401 Unauthorized`.
+- JWT signature and standard claims validation is delegated to the target organization's kcp authentication configuration. A kcp `403 Forbidden` response still proves that authentication succeeded; result authorization remains enforced by OpenFGA.
+- After validation, the service consumes parsed claims from context (`mail`, fallback `sub`).
+- With `--is-local=true`, the service only parses JWT claims and intentionally skips kcp validation. Never enable this mode in production.
 - Search hits missing required authorization hierarchy fields are dropped (fail-closed).
 
 ## Releasing

--- a/services/search-service/internal/clients/kcp/access_validator.go
+++ b/services/search-service/internal/clients/kcp/access_validator.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// maxSnippetBytes defines how much of an unexpected response body to read for logging.
-	maxSnippetBytes = 1 << 10
+	maxSnippetBytes = 1024
 )
 
 type OrgAccessValidator struct {

--- a/services/search-service/internal/clients/kcp/access_validator.go
+++ b/services/search-service/internal/clients/kcp/access_validator.go
@@ -29,6 +29,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	// maxSnippetBytes defines how much of an unexpected response body to read for logging.
+	maxSnippetBytes = 1 << 10
+)
+
 type OrgAccessValidator struct {
 	http    *http.Client
 	baseURL *url.URL
@@ -56,6 +61,12 @@ func NewOrgAccessValidator(restCfg *rest.Config, log *logger.Logger) (*OrgAccess
 	return &OrgAccessValidator{http: httpClient, baseURL: baseURL, log: log}, nil
 }
 
+// ValidateTokenForOrg returns true when kcp authenticated the JWT for the organization.
+// A forbidden response is valid here because it proves authentication succeeded; OpenFGA
+// remains responsible for authorizing individual search results.
+//
+// Only a kcp 401 means the JWT is invalid. Any other unexpected status is reported
+// as an error.
 func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader, org string) (bool, error) {
 	clusterPath := fmt.Sprintf("root:orgs:%s", org)
 	requestURL := fmt.Sprintf("%s://%s/clusters/%s/version", v.baseURL.Scheme, v.baseURL.Host, clusterPath)
@@ -75,7 +86,10 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 			Msg("kcp org token validation request failed")
 		return false, fmt.Errorf("execute kcp auth request: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusForbidden:
@@ -85,10 +99,10 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 			Str("organization", org).
 			Str("clusterPath", clusterPath).
 			Int("statusCode", resp.StatusCode).
-			Msg("kcp org token validation denied request")
+			Msg("kcp rejected the JWT")
 		return false, nil
 	default:
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxSnippetBytes))
 		bodySnippet := strings.TrimSpace(string(bodyBytes))
 		logEvt := v.log.Warn().
 			Str("organization", org).
@@ -99,9 +113,6 @@ func (v *OrgAccessValidator) ValidateTokenForOrg(ctx context.Context, authHeader
 		}
 		logEvt.Msg("kcp org token validation returned unexpected status")
 
-		if strings.HasPrefix(fmt.Sprintf("%d", resp.StatusCode), "5") {
-			return false, fmt.Errorf("kcp auth check failed with status %d", resp.StatusCode)
-		}
-		return false, nil
+		return false, fmt.Errorf("kcp auth check returned unexpected status %d", resp.StatusCode)
 	}
 }

--- a/services/search-service/internal/clients/kcp/access_validator_test.go
+++ b/services/search-service/internal/clients/kcp/access_validator_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.platform-mesh.io/golang-commons/logger/testlogger"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestOrgAccessValidatorValidateTokenForOrg(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		valid      bool
+		wantErr    bool
+	}{
+		{name: "authenticated", statusCode: http.StatusOK, valid: true},
+		{name: "authenticated with created response", statusCode: http.StatusCreated, valid: true},
+		{name: "authenticated but forbidden", statusCode: http.StatusForbidden, valid: true},
+		{name: "invalid JWT", statusCode: http.StatusUnauthorized, valid: false},
+		{name: "unexpected client response", statusCode: http.StatusBadRequest, wantErr: true},
+		{name: "unknown organization", statusCode: http.StatusNotFound, wantErr: true},
+		{name: "throttled by kcp", statusCode: http.StatusTooManyRequests, wantErr: true},
+		{name: "server failure", statusCode: http.StatusInternalServerError, wantErr: true},
+		{name: "kcp unavailable", statusCode: http.StatusServiceUnavailable, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/clusters/root:orgs:acme/version" {
+					t.Errorf("unexpected request path: %s", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer token" {
+					t.Errorf("unexpected authorization header: %q", got)
+				}
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(`{"gitVersion":"v1.30.0"}`))
+			}))
+			defer server.Close()
+
+			log := testlogger.New().HideLogOutput().Logger
+			validator, err := NewOrgAccessValidator(&rest.Config{Host: server.URL}, log)
+			if err != nil {
+				t.Fatalf("create validator: %v", err)
+			}
+
+			valid, err := validator.ValidateTokenForOrg(t.Context(), "Bearer token", "acme")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validate token: %v", err)
+			}
+
+			if valid != tc.valid {
+				t.Fatalf("expected valid=%t, got %t", tc.valid, valid)
+			}
+		})
+	}
+}
+
+// Validation runs on every API request, so the response body must be drained to keep the
+// connection poolable instead of forcing a fresh TLS handshake per request.
+func TestOrgAccessValidatorReusesConnections(t *testing.T) {
+	for _, statusCode := range []int{http.StatusOK, http.StatusUnauthorized, http.StatusBadRequest} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			conns := map[string]struct{}{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conns[r.RemoteAddr] = struct{}{}
+				w.WriteHeader(statusCode)
+				_, _ = w.Write([]byte(`{"gitVersion":"v1.30.0"}`))
+			}))
+			defer server.Close()
+
+			log := testlogger.New().HideLogOutput().Logger
+			validator, err := NewOrgAccessValidator(&rest.Config{Host: server.URL}, log)
+			if err != nil {
+				t.Fatalf("create validator: %v", err)
+			}
+
+			for range 3 {
+				_, _ = validator.ValidateTokenForOrg(t.Context(), "Bearer token", "acme")
+			}
+
+			if len(conns) != 1 {
+				t.Fatalf("expected all requests on one connection, got %d", len(conns))
+			}
+		})
+	}
+}

--- a/services/search-service/internal/middleware/orgauth.go
+++ b/services/search-service/internal/middleware/orgauth.go
@@ -29,7 +29,7 @@ import (
 	"go.platform-mesh.io/search-service/internal/service/search"
 )
 
-var issuerRegex = regexp.MustCompile(`^.*\/realms\/(.*?)\/?$`)
+var issuerRegex = regexp.MustCompile(`^.*/realms/(.*?)/?$`)
 
 const defaultLocalDevelopmentOrg = "local"
 
@@ -62,8 +62,8 @@ func (o *OrgContextMiddleware) SetRequestContext() func(http.Handler) http.Handl
 				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 				return
 			}
-			localHost := isLocalHost(r.Host)
-			if o.localDevelopment || localHost {
+
+			if o.localDevelopment {
 				org = o.localOrg
 			}
 
@@ -73,7 +73,7 @@ func (o *OrgContextMiddleware) SetRequestContext() func(http.Handler) http.Handl
 				return
 			}
 
-			if !o.localDevelopment && !localHost {
+			if !o.localDevelopment {
 				authHeader, err := pmcontext.GetAuthHeaderFromContext(ctx)
 				if err != nil {
 					http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
@@ -85,17 +85,17 @@ func (o *OrgContextMiddleware) SetRequestContext() func(http.Handler) http.Handl
 					return
 				}
 
-				allowed, err := o.validator.ValidateTokenForOrg(ctx, authHeader, org)
+				valid, err := o.validator.ValidateTokenForOrg(ctx, authHeader, org)
 				if err != nil {
 					log.Error().
 						Err(err).
 						Str("organization", org).
-						Msg("failed to validate token for org access")
+						Msg("failed to validate JWT")
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				}
-				if !allowed {
-					http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				if !valid {
+					http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 					return
 				}
 			}
@@ -138,19 +138,6 @@ func extractSubdomain(host string) string {
 		return ""
 	}
 	return strings.TrimSpace(parts[0])
-}
-
-func isLocalHost(host string) bool {
-	if host == "" {
-		return false
-	}
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	} else {
-		host = strings.Split(host, ":")[0]
-	}
-	host = strings.TrimSpace(strings.ToLower(host))
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 func normalizeBearerAuthHeader(header string) (string, error) {

--- a/services/search-service/internal/middleware/orgauth_test.go
+++ b/services/search-service/internal/middleware/orgauth_test.go
@@ -26,24 +26,27 @@ import (
 	pmcontext "go.platform-mesh.io/golang-commons/context"
 	"go.platform-mesh.io/golang-commons/context/keys"
 	"go.platform-mesh.io/golang-commons/jwt"
+	pmmw "go.platform-mesh.io/golang-commons/middleware"
 	appcontext "go.platform-mesh.io/search-service/internal/context"
 )
 
 type fakeOrgValidator struct {
-	allowed bool
-	err     error
-	org     string
-	auth    string
+	valid bool
+	err   error
+	org   string
+	auth  string
+	calls int
 }
 
 func (f *fakeOrgValidator) ValidateTokenForOrg(_ context.Context, authHeader, org string) (bool, error) {
+	f.calls++
 	f.org = org
 	f.auth = authHeader
-	return f.allowed, f.err
+	return f.valid, f.err
 }
 
 func TestSetRequestContextSuccessUsesMailFallbackToSub(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: true}
+	validator := &fakeOrgValidator{valid: true}
 	mw := NewOrgContextMiddleware(validator, false, "local")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -90,8 +93,8 @@ func TestSetRequestContextSuccessUsesMailFallbackToSub(t *testing.T) {
 	}
 }
 
-func TestSetRequestContextForbiddenWhenOrgCheckFails(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: false}
+func TestSetRequestContextReturns401WhenJWTValidationFails(t *testing.T) {
+	validator := &fakeOrgValidator{valid: false}
 	mw := NewOrgContextMiddleware(validator, false, "local")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -110,8 +113,11 @@ func TestSetRequestContextForbiddenWhenOrgCheckFails(t *testing.T) {
 		t.Fatalf("next handler must not be called")
 	})).ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	if validator.calls != 1 {
+		t.Fatalf("expected validator to be called once, got %d", validator.calls)
 	}
 }
 
@@ -141,7 +147,7 @@ func TestSetRequestContextReturns500OnValidatorError(t *testing.T) {
 }
 
 func TestSetRequestContextReturns401ForInvalidTokenContext(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: true}
+	validator := &fakeOrgValidator{valid: true}
 	mw := NewOrgContextMiddleware(validator, false, "local")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -156,10 +162,49 @@ func TestSetRequestContextReturns401ForInvalidTokenContext(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rr.Code)
 	}
+	if validator.calls != 0 {
+		t.Fatalf("validator must not be called without a parsed token")
+	}
+}
+
+func TestSetRequestContextReturns401ForMissingOrUnparseableJWT(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+	}{
+		{name: "missing token"},
+		{name: "unparseable token", authHeader: "Bearer not-a-jwt"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			validator := &fakeOrgValidator{valid: true}
+			mw := NewOrgContextMiddleware(validator, false, "local")
+			handler := pmmw.StoreWebToken()(pmmw.StoreAuthHeader()(mw.SetRequestContext()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatalf("next handler must not be called")
+			}))))
+
+			req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
+			req.Host = "acme.platform-mesh.io"
+			if tc.authHeader != "" {
+				req.Header.Set(pmmw.AuthorizationHeader, tc.authHeader)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", rr.Code)
+			}
+			if validator.calls != 0 {
+				t.Fatalf("validator must not be called without a parsed token")
+			}
+		})
+	}
 }
 
 func TestSetRequestContextReturns401ForInvalidIssuer(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: true}
+	validator := &fakeOrgValidator{valid: true}
 	mw := NewOrgContextMiddleware(validator, false, "local")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -183,8 +228,8 @@ func TestSetRequestContextReturns401ForInvalidIssuer(t *testing.T) {
 	}
 }
 
-func TestSetRequestContextLocalhostOverridesOrgAndBypassesValidator(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: false}
+func TestSetRequestContextLocalhostUsesHostOrgAndValidatesJWT(t *testing.T) {
+	validator := &fakeOrgValidator{valid: true}
 	mw := NewOrgContextMiddleware(validator, false, "local-org-test")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -206,7 +251,7 @@ func TestSetRequestContextLocalhostOverridesOrgAndBypassesValidator(t *testing.T
 		if err != nil {
 			t.Fatalf("request context missing: %v", err)
 		}
-		if rc.Organization != "local-org-test" {
+		if rc.Organization != "localhost" {
 			t.Fatalf("unexpected org: %s", rc.Organization)
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -217,13 +262,13 @@ func TestSetRequestContextLocalhostOverridesOrgAndBypassesValidator(t *testing.T
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
 	}
-	if validator.org != "" || validator.auth != "" {
-		t.Fatalf("validator must not be called for localhost requests")
+	if validator.calls != 1 || validator.org != "localhost" || validator.auth != "Bearer abc" {
+		t.Fatalf("unexpected validator call: calls=%d org=%q auth=%q", validator.calls, validator.org, validator.auth)
 	}
 }
 
-func TestSetRequestContextBypassesValidatorAndUsesConfiguredOrgInLocalDevelopmentMode(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: false}
+func TestSetRequestContextBypassesJWTValidationAndUsesConfiguredOrgInLocalDevelopmentMode(t *testing.T) {
+	validator := &fakeOrgValidator{valid: false}
 	mw := NewOrgContextMiddleware(validator, true, "local-org-test")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -256,13 +301,13 @@ func TestSetRequestContextBypassesValidatorAndUsesConfiguredOrgInLocalDevelopmen
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
 	}
-	if validator.org != "" || validator.auth != "" {
+	if validator.calls != 0 {
 		t.Fatalf("validator must not be called in local development mode")
 	}
 }
 
 func TestSetRequestContextReturns401ForMalformedAuthorizationHeader(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: true}
+	validator := &fakeOrgValidator{valid: true}
 	mw := NewOrgContextMiddleware(validator, false, "local")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
@@ -291,8 +336,8 @@ func TestSetRequestContextReturns401ForMalformedAuthorizationHeader(t *testing.T
 }
 
 func TestNewOrgContextMiddlewareFallsBackToDefaultLocalOrg(t *testing.T) {
-	validator := &fakeOrgValidator{allowed: false}
-	mw := NewOrgContextMiddleware(validator, false, "")
+	validator := &fakeOrgValidator{valid: false}
+	mw := NewOrgContextMiddleware(validator, true, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/v1/search?q=test", nil)
 	req.Host = "localhost:8443"
@@ -323,5 +368,8 @@ func TestNewOrgContextMiddlewareFallsBackToDefaultLocalOrg(t *testing.T) {
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+	if validator.calls != 0 {
+		t.Fatalf("validator must not be called in local development mode")
 	}
 }


### PR DESCRIPTION
The search-service now returns `401 Unauthorized` when JWT validation fails, including expired tokens and tokens with an invalid issuer or audience.

JWT validation happens in middleware before search business logic or OpenFGA calls. Missing and structurally invalid tokens also continue to return 401.

Local development behavior is preserved: `--is-local=true` uses the configured local organization and bypasses kcp JWT validation.

Fixes https://github.com/platform-mesh/backlog/issues/256