### PR TITLE
Restrict CODEOWNERS to maintainer teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
-* @platform-mesh/tsc @platform-mesh/go-approvers
+* @platform-mesh/go-maintainers
+
+# ownerless so renovate can auto-merge updates
+**/go.mod
+**/go.sum

--- a/cmd/jl/CODEOWNERS
+++ b/cmd/jl/CODEOWNERS
@@ -1,3 +1,0 @@
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers @platform-mesh/kube
-go.mod
-go.sum

--- a/cmd/qbrtool/CODEOWNERS
+++ b/cmd/qbrtool/CODEOWNERS
@@ -1,3 +1,0 @@
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers @platform-mesh/kube
-go.mod
-go.sum

--- a/golang-commons/CODEOWNERS
+++ b/golang-commons/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/operators/account-operator/CODEOWNERS
+++ b/operators/account-operator/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/operators/backup-operator/CODEOWNERS
+++ b/operators/backup-operator/CODEOWNERS
@@ -1,5 +1,0 @@
-* @platform-mesh/tsc @platform-mesh/kube-approvers @platform-mesh/go-approvers
-go.mod
-go.sum
-**/go.mod
-**/go.sum

--- a/operators/extension-manager-operator/CODEOWNERS
+++ b/operators/extension-manager-operator/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/operators/kcp-migration-operator/CODEOWNERS
+++ b/operators/kcp-migration-operator/CODEOWNERS
@@ -1,3 +1,0 @@
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers @platform-mesh/kube
-go.mod
-go.sum

--- a/operators/platform-mesh-operator/CODEOWNERS
+++ b/operators/platform-mesh-operator/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers @platform-mesh/kube
-go.mod
-go.sum

--- a/operators/search-operator/CODEOWNERS
+++ b/operators/search-operator/CODEOWNERS
@@ -1,3 +1,0 @@
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers @platform-mesh/kube
-go.mod
-go.sum

--- a/operators/security-operator/CODEOWNERS
+++ b/operators/security-operator/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/operators/terminal-controller-manager/CODEOWNERS
+++ b/operators/terminal-controller-manager/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/services/iam-service/CODEOWNERS
+++ b/services/iam-service/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/services/kubernetes-graphql-gateway/CODEOWNERS
+++ b/services/kubernetes-graphql-gateway/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/services/rebac-authz-webhook/CODEOWNERS
+++ b/services/rebac-authz-webhook/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/services/search-service/CODEOWNERS
+++ b/services/search-service/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/services/virtual-workspaces/CODEOWNERS
+++ b/services/virtual-workspaces/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum

--- a/subroutines/CODEOWNERS
+++ b/subroutines/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default code owners
-* @platform-mesh/kube @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
-go.mod
-go.sum


### PR DESCRIPTION
Part of the GitHub organisation cleanup decided in the TSC on 2026-08-19.