### PR TITLE
fix(contentconfiguration): load portal web components as ES modules

### DIFF
--- a/operators/kro-composition-operator/config/provider/contentconfiguration.yaml
+++ b/operators/kro-composition-operator/config/provider/contentconfiguration.yaml
@@ -43,7 +43,7 @@ spec:
                 "entityType": "main.core_platform-mesh_io_account",
                 "keepSelectedForChildren": true,
                 "url": "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
-                "webcomponent": { "selfRegistered": true },
+                "webcomponent": { "selfRegistered": true, "type": "module" },
                 "context": {
                   "resourceDefinition": {
                     "apiGroup": "kro_run",
@@ -88,7 +88,7 @@ spec:
                 "pathSegment": "dashboard",
                 "label": "Dashboard",
                 "url": "/assets/platform-mesh-portal-ui-wc.js#generic-detail-view",
-                "webcomponent": { "selfRegistered": true },
+                "webcomponent": { "selfRegistered": true, "type": "module" },
                 "defineEntity": { "id": "dashboard" },
                 "compound": { "children": [] }
               }

--- a/operators/kro-composition-operator/internal/composition/contentconfig.go
+++ b/operators/kro-composition-operator/internal/composition/contentconfig.go
@@ -94,7 +94,7 @@ func BuildContentConfig(group, version, kind, plural string, namespaced bool, sp
 		"entityType":              "main." + AccountEntity,
 		"keepSelectedForChildren": true,
 		"url":                     "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
-		"webcomponent":            map[string]any{"selfRegistered": true},
+		"webcomponent":            map[string]any{"selfRegistered": true, "type": "module"},
 		"context": map[string]any{
 			"resourceDefinition": map[string]any{
 				"apiGroup": ug,
@@ -135,7 +135,7 @@ func BuildContentConfig(group, version, kind, plural string, namespaced bool, sp
 		"pathSegment":  "dashboard",
 		"label":        "Overview",
 		"url":          "/assets/platform-mesh-portal-ui-wc.js#generic-detail-view",
-		"webcomponent": map[string]any{"selfRegistered": true},
+		"webcomponent": map[string]any{"selfRegistered": true, "type": "module"},
 		"defineEntity": map[string]any{"id": "dashboard"},
 		"compound":     map[string]any{"children": []any{}},
 	}

--- a/operators/platform-mesh-operator/manifests/features/feature-accounts-in-accounts/01-platform-mesh-system/contentconfiguration-account-accounts.yaml
+++ b/operators/platform-mesh-operator/manifests/features/feature-accounts-in-accounts/01-platform-mesh-system/contentconfiguration-account-accounts.yaml
@@ -40,7 +40,8 @@ spec:
                           "keepSelectedForChildren": true,
                           "url": "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
                           "webcomponent": {
-                              "selfRegistered": true
+                              "selfRegistered": true,
+                              "type": "module"
                           },
                           "children": [
                               {

--- a/operators/platform-mesh-operator/manifests/features/feature-enable-getting-started/01-platform-mesh-system/contentconfiguration-main-home-overview-getting-started.yaml
+++ b/operators/platform-mesh-operator/manifests/features/feature-enable-getting-started/01-platform-mesh-system/contentconfiguration-main-home-overview-getting-started.yaml
@@ -35,7 +35,8 @@ spec:
                   "column": "1 / -1"
                 },
                 "webcomponent": {
-                  "selfRegistered": true
+                  "selfRegistered": true,
+                  "type": "module"
                 }
               }
             ]

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-home.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-home.yaml
@@ -35,7 +35,8 @@ spec:
                 "order": 100,
                 "url": "/assets/platform-mesh-portal-ui-wc.js#generic-detail-view",
                 "webcomponent": {
-                  "selfRegistered": true
+                  "selfRegistered": true,
+                  "type": "module"
                 },
                 "defineEntity": {
                     "id": "dashboard"

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-namespace.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-account-namespace.yaml
@@ -46,7 +46,8 @@ spec:
                           "keepSelectedForChildren": true,
                           "url": "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
                           "webcomponent": {
-                              "selfRegistered": true
+                              "selfRegistered": true,
+                              "type": "module"
                           },
                           "context": {
                               "resourceDefinition": {

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-main-accounts.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-main-accounts.yaml
@@ -40,7 +40,8 @@ spec:
                           "keepSelectedForChildren": true,
                           "url": "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
                           "webcomponent": {
-                              "selfRegistered": true
+                              "selfRegistered": true,
+                              "type": "module"
                           },
                           "context": {
                               "resourceDefinition": {

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-main-os-accounts.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/contentconfiguration-main-os-accounts.yaml
@@ -41,7 +41,8 @@ spec:
                           "keepSelectedForChildren": true,
                           "url": "/assets/platform-mesh-portal-ui-wc.js#generic-os-list-view",
                           "webcomponent": {
-                              "selfRegistered": true
+                              "selfRegistered": true,
+                              "type": "module"
                           },
                           "context": {
                               "resourceDefinition": {


### PR DESCRIPTION
## Changes

Declare `webcomponent.type: "module"` on every node that points at `platform-mesh-portal-ui-wc.js`, so Luigi injects it as a module script.

## Why

`@platform-mesh/portal-ui-lib` moved to Angular 22, which replaced the webpack `ngx-build-plus` build of the web