### PR TITLE
security-operator: generate authorization models for self-bound APIExports

### DIFF
--- a/operators/security-operator/internal/subroutine/authorization_model_generation.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_generation.go
@@ -272,7 +272,6 @@ func (a *AuthorizationModelGenerationSubroutine) Process(ctx context.Context, ob
 	internalAPIBindings := []string{"core.platform-mesh.io", "system.platform-mesh.io", "providers.platform-mesh.io"}
 
 	if slices.Contains(internalAPIBindings, binding.Spec.Reference.Export.Name) || strings.HasSuffix(binding.Spec.Reference.Export.Name, "kcp.io") {
-		// If the APIExport is the core.platform-mesh.io, system.platform-mesh.io, providers.platform-mesh.io we can skip the model generation.
 		return subroutines.OK(), nil
 	}
 
@@ -298,22 +297,28 @@ func (a *AuthorizationModelGenerationSubroutine) Process(ctx context.Context, ob
 		return subroutines.OK(), fmt.Errorf("getting APIExport: %w", err)
 	}
 
-	providerCluster, err := a.mgr.GetCluster(ctx, config.MultiProviderName(config.ProvidersProviderName, binding.Status.APIExportClusterName))
-	if err != nil {
-		return subroutines.OK(), fmt.Errorf("getting provider cluster: %w", err)
-	}
-
-	var providerPermissionsList pmprovidersv1alpha1.ProviderPermissionsList
-	err = providerCluster.GetClient().List(ctx, &providerPermissionsList)
-	if err != nil {
-		return subroutines.OK(), fmt.Errorf("listing ProviderPermissions: %w", err)
-	}
-
+	var providerClient ctrlruntimeclient.Client
 	var providerPermissions *pmprovidersv1alpha1.ProviderPermissions
-	for i := range providerPermissionsList.Items {
-		if providerPermissionsList.Items[i].Spec.APIExport.Ref.Name == apiExport.Name {
-			providerPermissions = &providerPermissionsList.Items[i]
-			break
+
+	// A self-bound export has no provider workspace and uses the template defaults. Every
+	// other export must resolve, or the model would lose the provider's permission overrides.
+	if binding.Status.APIExportClusterName != logicalcluster.From(binding).String() {
+		providerCluster, err := a.mgr.GetCluster(ctx, config.MultiProviderName(config.ProvidersProviderName, binding.Status.APIExportClusterName))
+		if err != nil {
+			return subroutines.OK(), fmt.Errorf("getting provider cluster: %w", err)
+		}
+		providerClient = providerCluster.GetClient()
+
+		var providerPermissionsList pmprovidersv1alpha1.ProviderPermissionsList
+		if err := providerClient.List(ctx, &providerPermissionsList); err != nil {
+			return subroutines.OK(), fmt.Errorf("listing ProviderPermissions: %w", err)
+		}
+
+		for i := range providerPermissionsList.Items {
+			if providerPermissionsList.Items[i].Spec.APIExport.Ref.Name == apiExport.Name {
+				providerPermissions = &providerPermissionsList.Items[i]
+				break
+			}
 		}
 	}
 
@@ -402,7 +407,7 @@ func (a *AuthorizationModelGenerationSubroutine) Process(ctx context.Context, ob
 			Message:            "ProviderPermissions successfully applied to all AuthorizationModels",
 		})
 
-		if err := providerCluster.GetClient().Status().Update(ctx, providerPermissions); err != nil {
+		if err := providerClient.Status().Update(ctx, providerPermissions); err != nil {
 			return subroutines.OK(), fmt.Errorf("updating ProviderPermissions status: %w", err)
 		}
 	}

--- a/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
+++ b/operators/security-operator/internal/subroutine/authorization_model_generation_test.go
@@ -41,7 +41,8 @@ import (
 
 func newApiBinding(name, path string) *kcpapisv1alpha2.APIBinding {
 	return &kcpapisv1alpha2.APIBinding{
-		Spec: kcpapisv1alpha2.APIBindingSpec{Reference: kcpapisv1alpha2.BindingReference{Export: &kcpapisv1alpha2.ExportBindingReference{Name: name, Path: path}}},
+		Spec:   kcpapisv1alpha2.APIBindingSpec{Reference: kcpapisv1alpha2.BindingReference{Export: &kcpapisv1alpha2.ExportBindingReference{Name: name, Path: path}}},
+		Status: kcpapisv1alpha2.APIBindingStatus{APIExportClusterName: "export-cluster"},
 	}
 }
 
@@ -56,6 +57,21 @@ func bindingWithCluster(name, path, cluster string) *kcpapisv1alpha2.APIBinding 
 
 func bindingWithApiExportCluster(name, path, exportCluster string) *kcpapisv1alpha2.APIBinding {
 	b := newApiBinding(name, path)
+	b.Status.APIExportClusterName = exportCluster
+	return b
+}
+
+// selfBoundBinding is a binding whose APIExport lives in its own workspace, as KROaaS
+// publishes composite types. It has no path and its export cluster is its own cluster.
+func selfBoundBinding(name, cluster string) *kcpapisv1alpha2.APIBinding {
+	b := bindingWithCluster(name, "", cluster)
+	b.Status.APIExportClusterName = cluster
+	return b
+}
+
+// providerBoundBinding is a binding whose APIExport lives in a provider workspace.
+func providerBoundBinding(name, path, cluster, exportCluster string) *kcpapisv1alpha2.APIBinding {
+	b := bindingWithCluster(name, path, cluster)
 	b.Status.APIExportClusterName = exportCluster
 	return b
 }
@@ -358,6 +374,83 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				kcpClient.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Maybe()
 				kcpClient.EXPECT().Create(mock.Anything, mock.Anything).Return(nil).Maybe()
+			},
+		},
+		{
+			// A self-bound export lives in the consumer's own workspace, which is never in
+			// providers scope. The model must still be generated from the export's schemas,
+			// so no provider cluster is looked up at all: GetCluster is expected twice
+			// (binding workspace + APIExport cluster) rather than three times.
+			name:        "self-bound export generates a model without a provider lookup",
+			binding:     selfBoundBinding("kro-greeting", "consumer-cluster"),
+			expectError: false,
+			mockSetup: func(manager *mocks.MockManager, lister *mocks.MockLister, cluster *mocks.MockCluster, kcpClient *mocks.MockClient) {
+				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
+				cluster.EXPECT().GetClient().Return(kcpClient)
+				mockAccountInfo(kcpClient, "org", "origin")
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Times(2)
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
+						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
+						ae.Name = "kro-greeting"
+					}
+					return nil
+				}).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if rs, ok := o.(*kcpapisv1alpha1.APIResourceSchema); ok {
+						rs.Spec.Group = "kro.run"
+						rs.Spec.Names.Plural = "greetings"
+						rs.Spec.Names.Singular = "greeting"
+						rs.Spec.Scope = "Namespaced"
+					}
+					return nil
+				}).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				kcpClient.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Maybe()
+				kcpClient.EXPECT().Create(mock.Anything, mock.Anything).Return(nil).Maybe()
+			},
+		},
+		{
+			// A provider-backed export must keep failing closed: if its provider cluster
+			// cannot be resolved the model is left untouched rather than regenerated
+			// without the provider's ProviderPermissions overrides.
+			name:        "provider-backed export aborts when the provider cluster is unresolvable",
+			binding:     providerBoundBinding("some-export", "root:providers:p", "consumer-cluster", "provider-cluster"),
+			expectError: true,
+			mockSetup: func(manager *mocks.MockManager, lister *mocks.MockLister, cluster *mocks.MockCluster, kcpClient *mocks.MockClient) {
+				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
+				cluster.EXPECT().GetClient().Return(kcpClient)
+				mockAccountInfo(kcpClient, "org", "origin")
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
+						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
+						ae.Name = "some-export"
+					}
+					return nil
+				}).Once()
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
+			},
+		},
+		{
+			// An unreconciled binding has no APIExportClusterName, which does not match its
+			// own cluster, so it is not self-bound and fails closed.
+			name:        "unset APIExportClusterName takes the strict path",
+			binding:     bindingWithCluster("foo", "bar", "consumer-cluster"),
+			expectError: true,
+			mockSetup: func(manager *mocks.MockManager, lister *mocks.MockLister, cluster *mocks.MockCluster, kcpClient *mocks.MockClient) {
+				manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
+				cluster.EXPECT().GetClient().Return(kcpClient)
+				mockAccountInfo(kcpClient, "org", "origin")
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil).Once()
+				kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
+						ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
+						ae.Name = "foo"
+					}
+					return nil
+				}).Once()
+				manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
 			},
 		},
 		{


### PR DESCRIPTION
## Problem

Composite types published by KROaaS get no OpenFGA type, so the portal denies listing their instances. The RGD reports Active/Ready, so nothing surfaces the failure.

## Cause

`Process` resolves ProviderPermissions via `GetCluster(ProvidersProviderName, ...)` and returns on error. Only provider workspaces are in providers scope, and KROaaS self-binds its per-RGD APIExport in the consumer's own workspace, so it aborts before generating a model. Added by 511d6688, first shipped in v0.35.0.

## Fix

Skip the lookup when the export is self-bound (`APIExportClusterName` equals the binding's own cluster). Those exports have no ProviderPermissions to read and fall back to the template defaults, as v0.34.3 did unconditionally. Every other export keeps the v0.35.0 path.

Merely making the lookup non-fatal would be fail-open: `DefaultPermissions` can be stricter than the defaults, so a transient failure would overwrite a provider's restrictive model with a permissive one.

## Testing

Three cases added to `TestAuthorizationModelGeneration_Process`; the self-bound one fails without the fix. Unit and integration suites pass. Verified on local-setup.