### PR TITLE
kro-composition-operator: publish APIExports as apis.kcp.io/v1alpha2

### DIFF
--- a/operators/kro-composition-operator/config/provider/apiexport-kro.run.yaml
+++ b/operators/kro-composition-operator/config/provider/apiexport-kro.run.yaml
@@ -15,12 +15,16 @@
 # The kro.run APIExport publishes kro's ResourceGraphDefinition type into consumer
 # workspaces (so Accounts can author RGDs). Applied into root:providers:kro-provider.
 # The content-for label MUST equal the ProviderMetadata name for the Marketplace.
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
   name: kro.run
   labels:
     ui.platform-mesh.io/content-for: kro.run
 spec:
-  latestResourceSchemas:
-    - v1.resourcegraphdefinitions.kro.run
+  resources:
+    - group: kro.run
+      name: resourcegraphdefinitions
+      schema: v1.resourcegraphdefinitions.kro.run
+      storage:
+        crd: {}

--- a/operators/kro-composition-operator/internal/engine/publish.go
+++ b/operators/kro-composition-operator/internal/engine/publish.go
@@ -76,10 +76,17 @@ func (e *Engine) publishComposite(ctx context.Context, c ctrlruntimeclient.Clien
 		}
 	}
 
-	export := &kcpapisv1alpha1.APIExport{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	export := &kcpapisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, export, func() error {
 		setRGDOwner(export, rgd)
-		export.Spec.LatestResourceSchemas = []string{ars.Name}
+		export.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{
+			Name:   crd.Spec.Names.Plural,
+			Group:  crd.Spec.Group,
+			Schema: ars.Name,
+			Storage: kcpapisv1alpha2.ResourceSchemaStorage{
+				CRD: &kcpapisv1alpha2.ResourceSchemaStorageCRD{},
+			},
+		}}
 		return nil
 	}); err != nil {
 		return false, fmt.Errorf("apply APIExport %s: %w", name, err)
@@ -153,7 +160,7 @@ func teardownComposite(ctx context.Context, c ctrlruntimeclient.Client, rgd *kro
 	}}
 	kcpDefaultSecret := ctrlruntimeclient.ObjectKeyFromObject(identitySecret)
 
-	export := &kcpapisv1alpha1.APIExport{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	export := &kcpapisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	switch err := c.Get(ctx, types.NamespacedName{Name: name}, export); {
 	case err == nil:
 		if id := export.Spec.Identity; id != nil && id.SecretRef != nil && id.SecretRef.Name != "" {
@@ -349,18 +356,18 @@ func checkSchemaCompatibility(
 	}
 
 	name := compositeExportName(rgd.Name)
-	export := &kcpapisv1alpha1.APIExport{}
+	export := &kcpapisv1alpha2.APIExport{}
 	if err := c.Get(ctx, types.NamespacedName{Name: name}, export); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("get APIExport %s: %w", name, err)
 	}
-	if len(export.Spec.LatestResourceSchemas) == 0 {
+	if len(export.Spec.Resources) == 0 {
 		return nil
 	}
 
-	servedName := export.Spec.LatestResourceSchemas[0]
+	servedName := export.Spec.Resources[0].Schema
 	served := &kcpapisv1alpha1.APIResourceSchema{}
 	if err := c.Get(ctx, types.NamespacedName{Name: servedName}, served); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/operators/kro-composition-operator/internal/engine/publish_test.go
+++ b/operators/kro-composition-operator/internal/engine/publish_test.go
@@ -114,8 +114,8 @@ func TestTeardownCompositeDeletesIdentitySecret(t *testing.T) {
 	t.Run("deletes the secret kcp created, whose ref kcp populates", func(t *testing.T) {
 		t.Parallel()
 
-		export := &kcpapisv1alpha1.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
-		export.Spec.Identity = &kcpapisv1alpha1.Identity{
+		export := &kcpapisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
+		export.Spec.Identity = &kcpapisv1alpha2.Identity{
 			SecretRef: &corev1.SecretReference{Namespace: kcpDefault.Namespace, Name: kcpDefault.Name},
 		}
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
@@ -136,14 +136,14 @@ func TestTeardownCompositeDeletesIdentitySecret(t *testing.T) {
 			c.Get(context.Background(), kcpDefault, &corev1.Secret{})),
 			"identity secret %s must be deleted", kcpDefault)
 		require.True(t, apierrors.IsNotFound(
-			c.Get(context.Background(), types.NamespacedName{Name: exportName}, &kcpapisv1alpha1.APIExport{})),
+			c.Get(context.Background(), types.NamespacedName{Name: exportName}, &kcpapisv1alpha2.APIExport{})),
 			"APIExport must be deleted")
 	})
 
 	t.Run("deletes the default secret when no ref is set yet", func(t *testing.T) {
 		t.Parallel()
 
-		export := &kcpapisv1alpha1.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
+		export := &kcpapisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 			Name:      kcpDefault.Name,
 			Namespace: kcpDefault.Namespace,
@@ -166,8 +166,8 @@ func TestTeardownCompositeDeletesIdentitySecret(t *testing.T) {
 		t.Parallel()
 
 		shared := types.NamespacedName{Namespace: "custom-ns", Name: "shared-key"}
-		export := &kcpapisv1alpha1.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
-		export.Spec.Identity = &kcpapisv1alpha1.Identity{
+		export := &kcpapisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Name: exportName}}
+		export.Spec.Identity = &kcpapisv1alpha2.Identity{
 			SecretRef: &corev1.SecretReference{Namespace: shared.Namespace, Name: shared.Name},
 		}
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
@@ -472,12 +472,17 @@ func publishedClient(t *testing.T, rgd *krov1alpha1.ResourceGraphDefinition, crd
 
 	// Assert the state the compatibility check reads, so a test that expects no breaking
 	// change cannot pass merely because there was nothing to compare against.
-	export := &kcpapisv1alpha1.APIExport{}
+	export := &kcpapisv1alpha2.APIExport{}
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: compositeExportName(rgd.Name)}, export))
-	require.Len(t, export.Spec.LatestResourceSchemas, 1)
+	require.Len(t, export.Spec.Resources, 1)
+	// The entry is keyed by name+group, so a wrong one publishes the schema under a type
+	// nobody asked for rather than failing.
+	require.Equal(t, crd.Spec.Names.Plural, export.Spec.Resources[0].Name)
+	require.Equal(t, crd.Spec.Group, export.Spec.Resources[0].Group)
+	require.NotNil(t, export.Spec.Resources[0].Storage.CRD, "the type is served as a CRD")
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: export.Spec.LatestResourceSchemas[0]}, &kcpapisv1alpha1.APIResourceSchema{}))
+		types.NamespacedName{Name: export.Spec.Resources[0].Schema}, &kcpapisv1alpha1.APIResourceSchema{}))
 	return c
 }
 
@@ -557,10 +562,10 @@ func TestPublishCompositeRefusesBreakingChange(t *testing.T) {
 	served := compositeCRD(stringProps("image", "replicas"))
 	c := publishedClient(t, rgd, served)
 
-	export := &kcpapisv1alpha1.APIExport{}
+	export := &kcpapisv1alpha2.APIExport{}
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: compositeExportName(rgd.Name)}, export))
-	before := export.Spec.LatestResourceSchemas
+	before := export.Spec.Resources
 
 	_, err := (&Engine{}).publishComposite(context.Background(), c, compositeCRD(stringProps("image")), rgd)
 	require.Error(t, err)
@@ -568,7 +573,7 @@ func TestPublishCompositeRefusesBreakingChange(t *testing.T) {
 
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: compositeExportName(rgd.Name)}, export))
-	require.Equal(t, before, export.Spec.LatestResourceSchemas,
+	require.Equal(t, before, export.Spec.Resources,
 		"the export must still point at the schema it was serving")
 
 	list := &kcpapisv1alpha1.APIResourceSchemaList{}
@@ -611,7 +616,7 @@ func TestPublishCompositeRefusesForeignType(t *testing.T) {
 		require.Contains(t, err.Error(), "alpha", "the message must name the RGD holding the type")
 
 		require.Equal(t, 1, schemaCount(t, c))
-		export := &kcpapisv1alpha1.APIExport{}
+		export := &kcpapisv1alpha2.APIExport{}
 		require.True(t, apierrors.IsNotFound(
 			c.Get(context.Background(), types.NamespacedName{Name: compositeExportName("beta")}, export)),
 			"the refused RGD must not get an APIExport pointing at someone else's schema")

--- a/operators/kro-composition-operator/test/e2e/schema_change_test.go
+++ b/operators/kro-composition-operator/test/e2e/schema_change_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
 var rgdGVK = schema.GroupVersionKind{Group: "kro.run", Version: "v1alpha1", Kind: "ResourceGraphDefinition"}
@@ -142,10 +143,10 @@ func TestSchemaMetadataReachesPublishedSchema(t *testing.T) {
 // composite type from.
 func servedSchemaName(ctx context.Context, t *testing.T, c *consumer, rgdName string) string {
 	t.Helper()
-	export := &kcpapisv1alpha1.APIExport{}
+	export := &kcpapisv1alpha2.APIExport{}
 	require.NoError(t, c.Client.Get(ctx, types.NamespacedName{Name: "kro-" + rgdName}, export))
-	require.Len(t, export.Spec.LatestResourceSchemas, 1)
-	return export.Spec.LatestResourceSchemas[0]
+	require.Len(t, export.Spec.Resources, 1)
+	return export.Spec.Resources[0].Schema
 }
 
 func setSchemaSpec(ctx context.Context, t *testing.T, c *consumer, rgdName string, spec map[string]any) {

--- a/operators/kro-composition-operator/test/e2e/type_conflict_test.go
+++ b/operators/kro-composition-operator/test/e2e/type_conflict_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
 // TestTypeConflictBetweenRGDs covers two RGDs in one workspace claiming the same composite
@@ -71,7 +72,7 @@ func TestTypeConflictBetweenRGDs(t *testing.T) {
 	require.NotNil(t, kindReady.Message)
 	require.Contains(t, *kindReady.Message, "alpha", "the message must name the RGD holding the type")
 
-	export := &kcpapisv1alpha1.APIExport{}
+	export := &kcpapisv1alpha2.APIExport{}
 	require.True(t, apierrors.IsNotFound(
 		c.Client.Get(ctx, types.NamespacedName{Name: "kro-beta"}, export)),
 		"the refused RGD must not publish an APIExport")

--- a/operators/kro-composition-operator/test/e2e/uncompilable_test.go
+++ b/operators/kro-composition-operator/test/e2e/uncompilable_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
-	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
 // TestUncompilableRGDReportsWhy covers an RGD composing an API the workspace does not serve.
@@ -90,7 +90,7 @@ func TestUncompilableRGDReportsWhy(t *testing.T) {
 
 	// Nothing is published for a graph that never compiled.
 	require.True(t, apierrors.IsNotFound(
-		c.Client.Get(ctx, types.NamespacedName{Name: "kro-" + rgdName}, &kcpapisv1alpha1.APIExport{})),
+		c.Client.Get(ctx, types.NamespacedName{Name: "kro-" + rgdName}, &kcpapisv1alpha2.APIExport{})),
 		"an uncompilable RGD must not publish a type")
 
 	t.Log("composing a served API instead clears it")


### PR DESCRIPTION
Moves APIExports off the deprecated v1alpha1 in kro-composition-operator. The mirrored manifest in platform-mesh/helm-charts needs the same change.