### PR TITLE
feat(iam): add selectable user counts by role

### DIFF
--- a/services/iam-service/graph/schema.graphql
+++ b/services/iam-service/graph/schema.graphql
@@ -51,13 +51,21 @@ type UserRoles {
     roles: [Role!]!
 }
 
+""" Total number of users assigned to a role """
+type RoleCount {
+    roleId: String!
+    count: Int!
+}
+
 """ Is a list of the users and their roles """
 type UserConnection {
     users: [UserRoles!]!
     """ number of granted users in the list """
     pageInfo: PageInfo!
     """ number of users in the result set that have the owner role """
-    ownersCount: Int!
+    ownersCount: Int! @deprecated(reason: "Use roleCounts instead")
+    """ total user counts for the roles requested through countRoleFilters """
+    roleCounts: [RoleCount!]!
 }
 
 """ Result of role assignment operation """
@@ -121,7 +129,7 @@ type Query {
     """ roles returns the list of assignable roles for a particular groupResource/resource e.g. What roles can be assigned for a specific core_platform-mesh_io_account"""
     roles(context: ResourceContext!): [Role]! @authorized(permission: "get_iam_roles")
     """ returns all users that have roles assigned for a particular groupResource/resource."""
-    users(context: ResourceContext!, roleFilters: [String!], sortBy: SortByInput, page: PageInput): UserConnection! @authorized(permission: "get_iam_users")
+    users(context: ResourceContext!, roleFilters: [String!], countRoleFilters: [String!], sortBy: SortByInput, page: PageInput): UserConnection! @authorized(permission: "get_iam_users")
     """ returns all users known to the system, regardless of whether they have roles assigned."""
     knownUsers(sortBy: SortByInput, page: PageInput): UserConnection!
     """ returns a specific user by userId"""

--- a/services/iam-service/pkg/fga/fga.go
+++ b/services/iam-service/pkg/fga/fga.go
@@ -19,7 +19,6 @@ package fga
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel"
@@ -34,6 +33,8 @@ import (
 	"go.platform-mesh.io/iam-service/pkg/graph"
 	"go.platform-mesh.io/iam-service/pkg/roles"
 	"go.platform-mesh.io/iam-service/pkg/workspace"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -75,45 +76,82 @@ func New(client openfgav1.OpenFGAServiceClient, cfg *config.ServiceConfig, wsCli
 }
 
 func (s *Service) ListUsers(ctx context.Context, rctx graph.ResourceContext, roleFilters []string) ([]*graph.UserRoles, error) {
+	users, _, err := s.ListUsersWithRoleCounts(ctx, rctx, roleFilters, nil)
+	return users, err
+}
+
+func (s *Service) ListUsersWithRoleCounts(ctx context.Context, rctx graph.ResourceContext, roleFilters, countRoleFilters []string) ([]*graph.UserRoles, []*graph.RoleCount, error) {
 	log := logger.LoadLoggerFromContext(ctx)
 	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "fga.ListUsers")
 	defer span.End()
 
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get kcp user context")
+		return nil, nil, errors.Wrap(err, "failed to get kcp user context")
 	}
 
 	storeID, err := s.helper.GetStoreID(ctx, s.client, kctx.OrganizationName)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get store ID for organization %s", kctx.OrganizationName)
+		return nil, nil, errors.Wrap(err, "failed to get store ID for organization %s", kctx.OrganizationName)
 	}
 
-	appliedRoles, err := s.applyRoleFilter(rctx, roleFilters, log)
+	roleDefinitions, err := s.rolesRetriever.GetRoleDefinitions(rctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get available roles for group resource %s/%s", rctx.Group, rctx.Kind)
+		return nil, nil, errors.Wrap(err, "failed to get available roles for group resource %s/%s", rctx.Group, rctx.Kind)
+	}
+	availableRoles := roles.GetAvailableRoleIDs(roleDefinitions)
+	appliedRoles := filterAvailableRoles(roleFilters, availableRoles, log)
+
+	var appliedCountRoles []string
+	if len(countRoleFilters) > 0 {
+		appliedCountRoles = filterAvailableRoles(countRoleFilters, availableRoles, log)
 	}
 
-	// If no roles to process, return empty result
-	if len(appliedRoles) == 0 {
-		return []*graph.UserRoles{}, nil
+	rolesToList := append([]string{}, appliedRoles...)
+	roleSet := sets.New(appliedRoles...)
+	for _, role := range appliedCountRoles {
+		if roleSet.Has(role) {
+			continue
+		}
+		rolesToList = append(rolesToList, role)
+		roleSet.Insert(role)
 	}
 
-	// Use parallel processing for multiple roles
-	return s.listUsersParallel(ctx, rctx, storeID, appliedRoles)
+	if len(rolesToList) == 0 {
+		return []*graph.UserRoles{}, []*graph.RoleCount{}, nil
+	}
+
+	users, counts, err := s.listUsersParallel(ctx, rctx, storeID, rolesToList, sets.New(appliedRoles...), roleDefinitions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	roleCounts := make([]*graph.RoleCount, 0, len(appliedCountRoles))
+	for _, role := range appliedCountRoles {
+		roleCounts = append(roleCounts, &graph.RoleCount{
+			RoleID: role,
+			Count:  counts[role],
+		})
+	}
+
+	return users, roleCounts, nil
 }
 
 func (s *Service) CountUsersForRole(ctx context.Context, rctx graph.ResourceContext, roleID string) (int, error) {
-	users, err := s.ListUsers(ctx, rctx, []string{roleID})
+	_, roleCounts, err := s.ListUsersWithRoleCounts(ctx, rctx, []string{roleID}, []string{roleID})
 	if err != nil {
 		return 0, err
 	}
 
-	return len(users), nil
+	if len(roleCounts) == 0 {
+		return 0, nil
+	}
+
+	return roleCounts[0].Count, nil
 }
 
 // listUsersParallel performs parallel ListUsers calls for multiple roles
-func (s *Service) listUsersParallel(ctx context.Context, rctx graph.ResourceContext, storeID string, roles []string) ([]*graph.UserRoles, error) {
+func (s *Service) listUsersParallel(ctx context.Context, rctx graph.ResourceContext, storeID string, roles []string, rolesForUsers sets.Set[string], roleDefinitions []roles.RoleDefinition) ([]*graph.UserRoles, map[string]int, error) {
 	type roleResult struct {
 		role  string
 		users *openfgav1.ListUsersResponse
@@ -126,7 +164,7 @@ func (s *Service) listUsersParallel(ctx context.Context, rctx graph.ResourceCont
 
 	clusterId, err := appcontext.GetClusterId(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get cluster ID from context")
+		return nil, nil, errors.Wrap(err, "failed to get cluster ID from context")
 	}
 
 	// Launch goroutines for each role
@@ -157,39 +195,34 @@ func (s *Service) listUsersParallel(ctx context.Context, rctx graph.ResourceCont
 
 	// Collect results from all goroutines
 	allUserIDToRoles := UserIDToRoles{}
-	var mu sync.Mutex
+	roleCounts := make(map[string]int, len(roles))
 
 	for range roles {
 		result := <-resultChan
 
 		// Handle any errors
 		if result.err != nil {
-			return nil, errors.Wrap(result.err, "failed to list users for resource %s with role %s", rctx.Resource.Name, result.role)
+			return nil, nil, errors.Wrap(result.err, "failed to list users for resource %s with role %s", rctx.Resource.Name, result.role)
 		}
 
-		// Process users for this role with thread safety
-		mu.Lock()
+		roleUserIDs := sets.New[string]()
 		for _, tuple := range result.users.Users {
 			user := tuple.User.(*openfgav1.User_Object)
-			allUserIDToRoles[user.Object.Id] = append(allUserIDToRoles[user.Object.Id], result.role)
+			roleUserIDs.Insert(user.Object.Id)
+			if rolesForUsers.Has(result.role) {
+				allUserIDToRoles[user.Object.Id] = append(allUserIDToRoles[user.Object.Id], result.role)
+			}
 		}
-		mu.Unlock()
+		roleCounts[result.role] = roleUserIDs.Len()
 	}
 
 	// Convert UserIDToRoles to []*graph.UserRoles
-	return s.convertToGraphUserRoles(rctx, allUserIDToRoles), nil
+	return convertToGraphUserRoles(roleDefinitions, allUserIDToRoles), roleCounts, nil
 }
 
 // convertToGraphUserRoles converts UserIDToRoles map to []*graph.UserRoles
-func (s *Service) convertToGraphUserRoles(rctx graph.ResourceContext, userIDToRoles UserIDToRoles) []*graph.UserRoles {
+func convertToGraphUserRoles(roleDefinitions []roles.RoleDefinition, userIDToRoles UserIDToRoles) []*graph.UserRoles {
 	result := make([]*graph.UserRoles, 0, len(userIDToRoles))
-
-	// Get role definitions for this group resource
-	roleDefinitions, err := s.rolesRetriever.GetRoleDefinitions(rctx)
-	if err != nil {
-		// Fallback to basic roles if we can't get definitions
-		roleDefinitions = []roles.RoleDefinition{}
-	}
 
 	// Create a map for quick role definition lookup
 	roleDefMap := make(map[string]roles.RoleDefinition)
@@ -261,7 +294,10 @@ func (s *Service) applyRoleFilter(rctx graph.ResourceContext, roleFilters []stri
 		return nil, errors.Wrap(err, "failed to get role definitions for group resource %s/%s", rctx.Group, rctx.Kind)
 	}
 	availableRoles := roles.GetAvailableRoleIDs(roleDefinitions)
+	return filterAvailableRoles(roleFilters, availableRoles, log), nil
+}
 
+func filterAvailableRoles(roleFilters, availableRoles []string, log *logger.Logger) []string {
 	var appliedRoles []string
 	if len(roleFilters) > 0 {
 		log.Debug().Interface("roleFilters", roleFilters).Interface("availableRoles", availableRoles).Msg("Applying role filters")
@@ -273,7 +309,7 @@ func (s *Service) applyRoleFilter(rctx graph.ResourceContext, roleFilters []stri
 	} else {
 		appliedRoles = availableRoles
 	}
-	return appliedRoles, nil
+	return appliedRoles
 }
 
 // AssignRolesToUsers creates tuples in FGA for the given users and roles, and processes invites

--- a/services/iam-service/pkg/fga/fga_test.go
+++ b/services/iam-service/pkg/fga/fga_test.go
@@ -39,6 +39,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+type countingRolesRetriever struct {
+	delegate roles.RolesRetriever
+	calls    int
+}
+
+func (r *countingRolesRetriever) GetRoleDefinitions(resourceContext graph.ResourceContext) ([]roles.RoleDefinition, error) {
+	r.calls++
+	return r.delegate.GetRoleDefinitions(resourceContext)
+}
+
 // createTestConfig creates a test configuration
 func createTestConfig() *config.ServiceConfig {
 	testRolesFile := filepath.Join("testdata", "roles.yaml")
@@ -217,6 +227,79 @@ func TestService_ListUsers_Success(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, resultMap)
+}
+
+func TestService_ListUsersWithRoleCounts_ReusesRoleLookups(t *testing.T) {
+	service, client := createTestService(t)
+	rolesRetriever := &countingRolesRetriever{delegate: service.rolesRetriever}
+	service.rolesRetriever = rolesRetriever
+
+	ctx := appcontext.SetKCPContext(context.Background(), appcontext.KCPContext{
+		IDMTenant:        "test-tenant",
+		OrganizationName: "test-org",
+	})
+	ctx = appcontext.SetClusterId(ctx, "cluster-123")
+
+	rCtx := graph.ResourceContext{
+		Group: "core.platform-mesh.io",
+		Kind:  "Account",
+		Resource: &graph.Resource{
+			Name:      "test-account",
+			Namespace: ptr.To("default"),
+		},
+		AccountPath: "test-account",
+	}
+
+	client.EXPECT().ListStores(mock.Anything, mock.Anything).Return(&openfgav1.ListStoresResponse{
+		Stores: []*openfgav1.Store{{
+			Id:   "store-123",
+			Name: "test-org",
+		}},
+	}, nil).Once()
+
+	client.EXPECT().ListUsers(mock.Anything, mock.MatchedBy(func(req *openfgav1.ListUsersRequest) bool {
+		return req.StoreId == "store-123" &&
+			req.Object.Type == "role" &&
+			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test-account/owner" &&
+			req.Relation == "assignee"
+	})).Return(&openfgav1.ListUsersResponse{
+		Users: []*openfgav1.User{
+			{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: "user", Id: "user1"}}},
+			{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: "user", Id: "user2"}}},
+		},
+	}, nil).Once()
+
+	client.EXPECT().ListUsers(mock.Anything, mock.MatchedBy(func(req *openfgav1.ListUsersRequest) bool {
+		return req.StoreId == "store-123" &&
+			req.Object.Type == "role" &&
+			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test-account/member" &&
+			req.Relation == "assignee"
+	})).Return(&openfgav1.ListUsersResponse{
+		Users: []*openfgav1.User{
+			{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: "user", Id: "user2"}}},
+			{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: "user", Id: "user3"}}},
+		},
+	}, nil).Once()
+
+	users, roleCounts, err := service.ListUsersWithRoleCounts(
+		ctx,
+		rCtx,
+		[]string{"member"},
+		[]string{"owner", "member", "owner", "invalid-role"},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+	for _, user := range users {
+		assert.NotEqual(t, "user1", user.User.Email)
+		assert.Len(t, user.Roles, 1)
+		assert.Equal(t, "member", user.Roles[0].ID)
+	}
+	assert.Equal(t, []*graph.RoleCount{
+		{RoleID: "owner", Count: 2},
+		{RoleID: "member", Count: 2},
+	}, roleCounts)
+	assert.Equal(t, 1, rolesRetriever.calls)
 }
 
 func TestService_ListUsers_NoKCPContext(t *testing.T) {

--- a/services/iam-service/pkg/graph/generated.go
+++ b/services/iam-service/pkg/graph/generated.go
@@ -63,7 +63,7 @@ type ComplexityRoot struct {
 		Me         func(childComplexity int) int
 		Roles      func(childComplexity int, context ResourceContext) int
 		User       func(childComplexity int, userID string) int
-		Users      func(childComplexity int, context ResourceContext, roleFilters []string, sortBy *SortByInput, page *PageInput) int
+		Users      func(childComplexity int, context ResourceContext, roleFilters []string, countRoleFilters []string, sortBy *SortByInput, page *PageInput) int
 	}
 
 	Role struct {
@@ -76,6 +76,11 @@ type ComplexityRoot struct {
 		AssignedCount func(childComplexity int) int
 		Errors        func(childComplexity int) int
 		Success       func(childComplexity int) int
+	}
+
+	RoleCount struct {
+		Count  func(childComplexity int) int
+		RoleID func(childComplexity int) int
 	}
 
 	RoleRemovalResult struct {
@@ -94,6 +99,7 @@ type ComplexityRoot struct {
 	UserConnection struct {
 		OwnersCount func(childComplexity int) int
 		PageInfo    func(childComplexity int) int
+		RoleCounts  func(childComplexity int) int
 		Users       func(childComplexity int) int
 	}
 
@@ -109,7 +115,7 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	Roles(ctx context.Context, context ResourceContext) ([]*Role, error)
-	Users(ctx context.Context, context ResourceContext, roleFilters []string, sortBy *SortByInput, page *PageInput) (*UserConnection, error)
+	Users(ctx context.Context, context ResourceContext, roleFilters []string, countRoleFilters []string, sortBy *SortByInput, page *PageInput) (*UserConnection, error)
 	KnownUsers(ctx context.Context, sortBy *SortByInput, page *PageInput) (*UserConnection, error)
 	User(ctx context.Context, userID string) (*User, error)
 	Me(ctx context.Context) (*User, error)
@@ -231,7 +237,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Users(childComplexity, args["context"].(ResourceContext), args["roleFilters"].([]string), args["sortBy"].(*SortByInput), args["page"].(*PageInput)), true
+		return e.complexity.Query.Users(childComplexity, args["context"].(ResourceContext), args["roleFilters"].([]string), args["countRoleFilters"].([]string), args["sortBy"].(*SortByInput), args["page"].(*PageInput)), true
 
 	case "Role.description":
 		if e.complexity.Role.Description == nil {
@@ -270,6 +276,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.RoleAssignmentResult.Success(childComplexity), true
+
+	case "RoleCount.count":
+		if e.complexity.RoleCount.Count == nil {
+			break
+		}
+
+		return e.complexity.RoleCount.Count(childComplexity), true
+	case "RoleCount.roleId":
+		if e.complexity.RoleCount.RoleID == nil {
+			break
+		}
+
+		return e.complexity.RoleCount.RoleID(childComplexity), true
 
 	case "RoleRemovalResult.error":
 		if e.complexity.RoleRemovalResult.Error == nil {
@@ -327,6 +346,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UserConnection.PageInfo(childComplexity), true
+	case "UserConnection.roleCounts":
+		if e.complexity.UserConnection.RoleCounts == nil {
+			break
+		}
+
+		return e.complexity.UserConnection.RoleCounts(childComplexity), true
 	case "UserConnection.users":
 		if e.complexity.UserConnection.Users == nil {
 			break
@@ -512,13 +537,21 @@ type UserRoles {
     roles: [Role!]!
 }
 
+""" Total number of users assigned to a role """
+type RoleCount {
+    roleId: String!
+    count: Int!
+}
+
 """ Is a list of the users and their roles """
 type UserConnection {
     users: [UserRoles!]!
     """ number of granted users in the list """
     pageInfo: PageInfo!
     """ number of users in the result set that have the owner role """
-    ownersCount: Int!
+    ownersCount: Int! @deprecated(reason: "Use roleCounts instead")
+    """ total user counts for the roles requested through countRoleFilters """
+    roleCounts: [RoleCount!]!
 }
 
 """ Result of role assignment operation """
@@ -582,7 +615,7 @@ type Query {
     """ roles returns the list of assignable roles for a particular groupResource/resource e.g. What roles can be assigned for a specific core_platform-mesh_io_account"""
     roles(context: ResourceContext!): [Role]! @authorized(permission: "get_iam_roles")
     """ returns all users that have roles assigned for a particular groupResource/resource."""
-    users(context: ResourceContext!, roleFilters: [String!], sortBy: SortByInput, page: PageInput): UserConnection! @authorized(permission: "get_iam_users")
+    users(context: ResourceContext!, roleFilters: [String!], countRoleFilters: [String!], sortBy: SortByInput, page: PageInput): UserConnection! @authorized(permission: "get_iam_users")
     """ returns all users known to the system, regardless of whether they have roles assigned."""
     knownUsers(sortBy: SortByInput, page: PageInput): UserConnection!
     """ returns a specific user by userId"""
@@ -720,16 +753,21 @@ func (ec *executionContext) field_Query_users_args(ctx context.Context, rawArgs 
 		return nil, err
 	}
 	args["roleFilters"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOSortByInput2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐSortByInput)
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "countRoleFilters", ec.unmarshalOString2ᚕstringᚄ)
 	if err != nil {
 		return nil, err
 	}
-	args["sortBy"] = arg2
-	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "page", ec.unmarshalOPageInput2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐPageInput)
+	args["countRoleFilters"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOSortByInput2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐSortByInput)
 	if err != nil {
 		return nil, err
 	}
-	args["page"] = arg3
+	args["sortBy"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "page", ec.unmarshalOPageInput2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐPageInput)
+	if err != nil {
+		return nil, err
+	}
+	args["page"] = arg4
 	return args, nil
 }
 
@@ -1110,7 +1148,7 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 		ec.fieldContext_Query_users,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Users(ctx, fc.Args["context"].(ResourceContext), fc.Args["roleFilters"].([]string), fc.Args["sortBy"].(*SortByInput), fc.Args["page"].(*PageInput))
+			return ec.resolvers.Query().Users(ctx, fc.Args["context"].(ResourceContext), fc.Args["roleFilters"].([]string), fc.Args["countRoleFilters"].([]string), fc.Args["sortBy"].(*SortByInput), fc.Args["page"].(*PageInput))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next
@@ -1151,6 +1189,8 @@ func (ec *executionContext) fieldContext_Query_users(ctx context.Context, field 
 				return ec.fieldContext_UserConnection_pageInfo(ctx, field)
 			case "ownersCount":
 				return ec.fieldContext_UserConnection_ownersCount(ctx, field)
+			case "roleCounts":
+				return ec.fieldContext_UserConnection_roleCounts(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserConnection", field.Name)
 		},
@@ -1200,6 +1240,8 @@ func (ec *executionContext) fieldContext_Query_knownUsers(ctx context.Context, f
 				return ec.fieldContext_UserConnection_pageInfo(ctx, field)
 			case "ownersCount":
 				return ec.fieldContext_UserConnection_ownersCount(ctx, field)
+			case "roleCounts":
+				return ec.fieldContext_UserConnection_roleCounts(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserConnection", field.Name)
 		},
@@ -1590,6 +1632,64 @@ func (ec *executionContext) fieldContext_RoleAssignmentResult_assignedCount(_ co
 	return fc, nil
 }
 
+func (ec *executionContext) _RoleCount_roleId(ctx context.Context, field graphql.CollectedField, obj *RoleCount) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RoleCount_roleId,
+		func(ctx context.Context) (any, error) {
+			return obj.RoleID, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RoleCount_roleId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RoleCount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RoleCount_count(ctx context.Context, field graphql.CollectedField, obj *RoleCount) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RoleCount_count,
+		func(ctx context.Context) (any, error) {
+			return obj.Count, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RoleCount_count(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RoleCount",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RoleRemovalResult_success(ctx context.Context, field graphql.CollectedField, obj *RoleRemovalResult) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1891,6 +1991,41 @@ func (ec *executionContext) fieldContext_UserConnection_ownersCount(_ context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserConnection_roleCounts(ctx context.Context, field graphql.CollectedField, obj *UserConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserConnection_roleCounts,
+		func(ctx context.Context) (any, error) {
+			return obj.RoleCounts, nil
+		},
+		nil,
+		ec.marshalNRoleCount2ᚕᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐRoleCountᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserConnection_roleCounts(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "roleId":
+				return ec.fieldContext_RoleCount_roleId(ctx, field)
+			case "count":
+				return ec.fieldContext_RoleCount_count(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RoleCount", field.Name)
 		},
 	}
 	return fc, nil
@@ -4044,6 +4179,50 @@ func (ec *executionContext) _RoleAssignmentResult(ctx context.Context, sel ast.S
 	return out
 }
 
+var roleCountImplementors = []string{"RoleCount"}
+
+func (ec *executionContext) _RoleCount(ctx context.Context, sel ast.SelectionSet, obj *RoleCount) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, roleCountImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RoleCount")
+		case "roleId":
+			out.Values[i] = ec._RoleCount_roleId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "count":
+			out.Values[i] = ec._RoleCount_count(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var roleRemovalResultImplementors = []string{"RoleRemovalResult"}
 
 func (ec *executionContext) _RoleRemovalResult(ctx context.Context, sel ast.SelectionSet, obj *RoleRemovalResult) graphql.Marshaler {
@@ -4161,6 +4340,11 @@ func (ec *executionContext) _UserConnection(ctx context.Context, sel ast.Selecti
 			}
 		case "ownersCount":
 			out.Values[i] = ec._UserConnection_ownersCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "roleCounts":
+			out.Values[i] = ec._UserConnection_roleCounts(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -4732,6 +4916,60 @@ func (ec *executionContext) marshalNRoleAssignmentResult2ᚖgoᚗplatformᚑmesh
 		return graphql.Null
 	}
 	return ec._RoleAssignmentResult(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRoleCount2ᚕᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐRoleCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*RoleCount) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNRoleCount2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐRoleCount(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNRoleCount2ᚖgoᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐRoleCount(ctx context.Context, sel ast.SelectionSet, v *RoleCount) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RoleCount(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNRoleRemovalResult2goᚗplatformᚑmeshᚗioᚋiamᚑserviceᚋpkgᚋgraphᚐRoleRemovalResult(ctx context.Context, sel ast.SelectionSet, v RoleRemovalResult) graphql.Marshaler {

--- a/services/iam-service/pkg/graph/models_gen.go
+++ b/services/iam-service/pkg/graph/models_gen.go
@@ -70,6 +70,12 @@ type RoleAssignmentResult struct {
 	AssignedCount int      `json:"assignedCount"`
 }
 
+// Total number of users assigned to a role
+type RoleCount struct {
+	RoleID string `json:"roleId"`
+	Count  int    `json:"count"`
+}
+
 // Result of role removal operation
 type RoleRemovalResult struct {
 	Success     bool    `json:"success"`
@@ -97,6 +103,8 @@ type UserConnection struct {
 	PageInfo *PageInfo `json:"pageInfo"`
 	//  number of users in the result set that have the owner role
 	OwnersCount int `json:"ownersCount"`
+	//  total user counts for the roles requested through countRoleFilters
+	RoleCounts []*RoleCount `json:"roleCounts"`
 }
 
 // Holds information about a specific user and a list of roles that should be assigned to the user

--- a/services/iam-service/pkg/resolver/api/api.go
+++ b/services/iam-service/pkg/resolver/api/api.go
@@ -25,7 +25,7 @@ import (
 type ResolverService interface {
 	Me(ctx context.Context) (*graph.User, error)
 	User(ctx context.Context, userID string) (*graph.User, error)
-	Users(ctx context.Context, context graph.ResourceContext, roleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error)
+	Users(ctx context.Context, context graph.ResourceContext, roleFilters, countRoleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error)
 	Roles(ctx context.Context, context graph.ResourceContext) ([]*graph.Role, error)
 	AssignRolesToUsers(ctx context.Context, context graph.ResourceContext, changes []*graph.UserRoleChange, invites []*graph.InviteInput) (*graph.RoleAssignmentResult, error)
 	RemoveRole(ctx context.Context, context graph.ResourceContext, input graph.RemoveRoleInput) (*graph.RoleRemovalResult, error)

--- a/services/iam-service/pkg/resolver/pm/resolver_service.go
+++ b/services/iam-service/pkg/resolver/pm/resolver_service.go
@@ -18,6 +18,7 @@ package pm
 
 import (
 	"context"
+	"slices"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
@@ -75,15 +76,26 @@ func (s *Service) User(ctx context.Context, userID string) (*graph.User, error) 
 	return s.transformer.Transform(user), nil
 }
 
-func (s *Service) Users(ctx context.Context, rctx graph.ResourceContext, roleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
-	ownersCount, err := s.fgaService.CountUsersForRole(ctx, rctx, ownerRoleID)
+func (s *Service) Users(ctx context.Context, rctx graph.ResourceContext, roleFilters, countRoleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
+	rolesToCount := append([]string{}, countRoleFilters...)
+	if !slices.Contains(rolesToCount, ownerRoleID) {
+		rolesToCount = append(rolesToCount, ownerRoleID)
+	}
+
+	allUserRoles, allRoleCounts, err := s.fgaService.ListUsersWithRoleCounts(ctx, rctx, roleFilters, rolesToCount)
 	if err != nil {
 		return nil, err
 	}
 
-	allUserRoles, err := s.fgaService.ListUsers(ctx, rctx, roleFilters)
-	if err != nil {
-		return nil, err
+	ownersCount := 0
+	roleCounts := make([]*graph.RoleCount, 0, len(countRoleFilters))
+	for _, roleCount := range allRoleCounts {
+		if roleCount.RoleID == ownerRoleID {
+			ownersCount = roleCount.Count
+		}
+		if slices.Contains(countRoleFilters, roleCount.RoleID) {
+			roleCounts = append(roleCounts, roleCount)
+		}
 	}
 
 	err = s.keycloakService.EnrichUserRoles(ctx, allUserRoles)
@@ -104,6 +116,7 @@ func (s *Service) Users(ctx context.Context, rctx graph.ResourceContext, roleFil
 		Users:       paginatedUserRoles,
 		PageInfo:    pageInfo,
 		OwnersCount: ownersCount,
+		RoleCounts:  roleCounts,
 	}, nil
 }
 
@@ -135,6 +148,7 @@ func (s *Service) KnownUsers(ctx context.Context, sortBy *graph.SortByInput, pag
 		Users:       userRoles,
 		PageInfo:    pageInfo,
 		OwnersCount: 0,
+		RoleCounts:  []*graph.RoleCount{},
 	}, nil
 }
 

--- a/services/iam-service/pkg/resolver/pm/resolver_service_test.go
+++ b/services/iam-service/pkg/resolver/pm/resolver_service_test.go
@@ -22,10 +22,13 @@ import (
 	"testing"
 	"time"
 
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 
 	"go.platform-mesh.io/golang-commons/logger"
 	"go.platform-mesh.io/iam-service/pkg/config"
+	appcontext "go.platform-mesh.io/iam-service/pkg/context"
 	"go.platform-mesh.io/iam-service/pkg/fga"
 	"go.platform-mesh.io/iam-service/pkg/fga/mocks"
 	"go.platform-mesh.io/iam-service/pkg/graph"
@@ -321,6 +324,80 @@ func TestNewResolverService(t *testing.T) {
 	assert.NotNil(t, service.pager)
 	// mgr is nil in tests that don't require it
 	assert.NotNil(t, mockFGA) // Verify we got the mock back
+}
+
+func TestService_Users_ReturnsRequestedRoleCountsAndLegacyOwnerCount(t *testing.T) {
+	service, mockFGA := createTestResolverService(t)
+
+	ctx := appcontext.SetKCPContext(context.Background(), appcontext.KCPContext{
+		IDMTenant:        "test-tenant",
+		OrganizationName: "test-org",
+	})
+	ctx = appcontext.SetClusterId(ctx, "cluster-123")
+
+	rCtx := graph.ResourceContext{
+		Group: "core.platform-mesh.io",
+		Kind:  "Account",
+		Resource: &graph.Resource{
+			Name:      "test-account",
+			Namespace: ptr.To("default"),
+		},
+		AccountPath: "test-account",
+	}
+
+	mockFGA.EXPECT().ListStores(testifymock.Anything, testifymock.Anything).Return(&openfgav1.ListStoresResponse{
+		Stores: []*openfgav1.Store{{
+			Id:   "store-123",
+			Name: "test-org",
+		}},
+	}, nil).Once()
+
+	for _, roleID := range []string{"owner", "member"} {
+		mockFGA.EXPECT().ListUsers(testifymock.Anything, testifymock.MatchedBy(func(req *openfgav1.ListUsersRequest) bool {
+			return req.StoreId == "store-123" &&
+				req.Object.Type == "role" &&
+				req.Object.Id == "core_platform-mesh_io_account/cluster-123/test-account/"+roleID &&
+				req.Relation == "assignee"
+		})).Return(&openfgav1.ListUsersResponse{}, nil).Once()
+	}
+
+	result, err := service.Users(ctx, rCtx, []string{"member"}, []string{"member"}, nil, nil)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result.Users)
+	assert.Equal(t, 0, result.OwnersCount)
+	assert.Equal(t, []*graph.RoleCount{{RoleID: "member", Count: 0}}, result.RoleCounts)
+}
+
+func TestService_Users_EmptyCountFilterPreservesLegacyOwnerCount(t *testing.T) {
+	service, mockFGA := createTestResolverService(t)
+
+	ctx := appcontext.SetKCPContext(context.Background(), appcontext.KCPContext{
+		IDMTenant:        "test-tenant",
+		OrganizationName: "test-org",
+	})
+	ctx = appcontext.SetClusterId(ctx, "cluster-123")
+
+	rCtx := graph.ResourceContext{
+		Group: "core.platform-mesh.io",
+		Kind:  "Account",
+		Resource: &graph.Resource{
+			Name:      "test-account",
+			Namespace: ptr.To("default"),
+		},
+		AccountPath: "test-account",
+	}
+
+	mockFGA.EXPECT().ListStores(testifymock.Anything, testifymock.Anything).Return(&openfgav1.ListStoresResponse{
+		Stores: []*openfgav1.Store{{Id: "store-123", Name: "test-org"}},
+	}, nil).Once()
+	mockFGA.EXPECT().ListUsers(testifymock.Anything, testifymock.Anything).Return(&openfgav1.ListUsersResponse{}, nil).Once()
+
+	result, err := service.Users(ctx, rCtx, []string{"owner"}, nil, nil, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result.OwnersCount)
+	assert.Empty(t, result.RoleCounts)
 }
 
 // Removed trivial GraphQL resolver delegation tests - they're auto-generated and don't add value

--- a/services/iam-service/pkg/resolver/schema.resolvers.go
+++ b/services/iam-service/pkg/resolver/schema.resolvers.go
@@ -26,8 +26,8 @@ func (r *queryResolver) Roles(ctx context.Context, context graph.ResourceContext
 }
 
 // Users is the resolver for the users field.
-func (r *queryResolver) Users(ctx context.Context, context graph.ResourceContext, roleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
-	return r.svc.Users(ctx, context, roleFilters, sortBy, page)
+func (r *queryResolver) Users(ctx context.Context, context graph.ResourceContext, roleFilters []string, countRoleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
+	return r.svc.Users(ctx, context, roleFilters, countRoleFilters, sortBy, page)
 }
 
 // KnownUsers is the resolver for the knownUsers field.

--- a/services/iam-service/pkg/router/router_test.go
+++ b/services/iam-service/pkg/router/router_test.go
@@ -47,10 +47,11 @@ func (s *testResolverService) User(ctx context.Context, userID string) (*graph.U
 	return &graph.User{UserID: userID, Email: userID + "@example.com"}, nil
 }
 
-func (s *testResolverService) Users(ctx context.Context, resourceContext graph.ResourceContext, roleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
+func (s *testResolverService) Users(ctx context.Context, resourceContext graph.ResourceContext, roleFilters, countRoleFilters []string, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
 	return &graph.UserConnection{
-		Users:    []*graph.UserRoles{},
-		PageInfo: &graph.PageInfo{Count: 0, TotalCount: 0, HasNextPage: false, HasPreviousPage: false},
+		Users:      []*graph.UserRoles{},
+		PageInfo:   &graph.PageInfo{Count: 0, TotalCount: 0, HasNextPage: false, HasPreviousPage: false},
+		RoleCounts: []*graph.RoleCount{},
 	}, nil
 }
 
@@ -68,8 +69,9 @@ func (s *testResolverService) RemoveRole(ctx context.Context, resourceContext gr
 
 func (s *testResolverService) KnownUsers(ctx context.Context, sortBy *graph.SortByInput, page *graph.PageInput) (*graph.UserConnection, error) {
 	return &graph.UserConnection{
-		Users:    []*graph.UserRoles{},
-		PageInfo: &graph.PageInfo{Count: 0, TotalCount: 0, HasNextPage: false, HasPreviousPage: false},
+		Users:      []*graph.UserRoles{},
+		PageInfo:   &graph.PageInfo{Count: 0, TotalCount: 0, HasNextPage: false, HasPreviousPage: false},
+		RoleCounts: []*graph.RoleCount{},
 	}, nil
 }
 
@@ -376,15 +378,17 @@ func TestCreateRouter_GraphQLIntrospection(t *testing.T) {
 	// Execute
 	router := CreateRouter(commonCfg, serviceCfg, resolver, log, nil, createEmptyDirectiveRoot())
 
-	// Assert - Test introspection query
-	introspectionQuery := `{"query": "{ __schema { types { name } } }"}`
+	// Assert - Test the backward-compatible users contract through introspection.
+	introspectionQuery := `{"query":"{ connection: __type(name: \"UserConnection\") { fields(includeDeprecated: true) { name isDeprecated deprecationReason } } query: __type(name: \"Query\") { fields { name args { name } } } }"}`
 	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(introspectionQuery))
 	req.Header.Set("Content-Type", "application/json")
 
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
-	// Should not return error (introspection should be enabled)
-	assert.NotEqual(t, http.StatusNotFound, rr.Code)
-	assert.NotEqual(t, http.StatusMethodNotAllowed, rr.Code)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), `"errors"`)
+	assert.Contains(t, rr.Body.String(), `"name":"ownersCount","isDeprecated":true,"deprecationReason":"Use roleCounts instead"`)
+	assert.Contains(t, rr.Body.String(), `"name":"roleCounts","isDeprecated":false`)
+	assert.Contains(t, rr.Body.String(), `"name":"countRoleFilters"`)
 }


### PR DESCRIPTION
## Summary

- add `countRoleFilters` and generic `roleCounts` to the `users` query
- keep `ownersCount` deprecated for backward compatibility
- reuse OpenFGA lookups for overlapping user and count filters
- calculate distinct role totals independently of pagination

IAM UI migration: https://github.com/platform-mesh/iam-ui/pull/106

## Verification

- added FGA, resolver, and GraphQL contract tests
- `task unittest`, `task lint`, and `task build`
- tested the locally built backend through the authenticated GraphQL endpoint
- tested both the existing and migrated IAM UI

Part of #91