### PR TITLE
fix(marketplace): use identityHash to skip unestablished APIExports

### DIFF
--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -241,7 +241,7 @@ func Marketplace(
 					if logicalcluster.From(&export) != providerClusterID {
 						continue
 					}
-					if len(export.Spec.LatestResourceSchemas) == 0 {
+					if export.Status.IdentityHash == "" {
 						continue
 					}
 

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -84,6 +84,9 @@ func makeExport(cfg config.ServiceConfig, name, clusterID, provider string) *kcp
 		Spec: kcpapisv1alpha1.APIExportSpec{
 			LatestResourceSchemas: []string{"v260810" + name},
 		},
+		Status: kcpapisv1alpha1.APIExportStatus{
+			IdentityHash: "testhash-" + name,
+		},
 	}
 }
 
@@ -243,4 +246,56 @@ func TestMarketplace_ExportsWithoutMatchingProvider(t *testing.T) {
 	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)
 
 	assert.Empty(t, list.Items, "should skip unknown providers")
+}
+
+func TestMarketplace_UIOnlyExportWithNoSchemas(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	uiOnlyExport := &kcpapisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testExportName,
+			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
+			Labels:      map[string]string{cfg.ContentForLabel: testProviderName},
+		},
+		Spec: kcpapisv1alpha1.APIExportSpec{},
+		Status: kcpapisv1alpha1.APIExportStatus{
+			IdentityHash: "testhash-ui-only",
+		},
+	}
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(testProviderClusterID), uiOnlyExport).
+		Build()
+
+	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)
+
+	require.Len(t, list.Items, 1, "UI-only export with no schemas but established identityHash should appear in Marketplace")
+}
+
+func TestMarketplace_UnestablishedExportSkipped(t *testing.T) {
+	cfg := config.NewServiceConfig()
+	s := marketplaceTestScheme(t)
+
+	unestablishedExport := &kcpapisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testExportName,
+			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
+			Labels:      map[string]string{cfg.ContentForLabel: testProviderName},
+		},
+		Spec: kcpapisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"v1.myresources.example.com"},
+		},
+		Status: kcpapisv1alpha1.APIExportStatus{},
+	}
+
+	lister := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(makeProviderMeta(testProviderClusterID), unestablishedExport).
+		Build()
+
+	list := listMarketplace(t, lister, fake.NewClientBuilder().WithScheme(s).Build(), cfg)
+
+	assert.Empty(t, list.Items, "export with schemas but empty identityHash should be skipped")
 }


### PR DESCRIPTION
## What

In `services/virtual-workspaces/pkg/storage/filter.go`, the `Marketplace()` function skips `APIExport`s with `len(latestResourceSchemas) == 0`. This PR replaces that condition with `export.Status.IdentityHash == ""`.

## Why

The `latestResourceSchemas` check was intended to skip exports that are not yet established. But it conflates two distinct states:

1. **Not yet established** — kcp has not set the identity hash; the export cannot accept bindings yet.
2. **UI-only** — the provider intentionally exposes no CRD (no resource schemas), but is fully established and ready to accept bindings.

`status.identityHash` is the correct readiness signal. Looking at the kcp APIExport reconciler (`pkg/reconciler/apis/apiexport/apiexport_reconcile.go`), the lifecycle is:
- **Reconciliation 1**: kcp creates the identity secret and sets `spec.identity.secretRef`, then returns early — `status.identityHash` is still empty at this point.
- **Reconciliation 2**: kcp reads the secret, SHA-256 hashes the key, and writes the result to `status.identityHash`. Once set it is immutable.

`identityHash` is therefore the authoritative signal that the export is established and can accept bindings — independent of whether any `APIResourceSchema`s are referenced.

## Impact

With the previous check, any UI-only provider (portal navigation / micro-frontend, no operator CRD) is permanently excluded from the Marketplace catalog even after its workspace resources are fully applied. All four existing local-setup providers happen to have schemas so this was never hit — but migrating the first UI-only extension (`cloud-orchestrator`) uncovered the bug.

After this change, UI-only providers appear in the Marketplace as soon as `identityHash` is set.

## Side effects and edge cases

**Transient empty hash (first reconciliation window):** An `APIExport` will briefly have an empty `identityHash` between the first and second reconciliation cycle (typically sub-second). During this window the Marketplace skips it — identical to the previous behavior where a schema-less export was always skipped. This self-resolves.

**Empty `APIBinding` for UI-only exports:** When a UI-only export is installed, the `APIBinding` is created with an empty bound API group — there are no schemas for kcp to project. This is intentional: the binding scopes the consumer workspace to the provider, and the portal renders the `ContentConfiguration`. No functional regression for existing schema-carrying providers.

**Exports with schemas:** Behavior is unchanged — they have a non-empty `identityHash` once established, so they continue to appear exactly as before.

## Changes

- `filter.go`: one-line guard change.
- `marketplace_test.go`: updated `makeExport` fixture to set `Status.IdentityHash` (required by the new check); added two new tests:
  - `TestMarketplace_UIOnlyExportWithNoSchemas` — export with no schemas but established `identityHash` appears in Marketplace.
  - `TestMarketplace_UnestablishedExportSkipped` — export with schemas but empty `identityHash` is still skipped.

Discovered while validating the HSP → Platform Mesh extension migration end-to-end on a local kind cluster (DXPFRAME-2475).