### PR TITLE
fix(kubernetes-graphql-gateway): prevent duplicate token reviews

### DIFF
--- a/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview.go
@@ -123,25 +123,48 @@ func NewTokenReviewValidatorFromClientset(cs kubernetes.Interface, cacheTTL time
 	}
 }
 
-func (v *TokenReviewValidator) Validate(ctx context.Context, token string) (bool, error) {
-	key := hashToken(token)
-	if v.cache != nil {
-		if item := v.cache.Get(key); item != nil {
-			if v.metrics != nil {
-				labelResult := metrics.ResultDenied
-				if item.Value() {
-					labelResult = metrics.ResultAllowed
-				}
-				v.metrics.RecordCacheHit(labelResult)
-			}
-			if !item.Value() {
-				log.FromContext(ctx).V(1).Info("token denied (cached TokenReview verdict)")
-			}
-			return item.Value(), nil
-		}
+func (v *TokenReviewValidator) cachedVerdict(ctx context.Context, key string) (bool, bool) {
+	if v.cache == nil {
+		return false, false
 	}
 
+	item := v.cache.Get(key)
+	if item == nil {
+		return false, false
+	}
+
+	authenticated := item.Value()
+	if v.metrics != nil {
+		labelResult := metrics.ResultDenied
+		if authenticated {
+			labelResult = metrics.ResultAllowed
+		}
+		v.metrics.RecordCacheHit(labelResult)
+	}
+	if !authenticated {
+		log.FromContext(ctx).V(1).Info("token denied (cached TokenReview verdict)")
+	}
+	return authenticated, true
+}
+
+func (v *TokenReviewValidator) Validate(ctx context.Context, token string) (bool, error) {
+	key := hashToken(token)
+	if result, ok := v.cachedVerdict(ctx, key); ok {
+		return result, nil
+	}
+
+	return v.validateAfterCacheMiss(ctx, token, key)
+}
+
+func (v *TokenReviewValidator) validateAfterCacheMiss(ctx context.Context, token, key string) (bool, error) {
 	result, err, _ := v.inflight.Do(key, func() (any, error) {
+		// A caller can observe a cache miss and then reach singleflight after a
+		// previous flight has populated the cache and completed. Recheck here so
+		// that stale miss does not trigger another TokenReview API call.
+		if result, ok := v.cachedVerdict(ctx, key); ok {
+			return result, nil
+		}
+
 		start := time.Now()
 		tr, err := v.clientset.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
 			Spec: authenticationv1.TokenReviewSpec{Token: token},

--- a/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview_test.go
+++ b/services/kubernetes-graphql-gateway/gateway/gateway/authn/tokenreview_test.go
@@ -277,15 +277,35 @@ func TestDeniedVerdictIsLogged(t *testing.T) {
 	assert.Contains(t, joined, "cached", "cached denial must be distinguishable from a fresh review")
 }
 
+func TestStaleCacheMissUsesCachedVerdict(t *testing.T) {
+	var calls atomic.Int32
+	v := NewTokenReviewValidatorFromClientset(fakeClientset(true, &calls, nil), 5*time.Minute)
+	const token = "stale-miss-token"
+
+	ok, err := v.Validate(t.Context(), token)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), calls.Load())
+
+	// Simulate a caller that observed a cache miss before the first validation
+	// populated the cache, but reached singleflight only after it completed.
+	ok, err = v.validateAfterCacheMiss(t.Context(), token, hashToken(token))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), calls.Load(), "stale cache miss should not trigger another TokenReview")
+}
+
 func TestConcurrentValidation(t *testing.T) {
 	var calls atomic.Int32
 	v := NewTokenReviewValidatorFromClientset(fakeClientset(true, &calls, nil), 5*time.Minute)
 
 	const goroutines = 20
 	errCh := make(chan error, goroutines)
+	start := make(chan struct{})
 
 	for range goroutines {
 		go func() {
+			<-start
 			ok, err := v.Validate(t.Context(), "concurrent-token")
 			if err != nil {
 				errCh <- err
@@ -298,12 +318,13 @@ func TestConcurrentValidation(t *testing.T) {
 			errCh <- nil
 		}()
 	}
+	close(start)
 
 	for range goroutines {
 		assert.NoError(t, <-errCh)
 	}
 
-	// singleflight deduplicates concurrent in-flight calls for the same key,
-	// so we expect exactly 1 API call (all goroutines share the result).
-	assert.Equal(t, int32(1), calls.Load(), "singleflight should deduplicate concurrent calls")
+	// The cache recheck inside singleflight covers callers that observed the
+	// initial cache miss but arrive after the first flight has completed.
+	assert.Equal(t, int32(1), calls.Load(), "concurrent calls should share one TokenReview")
 }


### PR DESCRIPTION
Recheck the TokenReview cache after entering `singleflight` and before making
the Kubernetes API call.

This preserves the existing fast cache-hit path while preventing callers with
a stale cache-miss result from starting another TokenReview after an earlier
flight has already populated the cache.

The change also adds deterministic regression coverage for this ordering case
and strengthens the existing concurrent validation test.

The cache lookup and `singleflight.Do` call were separate operations:

1. Multiple callers could observe a cache miss.
2. The first caller completed TokenReview and populated the cache.
3. A delayed caller entered `singleflight` after the first flight had finished.
4. Because the cache was not checked again, it started a second TokenReview.

This caused `TestConcurrentValidation` to fail intermittently and could produce
unnecessary TokenReview API calls in production.

Observed in:

- https://github.com/platform-mesh/platform-mesh/actions/runs/33689731040/job/100445459031
- https://github.com/platform-mesh/platform-mesh/actions/runs/33636752914/job/100269421004

## Testing

- Authn package tests
- `TestConcurrentValidation` and the deterministic stale-cache-miss regression
  test repeated 15,000 times across multiple `GOMAXPROCS` values
- 500 iterations of both concurrency tests with the race detector
- Full `task test`
- Component lint, tidy, dependency, and boilerplate verification
