### PR TITLE
fix(marketplace)!: Migrate marketplaceentry APIExport to v1alpha2 in vw service - #337

### DIFF
--- a/apis/marketplace/v1alpha1/marketplaceentry_types.go
+++ b/apis/marketplace/v1alpha1/marketplaceentry_types.go
@@ -21,7 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
 // MarketplaceEntrySpec defines the desired state of MarketplaceEntry.
@@ -35,7 +35,7 @@ type MarketplaceEntrySpec struct {
 	ProviderMetadata pmuiv1alpha1.ProviderMetadata `json:"providerMetadata"`
 
 	// PermissionClaims are the permission claims associated with the marketplace entry.
-	APIExport kcpapisv1alpha1.APIExport `json:"apiExport"`
+	APIExport kcpapisv1alpha2.APIExport `json:"apiExport"`
 }
 
 // MarketplaceEntryStatus defines the observed state of MarketplaceEntry.

--- a/apis/marketplace/v1alpha1/marketplaceentry_types.go
+++ b/apis/marketplace/v1alpha1/marketplaceentry_types.go
@@ -34,7 +34,7 @@ type MarketplaceEntrySpec struct {
 	// ProviderMetadata contains metadata about the provider of the marketplace entry.
 	ProviderMetadata pmuiv1alpha1.ProviderMetadata `json:"providerMetadata"`
 
-	// PermissionClaims are the permission claims associated with the marketplace entry.
+	// APIExport associated with the marketplace entry.
 	APIExport kcpapisv1alpha2.APIExport `json:"apiExport"`
 }
 

--- a/apis/marketplace/v1alpha1/roundtrip_fuzz_test.go
+++ b/apis/marketplace/v1alpha1/roundtrip_fuzz_test.go
@@ -50,13 +50,14 @@ var marketplaceEntrySeeds = []struct {
 			"apiExport": {
 				"metadata": {"name": "test-api-export", "annotations": {"kcp.io/path": "root:providers:foo"}},
 				"spec": {
-					"latestResourceSchemas": ["v260623-482e10b2.widgets.foo.io"],
+					"resources": [{"group": "foo.io", "name": "widgets",
+					 "schema": "v260623-482e10b2.widgets.foo.io", "storage": {"crd": {}}}],
 					"identity": {"secretRef": {"name": "widgets-identity", "namespace": "kcp-system"}},
 					"maximalPermissionPolicy": {"local": {}},
 					"permissionClaims": [
-						{"group": "", "resource": "secrets", "all": true, "identityHash": "abc123"},
-						{"group": "apps", "resource": "deployments",
-						 "resourceSelector": [{"name": "one", "namespace": "two"}]}
+						{"group": "", "resource": "secrets", "verbs": ["*"], "identityHash": "abc123"},
+						{"group": "apps", "resource": "deployments", "verbs": ["get", "list"],
+						 "defaultSelector": {"matchAll": true}}
 					]
 				}
 			}

--- a/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
+++ b/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
@@ -115,20 +115,6 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
-                      latestResourceSchemas:
-                        description: |-
-                          latestResourceSchemas records the latest APIResourceSchemas that are exposed
-                          with this APIExport.
-
-                          The schemas can be changed in the life-cycle of the APIExport. These changes
-                          have no effect on existing APIBindings, but only on newly bound ones.
-
-                          For updating existing APIBindings, use an APIDeployment keeping bound
-                          workspaces up-to-date.
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: set
                       maximalPermissionPolicy:
                         description: |-
                           maximalPermissionPolicy will allow for a service provider to set an upper bound on what is allowed
@@ -145,13 +131,6 @@ spec:
                           but in addition the RBAC policy here in the APIExport workspace has to grant access to the
                           user `apis.kcp.io:binding:adam` with the groups `apis.kcp.io:binding:system:authenticated`
                           and `apis.kcp.io:binding:a-team`.
-
-                          If an APIExport with a maximalPermissionPolicy is deleted, these additional checks will no longer
-                          be applied to resources of this APIExport.
-
-                          For example: Assume an APIExport with a maximalPermissionPolicy that only allows creation and
-                          deletion of resources, but not updates - if the APIExport is deleted users will be able to update
-                          the resources of the APIExport again (given the constraints of their workspace's RBAC policies).
                         properties:
                           local:
                             description: local is the policy that is defined in same
@@ -176,18 +155,73 @@ spec:
                             Its purpose is to determine the added permissions that a service provider may
                             request and that a consumer may accept and allow the service provider access to.
                           properties:
-                            all:
+                            defaultSelector:
                               description: |-
-                                all claims all resources for the given group/resource.
-                                This is mutually exclusive with resourceSelector.
-                              type: boolean
+                                defaultSelector is the default selector to use when creating APIBindings
+                                via WorkspaceType's defaultAPIBindings. If not set, the APIBinding will
+                                default to matchAll: true.
+
+                                This allows API providers to suggest a default scope for permission claims
+                                that will be used when workspaces are automatically created with default
+                                APIBindings. Users can always override the default selector by accepting the
+                                claim with a different selector or by manually creating APIBindings with a custom selector.
+                              properties:
+                                matchAll:
+                                  description: matchAll grants access to all objects
+                                    of the claimed resource.
+                                  type: boolean
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
                             group:
+                              default: ""
                               description: |-
                                 group is the name of an API group.
                                 For core groups this is the empty string '""'.
                               pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
                               type: string
                             identityHash:
+                              default: ""
                               description: |-
                                 This is the identity for a given APIExport that the APIResourceSchema belongs to.
                                 The hash can be found on APIExport and APIResourceSchema's status.
@@ -201,42 +235,114 @@ spec:
                                 not provided by an api export.
                               pattern: ^[a-z][-a-z0-9]*[a-z0-9]$
                               type: string
-                            resourceSelector:
-                              description: resourceSelector is a list of claimed resource
-                                selectors.
+                            verbs:
+                              description: |-
+                                verbs is a list of supported API operation types (this includes
+                                but is not limited to get, list, watch, create, update, patch,
+                                delete, deletecollection, and proxy).
                               items:
-                                properties:
-                                  name:
-                                    description: |-
-                                      name of an object within a claimed group/resource.
-                                      It matches the metadata.name field of the underlying object.
-                                      If namespace is unset, all objects matching that name will be claimed.
-                                    maxLength: 253
-                                    minLength: 1
-                                    pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      namespace containing the named object. Matches metadata.namespace field.
-                                      If "name" is unset, all objects from the namespace are being claimed.
-                                    minLength: 1
-                                    type: string
-                                type: object
-                                x-kubernetes-validations:
-                                - message: at least one field must be set
-                                  rule: has(self.__namespace__) || has(self.name)
+                                type: string
+                              minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                           required:
                           - resource
+                          - verbs
                           type: object
-                          x-kubernetes-validations:
-                          - message: either "all" or "resourceSelector" must be set
-                            rule: (has(self.all) && self.all) != (has(self.resourceSelector)
-                              && size(self.resourceSelector) > 0)
                         type: array
                         x-kubernetes-list-map-keys:
                         - group
                         - resource
+                        x-kubernetes-list-type: map
+                      resources:
+                        description: |-
+                          Resources records the APIResourceSchemas that are exposed with this
+                          APIExport.
+
+                          The schemas can be changed in the life-cycle of the APIExport. These changes
+                          have no effect on existing APIBindings, but only on newly bound ones.
+
+                          For updating existing APIBindings, use an APIDeployment keeping bound
+                          workspaces up-to-date.
+                        items:
+                          description: ResourceSchema defines the resource schemas
+                            that are exposed with this APIExport.
+                          properties:
+                            group:
+                              description: Group is the API group of the resource.
+                                Empty string represents the core group.
+                              type: string
+                            name:
+                              description: Name is the name of the resource.
+                              type: string
+                            schema:
+                              description: |-
+                                Schema is the name of the referenced APIResourceSchema. This must be of the format
+                                "<version>.<name>.<group>".
+                              type: string
+                            storage:
+                              default:
+                                crd: {}
+                              description: Storage defines how the resource is stored.
+                              properties:
+                                crd:
+                                  description: |-
+                                    CRD storage defines that this APIResourceSchema is exposed as
+                                    CustomResourceDefinitions inside the workspaces that bind to the APIExport.
+                                    Like in vanilla Kubernetes, users can then create, update and delete
+                                    custom resources.
+                                  type: object
+                                virtual:
+                                  description: |-
+                                    Virtual storage defines that this APIResourceSchema is exposed as
+                                    a projection of the referenced resource inside the workspaces that
+                                    bind to the APIExport.
+                                  properties:
+                                    identityHash:
+                                      description: IdentityHash is the identity of
+                                        the virtual resource.
+                                      type: string
+                                    reference:
+                                      description: |-
+                                        Reference points to another object that has a URL to a virtual workspace
+                                        in a "url" field in its status. The object can be of any kind.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - identityHash
+                                  - reference
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of crd or virtual must be set
+                                rule: has(self.crd) != has(self.virtual)
+                          required:
+                          - group
+                          - name
+                          - schema
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - group
                         x-kubernetes-list-type: map
                     type: object
                   status:
@@ -297,8 +403,11 @@ spec:
                       virtualWorkspaces:
                         description: |-
                           virtualWorkspaces contains all APIExport virtual workspace URLs.
+                          this field is empty unless kcp has been started with the
+                          'EnableDeprecatedAPIExportVirtualWorkspacesUrls' feature gate.
 
-                          Deprecated: use APIExportEndpointSlice.status.endpoints instead
+                          Deprecated: use APIExportEndpointSlice.status.endpoints instead. This
+                          field will be removed in an upcoming API version.
                         items:
                           properties:
                             url:

--- a/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
+++ b/services/virtual-workspaces/config/crd/bases/marketplace.platform-mesh.io_marketplaceentries.yaml
@@ -58,8 +58,7 @@ spec:
                   Empty means not installed.
                 type: string
               apiExport:
-                description: PermissionClaims are the permission claims associated
-                  with the marketplace entry.
+                description: APIExport associated with the marketplace entry.
                 properties:
                   apiVersion:
                     description: |-

--- a/services/virtual-workspaces/config/resources/apiexport-marketplace.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiexport-marketplace.platform-mesh.io.yaml
@@ -20,7 +20,7 @@ spec:
   resources:
   - group: marketplace.platform-mesh.io
     name: marketplaceentries
-    schema: v260817-34f4400b.marketplaceentries.marketplace.platform-mesh.io
+    schema: v260827-27c8d645.marketplaceentries.marketplace.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/services/virtual-workspaces/config/resources/apiexport-marketplace.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiexport-marketplace.platform-mesh.io.yaml
@@ -20,7 +20,7 @@ spec:
   resources:
   - group: marketplace.platform-mesh.io
     name: marketplaceentries
-    schema: v260817-a47fd3e4.marketplaceentries.marketplace.platform-mesh.io
+    schema: v260817-34f4400b.marketplaceentries.marketplace.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/services/virtual-workspaces/config/resources/apiresourceschema-marketplaceentries.marketplace.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiresourceschema-marketplaceentries.marketplace.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260817-34f4400b.marketplaceentries.marketplace.platform-mesh.io
+  name: v260827-27c8d645.marketplaceentries.marketplace.platform-mesh.io
 spec:
   group: marketplace.platform-mesh.io
   names:
@@ -55,8 +55,7 @@ spec:
                 Empty means not installed.
               type: string
             apiExport:
-              description: PermissionClaims are the permission claims associated with
-                the marketplace entry.
+              description: APIExport associated with the marketplace entry.
               properties:
                 apiVersion:
                   description: |-

--- a/services/virtual-workspaces/config/resources/apiresourceschema-marketplaceentries.marketplace.platform-mesh.io.yaml
+++ b/services/virtual-workspaces/config/resources/apiresourceschema-marketplaceentries.marketplace.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260817-a47fd3e4.marketplaceentries.marketplace.platform-mesh.io
+  name: v260817-34f4400b.marketplaceentries.marketplace.platform-mesh.io
 spec:
   group: marketplace.platform-mesh.io
   names:
@@ -112,20 +112,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
-                    latestResourceSchemas:
-                      description: |-
-                        latestResourceSchemas records the latest APIResourceSchemas that are exposed
-                        with this APIExport.
-
-                        The schemas can be changed in the life-cycle of the APIExport. These changes
-                        have no effect on existing APIBindings, but only on newly bound ones.
-
-                        For updating existing APIBindings, use an APIDeployment keeping bound
-                        workspaces up-to-date.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: set
                     maximalPermissionPolicy:
                       description: |-
                         maximalPermissionPolicy will allow for a service provider to set an upper bound on what is allowed
@@ -142,13 +128,6 @@ spec:
                         but in addition the RBAC policy here in the APIExport workspace has to grant access to the
                         user `apis.kcp.io:binding:adam` with the groups `apis.kcp.io:binding:system:authenticated`
                         and `apis.kcp.io:binding:a-team`.
-
-                        If an APIExport with a maximalPermissionPolicy is deleted, these additional checks will no longer
-                        be applied to resources of this APIExport.
-
-                        For example: Assume an APIExport with a maximalPermissionPolicy that only allows creation and
-                        deletion of resources, but not updates - if the APIExport is deleted users will be able to update
-                        the resources of the APIExport again (given the constraints of their workspace's RBAC policies).
                       properties:
                         local:
                           description: local is the policy that is defined in same
@@ -173,18 +152,73 @@ spec:
                           Its purpose is to determine the added permissions that a service provider may
                           request and that a consumer may accept and allow the service provider access to.
                         properties:
-                          all:
+                          defaultSelector:
                             description: |-
-                              all claims all resources for the given group/resource.
-                              This is mutually exclusive with resourceSelector.
-                            type: boolean
+                              defaultSelector is the default selector to use when creating APIBindings
+                              via WorkspaceType's defaultAPIBindings. If not set, the APIBinding will
+                              default to matchAll: true.
+
+                              This allows API providers to suggest a default scope for permission claims
+                              that will be used when workspaces are automatically created with default
+                              APIBindings. Users can always override the default selector by accepting the
+                              claim with a different selector or by manually creating APIBindings with a custom selector.
+                            properties:
+                              matchAll:
+                                description: matchAll grants access to all objects
+                                  of the claimed resource.
+                                type: boolean
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
                           group:
+                            default: ""
                             description: |-
                               group is the name of an API group.
                               For core groups this is the empty string '""'.
                             pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
                             type: string
                           identityHash:
+                            default: ""
                             description: |-
                               This is the identity for a given APIExport that the APIResourceSchema belongs to.
                               The hash can be found on APIExport and APIResourceSchema's status.
@@ -198,42 +232,114 @@ spec:
                               not provided by an api export.
                             pattern: ^[a-z][-a-z0-9]*[a-z0-9]$
                             type: string
-                          resourceSelector:
-                            description: resourceSelector is a list of claimed resource
-                              selectors.
+                          verbs:
+                            description: |-
+                              verbs is a list of supported API operation types (this includes
+                              but is not limited to get, list, watch, create, update, patch,
+                              delete, deletecollection, and proxy).
                             items:
-                              properties:
-                                name:
-                                  description: |-
-                                    name of an object within a claimed group/resource.
-                                    It matches the metadata.name field of the underlying object.
-                                    If namespace is unset, all objects matching that name will be claimed.
-                                  maxLength: 253
-                                  minLength: 1
-                                  pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
-                                  type: string
-                                namespace:
-                                  description: |-
-                                    namespace containing the named object. Matches metadata.namespace field.
-                                    If "name" is unset, all objects from the namespace are being claimed.
-                                  minLength: 1
-                                  type: string
-                              type: object
-                              x-kubernetes-validations:
-                              - message: at least one field must be set
-                                rule: has(self.__namespace__) || has(self.name)
+                              type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                         required:
                         - resource
+                        - verbs
                         type: object
-                        x-kubernetes-validations:
-                        - message: either "all" or "resourceSelector" must be set
-                          rule: (has(self.all) && self.all) != (has(self.resourceSelector)
-                            && size(self.resourceSelector) > 0)
                       type: array
                       x-kubernetes-list-map-keys:
                       - group
                       - resource
+                      x-kubernetes-list-type: map
+                    resources:
+                      description: |-
+                        Resources records the APIResourceSchemas that are exposed with this
+                        APIExport.
+
+                        The schemas can be changed in the life-cycle of the APIExport. These changes
+                        have no effect on existing APIBindings, but only on newly bound ones.
+
+                        For updating existing APIBindings, use an APIDeployment keeping bound
+                        workspaces up-to-date.
+                      items:
+                        description: ResourceSchema defines the resource schemas that
+                          are exposed with this APIExport.
+                        properties:
+                          group:
+                            description: Group is the API group of the resource. Empty
+                              string represents the core group.
+                            type: string
+                          name:
+                            description: Name is the name of the resource.
+                            type: string
+                          schema:
+                            description: |-
+                              Schema is the name of the referenced APIResourceSchema. This must be of the format
+                              "<version>.<name>.<group>".
+                            type: string
+                          storage:
+                            default:
+                              crd: {}
+                            description: Storage defines how the resource is stored.
+                            properties:
+                              crd:
+                                description: |-
+                                  CRD storage defines that this APIResourceSchema is exposed as
+                                  CustomResourceDefinitions inside the workspaces that bind to the APIExport.
+                                  Like in vanilla Kubernetes, users can then create, update and delete
+                                  custom resources.
+                                type: object
+                              virtual:
+                                description: |-
+                                  Virtual storage defines that this APIResourceSchema is exposed as
+                                  a projection of the referenced resource inside the workspaces that
+                                  bind to the APIExport.
+                                properties:
+                                  identityHash:
+                                    description: IdentityHash is the identity of the
+                                      virtual resource.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Reference points to another object that has a URL to a virtual workspace
+                                      in a "url" field in its status. The object can be of any kind.
+                                    properties:
+                                      apiGroup:
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource
+                                          being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource
+                                          being referenced
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - identityHash
+                                - reference
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Exactly one of crd or virtual must be set
+                              rule: has(self.crd) != has(self.virtual)
+                        required:
+                        - group
+                        - name
+                        - schema
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      - group
                       x-kubernetes-list-type: map
                   type: object
                 status:
@@ -294,8 +400,11 @@ spec:
                     virtualWorkspaces:
                       description: |-
                         virtualWorkspaces contains all APIExport virtual workspace URLs.
+                        this field is empty unless kcp has been started with the
+                        'EnableDeprecatedAPIExportVirtualWorkspacesUrls' feature gate.
 
-                        Deprecated: use APIExportEndpointSlice.status.endpoints instead
+                        Deprecated: use APIExportEndpointSlice.status.endpoints instead. This
+                        field will be removed in an upcoming API version.
                       items:
                         properties:
                           url:

--- a/services/virtual-workspaces/pkg/storage/filter.go
+++ b/services/virtual-workspaces/pkg/storage/filter.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	mcpcache "github.com/kcp-dev/multicluster-provider/pkg/cache"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
 )
 
@@ -226,7 +227,7 @@ func Marketplace(
 
 			// For each provider, find matching APIExports across all shards
 			for _, provider := range providerList.Items {
-				exportList := &kcpapisv1alpha1.APIExportList{}
+				exportList := &kcpapisv1alpha2.APIExportList{}
 
 				if err := lister.List(ctx, exportList, &ctrlruntimeclient.ListOptions{
 					LabelSelector: labels.SelectorFromValidatedSet(map[string]string{

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
 )
 
@@ -47,6 +48,8 @@ const (
 	testProviderClusterID = "abcd-provider-cluster-id"
 	testProviderName      = "abcd"
 	testExportName        = "widgets.abcd.io"
+	testResourceName      = "widgets"
+	testResourceGroup     = "abcd.io"
 )
 
 func marketplaceTestScheme(t *testing.T) *runtime.Scheme {
@@ -54,6 +57,7 @@ func marketplaceTestScheme(t *testing.T) *runtime.Scheme {
 	s := runtime.NewScheme()
 	utilruntime.Must(pmuiv1alpha1.AddToScheme(s))
 	utilruntime.Must(kcpapisv1alpha1.AddToScheme(s))
+	utilruntime.Must(kcpapisv1alpha2.AddToScheme(s))
 	return s
 }
 
@@ -69,20 +73,27 @@ func makeProviderMeta(clusterID string) *pmuiv1alpha1.ProviderMetadata {
 }
 
 // makeDefaultExport with default values.
-func makeDefaultExport(cfg config.ServiceConfig) *kcpapisv1alpha1.APIExport {
+func makeDefaultExport(cfg config.ServiceConfig) *kcpapisv1alpha2.APIExport {
 	return makeExport(cfg, testExportName, testProviderClusterID, testProviderName)
 }
 
 // makeExport returns an APIExport with the given name and provider label.
-func makeExport(cfg config.ServiceConfig, name, clusterID, provider string) *kcpapisv1alpha1.APIExport {
-	return &kcpapisv1alpha1.APIExport{
+func makeExport(cfg config.ServiceConfig, name, clusterID, provider string) *kcpapisv1alpha2.APIExport {
+	return &kcpapisv1alpha2.APIExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: map[string]string{"kcp.io/cluster": clusterID},
 			Labels:      map[string]string{cfg.ContentForLabel: provider},
 		},
-		Spec: kcpapisv1alpha1.APIExportSpec{
-			LatestResourceSchemas: []string{"v260810" + name},
+		Spec: kcpapisv1alpha2.APIExportSpec{
+			Resources: []kcpapisv1alpha2.ResourceSchema{{
+				Name:   testResourceName,
+				Group:  testResourceGroup,
+				Schema: "v260810." + testResourceName + "." + testResourceGroup,
+				Storage: kcpapisv1alpha2.ResourceSchemaStorage{
+					CRD: &kcpapisv1alpha2.ResourceSchemaStorageCRD{},
+				},
+			}},
 		},
 		Status: kcpapisv1alpha1.APIExportStatus{
 			IdentityHash: "testhash-" + name,

--- a/services/virtual-workspaces/pkg/storage/marketplace_test.go
+++ b/services/virtual-workspaces/pkg/storage/marketplace_test.go
@@ -95,7 +95,7 @@ func makeExport(cfg config.ServiceConfig, name, clusterID, provider string) *kcp
 				},
 			}},
 		},
-		Status: kcpapisv1alpha1.APIExportStatus{
+		Status: kcpapisv1alpha2.APIExportStatus{
 			IdentityHash: "testhash-" + name,
 		},
 	}
@@ -263,14 +263,14 @@ func TestMarketplace_UIOnlyExportWithNoSchemas(t *testing.T) {
 	cfg := config.NewServiceConfig()
 	s := marketplaceTestScheme(t)
 
-	uiOnlyExport := &kcpapisv1alpha1.APIExport{
+	uiOnlyExport := &kcpapisv1alpha2.APIExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        testExportName,
 			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
 			Labels:      map[string]string{cfg.ContentForLabel: testProviderName},
 		},
-		Spec: kcpapisv1alpha1.APIExportSpec{},
-		Status: kcpapisv1alpha1.APIExportStatus{
+		Spec: kcpapisv1alpha2.APIExportSpec{},
+		Status: kcpapisv1alpha2.APIExportStatus{
 			IdentityHash: "testhash-ui-only",
 		},
 	}
@@ -289,16 +289,23 @@ func TestMarketplace_UnestablishedExportSkipped(t *testing.T) {
 	cfg := config.NewServiceConfig()
 	s := marketplaceTestScheme(t)
 
-	unestablishedExport := &kcpapisv1alpha1.APIExport{
+	unestablishedExport := &kcpapisv1alpha2.APIExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        testExportName,
 			Annotations: map[string]string{"kcp.io/cluster": testProviderClusterID},
 			Labels:      map[string]string{cfg.ContentForLabel: testProviderName},
 		},
-		Spec: kcpapisv1alpha1.APIExportSpec{
-			LatestResourceSchemas: []string{"v1.myresources.example.com"},
+		Spec: kcpapisv1alpha2.APIExportSpec{
+			Resources: []kcpapisv1alpha2.ResourceSchema{{
+				Name:   "myresources",
+				Group:  "example.com",
+				Schema: "v1.myresources.example.com",
+				Storage: kcpapisv1alpha2.ResourceSchemaStorage{
+					CRD: &kcpapisv1alpha2.ResourceSchemaStorageCRD{},
+				},
+			}},
 		},
-		Status: kcpapisv1alpha1.APIExportStatus{},
+		Status: kcpapisv1alpha2.APIExportStatus{},
 	}
 
 	lister := fake.NewClientBuilder().


### PR DESCRIPTION
Original PR (can no longer push changes): https://github.com/platform-mesh/platform-mesh/pull/274

Resolves: #300 

---

This PR migrates the MarketplaceEntry `apiExport` field to the v1alpha2 type. The change fixes the broken CRD and ARS; types are regenerated. 

> (!!!) This is a breaking change for any `spec.apiExport` consumers. Field `latestResourceSchemas` is replaced with `resources`; `all` is dropped. We need to ensure that the UI is not relying on any of these.

Frontend PR (merged): https://github.com/platform-mesh/marketplace-ui/pull/187

## Description
The MarketplaceEntries CRD (and ARS) fails validation on apply. The `apiExport` field references an older version of the KCP APIExport type. That type declares that `group` is the map key for permissionClaims, but it is neither made required, nor is a default provided. 

This is fixed in a newer version of the APIExport type. I couldn't find a related issue in KCP, only this PR which adds the default value to the v1alpha2 schema: https://github.com/kcp-dev/kcp/pull/3486
- link to exact line: https://github.com/kcp-dev/kcp/pull/3486/files#diff-db1d09cd3ca584946616da9eee212c73381cf0a6aa69d926d811b2630409fe04R637

The failing `x-kubernetes-list-map-keys` validation requires either a default value or a mandatory field.
- upstream docs: https://kubernetes.io/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1/
> x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map. [snip] The properties specified must either be required or have a default value, to ensure those properties are present for all list items.


**Why is this bug suddenly a problem?**
Until now we constructed MarketplaceEntries in the VW service in-process, and returned them to the client. MarketplaceEntry objects do not exist anywhere in kcp / etcd state. In #273 I am adding VisibilityGrants (a persisted type) in the same API group, so the two marketplace ARS(chemas) and the APIExport are created for the first time in PM. Applying them failed and exposed the problem.

I am not sure why this isn't breaking kcp as v1alpha1 types are being served today. kcp doesnt use the ARS->CRDs flow? 

## Spec changes

APIExport field changes:
- `spec.latestResourceSchemas []string` replaced with `spec.resources` (object list)
- `permissionClaims[].all` replaced (see `defaultSelector`)
- NEW: `permissionClaims[].verbs` (required, minItems 1)
- Minor / fixes:
  - `permissionClaims[].group` has a `default: ""` added (the ARS bugfix)
  - `permissionClaims[].identityHash` same, default added
