### PR TITLE
fix: change default user-claim from email to sub [DXPFRAME-2502]

### DIFF
--- a/operators/security-operator/internal/config/config.go
+++ b/operators/security-operator/internal/config/config.go
@@ -133,7 +133,7 @@ func NewConfig() Config {
 		},
 		BaseDomain:               "portal.dev.local:8443",
 		GroupClaim:               "groups",
-		UserClaim:                "email",
+		UserClaim:                "sub",
 		WorkspacePath:            "root",
 		WorkspaceTypeName:        "security",
 		HttpClientTimeoutSeconds: 30,

--- a/operators/security-operator/internal/subroutine/workspace_authorization_test.go
+++ b/operators/security-operator/internal/subroutine/workspace_authorization_test.go
@@ -57,7 +57,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -83,7 +83,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 						assert.Equal(t, "https://test.domain/keycloak/realms/test-workspace", wac.Spec.JWT[0].Issuer.URL)
 						assert.Equal(t, kcptenancyv1alpha1.AudienceMatchPolicyMatchAny, wac.Spec.JWT[0].Issuer.AudienceMatchPolicy)
 						assert.Equal(t, "groups", wac.Spec.JWT[0].ClaimMappings.Groups.Claim)
-						assert.Equal(t, "email", wac.Spec.JWT[0].ClaimMappings.Username.Claim)
+						assert.Equal(t, "sub", wac.Spec.JWT[0].ClaimMappings.Username.Claim)
 						return nil
 					}).Once()
 
@@ -115,7 +115,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "example.com", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "example.com", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -181,7 +181,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			cfg:            config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg:            config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks:     func(m *mocks.MockClient, mgrClient *mocks.MockClient) {},
 			expectError:    true,
 			expectedResult: subroutines.OK(),
@@ -195,7 +195,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg:            config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg:            config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks:     func(m *mocks.MockClient, mgrClient *mocks.MockClient) {},
 			expectError:    true,
 			expectedResult: subroutines.OK(),
@@ -209,7 +209,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -243,7 +243,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -281,7 +281,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -313,7 +313,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -437,7 +437,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -473,7 +473,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -607,7 +607,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					Return(errors.New("accountinfo not found")).Once()
@@ -624,7 +624,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -649,7 +649,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
@@ -676,7 +676,7 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 					},
 				},
 			},
-			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "email"},
+			cfg: config.Config{BaseDomain: "test.domain", GroupClaim: "groups", UserClaim: "sub"},
 			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
 				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
 					RunAndReturn(func(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {

--- a/services/search-service/internal/config/config.go
+++ b/services/search-service/internal/config/config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const defaultUserClaim = "email"
+const defaultUserClaim = "sub"
 
 type OpenSearchConfig struct {
 	URL      string

--- a/services/search-service/internal/config/config_test.go
+++ b/services/search-service/internal/config/config_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestUserClaimConfiguration(t *testing.T) {
 	cfg := NewServiceConfig()
-	if cfg.UserClaim != "email" {
-		t.Fatalf("expected default user claim email, got %q", cfg.UserClaim)
+	if cfg.UserClaim != "sub" {
+		t.Fatalf("expected default user claim sub, got %q", cfg.UserClaim)
 	}
 
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)


### PR DESCRIPTION
## Summary
- Change the default `UserClaim` from `"email"` to `"sub"` in the security-operator config
- Change the default `userClaim` from `"email"` to `"sub"` in the search-service config
- Update all related test assertions to match the new default

This aligns FGA tuple keys with the JWT `sub` claim already used by golang-dxp `@auth` checks and Hyperspace, ensuring consistent user identification across the platform.

## Test plan
- [x] Security-operator unit tests pass (`go test ./internal/config/ ./internal/subroutine/`)
- [x] Search-service unit tests pass (`go test ./internal/config/ ./internal/middleware/`)
- [ ] Verify in dev environment that FGA tuples are written with UserID (sub) instead of email

## Links
- [DXPFRAME-2502: Backend: Security Operator E-Mail to UserID Switch & golang-dxp @auth Adjustment](https://sap.atlassian.net/browse/DXPFRAME-2502)