### PR TITLE
replace todo contexts with test contexts

### DIFF
--- a/operators/platform-mesh-operator/pkg/subroutines/kcpsetup_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/kcpsetup_test.go
@@ -651,6 +651,8 @@ users:
 }
 
 func (s *KcpsetupTestSuite) Test_getAPIExportHashInventory() {
+	ctx := s.T().Context()
+
 	// mocks
 	mockKcpClient := new(mocks.Client)
 	mockedKcpHelper := new(mocks.KcpHelper)
@@ -676,7 +678,7 @@ func (s *KcpsetupTestSuite) Test_getAPIExportHashInventory() {
 			return errors.New("error")
 		}).Once()
 
-	inventory, err := s.testObj.GetAPIExportHashInventory(context.TODO(), &rest.Config{})
+	inventory, err := s.testObj.GetAPIExportHashInventory(ctx, &rest.Config{})
 	s.Assert().Error(err)
 	s.Assert().Equal(map[string]string{
 		"apiExportRootTenancyKcpIoIdentityHash": "hash1",
@@ -697,7 +699,7 @@ func (s *KcpsetupTestSuite) Test_getAPIExportHashInventory() {
 			return errors.New("error")
 		}).Once()
 
-	inventory, err = s.testObj.GetAPIExportHashInventory(context.TODO(), &rest.Config{})
+	inventory, err = s.testObj.GetAPIExportHashInventory(ctx, &rest.Config{})
 	s.Assert().Error(err)
 	s.Assert().Equal(map[string]string{
 		"apiExportRootTenancyKcpIoIdentityHash": "hash1",
@@ -711,14 +713,14 @@ func (s *KcpsetupTestSuite) Test_getAPIExportHashInventory() {
 			return errors.New("error")
 		}).Once()
 
-	inventory, err = s.testObj.GetAPIExportHashInventory(context.TODO(), &rest.Config{})
+	inventory, err = s.testObj.GetAPIExportHashInventory(ctx, &rest.Config{})
 	s.Assert().Error(err)
 	s.Assert().Equal(map[string]string{}, inventory)
 
 	// test error 4
 	mockedKcpHelper.EXPECT().NewKcpClient(mock.Anything, mock.Anything).
 		Return(nil, errors.New("Error")).Once()
-	inventory, err = s.testObj.GetAPIExportHashInventory(context.TODO(), &rest.Config{})
+	inventory, err = s.testObj.GetAPIExportHashInventory(ctx, &rest.Config{})
 	s.Assert().Error(err)
 	s.Assert().Equal(map[string]string{}, inventory)
 }

--- a/operators/platform-mesh-operator/pkg/subroutines/resource/subroutine_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/resource/subroutine_test.go
@@ -52,7 +52,7 @@ func (s *ResourceTestSuite) SetupTest() {
 }
 
 func (s *ResourceTestSuite) Test_applyReleaseWithValues() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -109,7 +109,7 @@ func (s *ResourceTestSuite) Test_GetName() {
 }
 
 func (s *ResourceTestSuite) Test_Finalize() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	inst := &unstructured.Unstructured{}
 	result, err := s.subroutine.Finalize(ctx, inst)
 	s.Nil(err)
@@ -255,7 +255,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			ctx := context.TODO()
+			ctx := s.T().Context()
 
 			annotations := map[string]any{
 				"artifact": tt.artifact,
@@ -335,7 +335,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag() {
 }
 
 func (s *ResourceTestSuite) Test_updateGitRepo() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -396,7 +396,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo() {
 }
 
 func (s *ResourceTestSuite) Test_updateGitRepo_CreateOrUpdateError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -436,7 +436,7 @@ func (s *ResourceTestSuite) Test_updateGitRepo_CreateOrUpdateError() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmRepository() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -510,7 +510,7 @@ func (s *ResourceTestSuite) Test_updateHelmRepository() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmRepository_MissingURL() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -544,7 +544,7 @@ func (s *ResourceTestSuite) Test_updateHelmRepository_MissingURL() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmRelease() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -603,7 +603,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmRelease_GetError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -643,7 +643,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease_GetError() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmRelease_UpdateError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -695,7 +695,7 @@ func (s *ResourceTestSuite) Test_updateHelmRelease_UpdateError() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_GetError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -730,7 +730,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_GetError() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_UpdateError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -777,7 +777,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseWithImageTag_UpdateError() {
 }
 
 func (s *ResourceTestSuite) Test_updateOciRepo_ParseRefError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -814,7 +814,7 @@ func (s *ResourceTestSuite) Test_updateOciRepo_ParseRefError() {
 }
 
 func (s *ResourceTestSuite) Test_updateOciRepo_CreateOrUpdateError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -854,7 +854,7 @@ func (s *ResourceTestSuite) Test_updateOciRepo_CreateOrUpdateError() {
 }
 
 func (s *ResourceTestSuite) Test_Process_NoAnnotations() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -874,7 +874,7 @@ func (s *ResourceTestSuite) Test_Process_NoAnnotations() {
 }
 
 func (s *ResourceTestSuite) Test_updateArgoCDApplication_HelmRepo() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -933,7 +933,7 @@ func (s *ResourceTestSuite) Test_updateArgoCDApplication_HelmRepo() {
 }
 
 func (s *ResourceTestSuite) Test_updateArgoCDApplication_AlreadyUpToDate() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -980,7 +980,7 @@ func (s *ResourceTestSuite) Test_updateArgoCDApplication_AlreadyUpToDate() {
 }
 
 func (s *ResourceTestSuite) Test_updateArgoCDApplicationHelmValues() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1128,7 +1128,7 @@ func (s *ResourceTestSuite) Test_SetRuntimeClient() {
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_InfraDeploymentNamespace() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	clientMock := new(mocks.Client)
 	sub := NewResourceSubroutine(clientMock, nil, nil)
 
@@ -1149,7 +1149,7 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_InfraDeploymentNames
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeploymentNamespace() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	clientMock := new(mocks.Client)
 	sub := NewResourceSubroutine(clientMock, nil, nil)
 
@@ -1170,7 +1170,7 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_ComponentsDeployment
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_Fallback() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	clientMock := new(mocks.Client)
 	sub := NewResourceSubroutine(clientMock, nil, nil)
 
@@ -1183,7 +1183,7 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_Fallback() {
 }
 
 func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_NoDeploymentNamespace() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	clientMock := new(mocks.Client)
 	sub := NewResourceSubroutine(clientMock, nil, nil)
 
@@ -1207,7 +1207,7 @@ func (s *ResourceTestSuite) Test_getAppNamespaceFromProfile_NoDeploymentNamespac
 }
 
 func (s *ResourceTestSuite) Test_updateArgoCDApplication_UsesDeploymentNamespace() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1510,7 +1510,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			ctx := context.TODO()
+			ctx := s.T().Context()
 
 			annotations := map[string]any{
 				"artifact": tt.artifact,
@@ -1622,7 +1622,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_StoresResolvedTag() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	store := subroutines.NewImageVersionStore()
 
 	inst := imageResource("test-resource",
@@ -1654,7 +1654,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_StoresResolvedTag() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_RemovesStaleCoordinatesFromStore() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	store := subroutines.NewImageVersionStore()
 	store.Set("default", "test-resource", "image.registry", "stale-registry")
 	store.Set("default", "test-resource", "image.repository", "stale/repo")
@@ -1678,7 +1678,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_RemovesStaleCoordinatesF
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_StoresCoordinatesAtCustomPath() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	store := subroutines.NewImageVersionStore()
 
 	inst := imageResource("test-resource",
@@ -1707,7 +1707,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_StoresCoordinatesAtCusto
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_PathLeafCollision() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := imageResource("test-resource",
 		map[string]any{"artifact": "image", "repo": "oci", "path": "image.registry"},
@@ -1747,7 +1747,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_PathLeafCollision() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_CombinedRefStyle() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	store := subroutines.NewImageVersionStore()
 
 	inst := imageResource("openfga-image",
@@ -1803,7 +1803,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_CombinedRefStyle() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_GetError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1849,7 +1849,7 @@ func (s *ResourceTestSuite) Test_updateHelmReleaseImage_GetError() {
 }
 
 func (s *ResourceTestSuite) Test_updateHelmReleaseImage_UpdateError() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	inst := &unstructured.Unstructured{
 		Object: map[string]any{

--- a/operators/platform-mesh-operator/test/e2e/kind/kind_operator_test.go
+++ b/operators/platform-mesh-operator/test/e2e/kind/kind_operator_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -38,7 +37,7 @@ func TestKindSuite(t *testing.T) {
 }
 
 func (s *KindTestSuite) Test01ResourceReady() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	s.Eventually(func() bool {
 		pm := pmcorev1alpha1.PlatformMesh{}
@@ -62,7 +61,7 @@ func (s *KindTestSuite) Test01ResourceReady() {
 }
 
 func (s *KindTestSuite) Test02ExtraWorkspaces() {
-	ctx := context.TODO()
+	ctx := s.T().Context()
 
 	pm := pmcorev1alpha1.PlatformMesh{}
 	err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{

--- a/operators/platform-mesh-operator/test/e2e/kind/kind_scoped_kubeconfig_test.go
+++ b/operators/platform-mesh-operator/test/e2e/kind/kind_scoped_kubeconfig_test.go
@@ -191,7 +191,7 @@ func (s *KindTestSuite) waitScopedProviderConnectionSecretsReady(ctx context.Con
 // instance for that export (virtual workspace server).
 func (s *KindTestSuite) TestScoped02KubeconfigProvider1() {
 	s.logger.Info().Str("kind_e2e", "TestScoped02KubeconfigProvider1").Msg("start")
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	s.scopedWaitPlatformMeshReady(ctx)
 
 	sec := s.requireE2EProviderKubeconfigSecret(ctx, e2eScopedKubeconfigProvider1SecretName)
@@ -224,7 +224,7 @@ spec:
 // Test creates an E2EProviderConfig resource with that kubeconfig only (no APIExport creation in the test).
 func (s *KindTestSuite) TestScoped03KubeconfigProvider2() {
 	s.logger.Info().Str("kind_e2e", "TestScoped03KubeconfigProvider2").Msg("start")
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	s.scopedWaitPlatformMeshReady(ctx)
 
 	sec := s.requireE2EProviderKubeconfigSecret(ctx, e2eScopedKubeconfigProvider2SecretName)
@@ -256,7 +256,7 @@ spec:
 // Provider3: extraProviderConnections entry with adminAuth true — same slice-based virtual workspace wiring as default providers, admin cert material.
 func (s *KindTestSuite) TestScoped04ExtraProviderAdminKubeconfigProvider3() {
 	s.logger.Info().Str("kind_e2e", "TestScoped04ExtraProviderAdminKubeconfigProvider3").Msg("start")
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	s.scopedWaitPlatformMeshReady(ctx)
 
 	sec := s.requireE2EProviderKubeconfigSecret(ctx, e2eAdminKubeconfigProvider3SecretName)

--- a/operators/platform-mesh-operator/test/e2e/kind/suite_kind_test.go
+++ b/operators/platform-mesh-operator/test/e2e/kind/suite_kind_test.go
@@ -265,7 +265,7 @@ func (s *KindTestSuite) createKindCluster() error {
 	s.config = configClient
 
 	pods := &corev1.PodList{}
-	err = s.client.List(context.TODO(), pods, &ctrlruntimeclient.ListOptions{
+	err = s.client.List(s.T().Context(), pods, &ctrlruntimeclient.ListOptions{
 		Namespace: "kube-system",
 	})
 	if err != nil {


### PR DESCRIPTION
IMHO a TODO context indicates "this code right here should take a context from the calling function, but is currently not provided one. So we leave a TODO comment". Meaning that one should grep for `TODO` in a codebase and find actual contexts where something in the callstack should be improved.

Using a TODO context in any other way is IMHO misleading. For example in tests one should simply use a background context, since there would never ever be a situation where something in the callstack of a unit test would suddenly change (or even be changable).

Since we're on a recent Go version, we can in our case simply make use of `t.Context()` and call it a day. :)