### PR TITLE
chore (platform-mesh operator): suspend logging

### DIFF
--- a/operators/platform-mesh-operator/README.md
+++ b/operators/platform-mesh-operator/README.md
@@ -490,6 +490,29 @@ spec:
 {{ end -}}
 ```
 
+### Using External Cert-Manager
+
+If cert-manager is already installed in your cluster (via ArgoCD, manual installation, or another operator), you can disable the platform-mesh-operator's cert-manager deployment by setting `certManager.enabled: false` in your profile:
+
+```yaml
+# profile.yaml
+infra:
+  certManager:
+    enabled: false
+```
+
+**Requirements:**
+- Cert-manager CRDs must be installed: `issuers.cert-manager.io`, `certificates.cert-manager.io`
+- Cert-manager controller must be running and processing Certificate resources
+- The deployment name and namespace don't matter — the operator only validates CRDs exist
+
+**How it works:**
+The operator will:
+- Skip creating HelmRelease/Application for cert-manager
+- Validate that cert-manager CRDs are established
+- Create its own Issuer and Certificate resources in `platform-mesh-system` for authorization webhooks
+- Requeue if CRDs are not yet available
+
 ## Remote Deployment
 
 The operator supports multi-cluster deployment where the operator process runs in a **local** cluster but manages resources on separate **runtime** and **infra** clusters.

--- a/operators/platform-mesh-operator/README.md
+++ b/operators/platform-mesh-operator/README.md
@@ -502,11 +502,13 @@ infra:
 ```
 
 **Requirements:**
+
 - Cert-manager CRDs must be installed: `issuers.cert-manager.io`, `certificates.cert-manager.io`
 - Cert-manager controller must be running and processing Certificate resources
 - The deployment name and namespace don't matter — the operator only validates CRDs exist
 
 **How it works:**
+
 The operator will:
 - Skip creating HelmRelease/Application for cert-manager
 - Validate that cert-manager CRDs are established

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment_helpers.go
@@ -489,6 +489,19 @@ func (r *DeploymentSubroutine) infraManifestPostProcess(ctx context.Context, log
 		}
 		if obj.GetKind() == "HelmRelease" && obj.GetAPIVersion() == "helm.toolkit.fluxcd.io/v2" {
 			r.mergeImageVersionsIntoHelmReleaseValues(obj, obj.GetName(), obj.GetNamespace(), log)
+
+			// Diagnostic logging for suspended HelmReleases waiting on image injection
+			suspended, found, _ := unstructured.NestedBool(obj.Object, "spec", "suspend")
+			if found && suspended && r.imageVersionStore != nil {
+				// Check if this HelmRelease has been unsuspended by ResourceSubroutine
+				if !r.imageVersionStore.IsUnsuspended(obj.GetNamespace(), obj.GetName()) {
+					// HelmRelease is suspended and has not been unsuspended yet - likely waiting for image injection
+					log.Warn().
+						Str("helmRelease", obj.GetName()).
+						Str("namespace", obj.GetNamespace()).
+						Msg("HelmRelease created in suspended state. It will remain suspended until ResourceSubroutine processes OCM imageResources and sets suspend=false. If this HelmRelease never starts, verify that its imageResources configuration includes an entry with 'unsuspend: \"true\"' annotation.")
+				}
+			}
 		}
 		return nil
 	}

--- a/operators/platform-mesh-operator/pkg/subroutines/resource/subroutine.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/resource/subroutine.go
@@ -334,6 +334,12 @@ func (r *ResourceSubroutine) updateHelmReleaseImage(ctx context.Context, inst *u
 	}
 	if getMetadataValue(inst, "unsuspend") == "true" {
 		r.storeUnsuspended(namespace, name)
+		log.Info().
+			Str("helmRelease", name).
+			Str("namespace", namespace).
+			Str("resource", inst.GetName()).
+			Str("version", version).
+			Msg("Image injection complete - HelmRelease unsuspended and ready for reconciliation")
 	}
 	return subroutineslib.OK(), nil
 }


### PR DESCRIPTION
This pr is related to this issue https://github.com/platform-mesh/helm-charts/issues/2394

## Description
1. adds logging in platform-mesh operator about suspension of HelmReleases, it will help to identify what's happening with a HelmRelease. As well documentation about image injection from ocm resources is added
2. adds documentation about running Platfrom Mesh with external cert manager