### PR TITLE
feat: improve exposure configuration in platform-mesh-operator

### DIFF
--- a/apis/core/v1alpha1/platformmesh_types.go
+++ b/apis/core/v1alpha1/platformmesh_types.go
@@ -78,9 +78,11 @@ type ComponentConfig struct {
 }
 
 type ExposureConfig struct {
-	BaseDomain string `json:"baseDomain,omitempty"`
-	Port       int    `json:"port,omitempty"`
-	Protocol   string `json:"protocol,omitempty"`
+	BaseDomain             string `json:"baseDomain,omitempty"`
+	Port                   int    `json:"port,omitempty"`
+	Protocol               string `json:"protocol,omitempty"`
+	TraefikClusterIP       string `json:"traefikClusterIP,omitempty"`
+	KcpFrontProxyClusterIP string `json:"kcpFrontProxyClusterIP,omitempty"`
 }
 
 type Kcp struct {

--- a/operators/platform-mesh-operator/README.md
+++ b/operators/platform-mesh-operator/README.md
@@ -41,15 +41,27 @@ The ConfigMap must contain a `profile.yaml` key with two top-level sections: `in
 
 ### Exposure Configuration
 
-The `exposure` section configures how services are exposed externally:
+The `exposure` section configures how services are exposed externally. All fields are optional; when unset, the operator falls back to the local-development defaults shown below.
 
 ```yaml
 spec:
   exposure:
-    baseDomain: example.com       # Base domain for exposure
-    port: 443                     # Port to expose services on
-    protocol: https               # Protocol (http/https)
+    baseDomain: example.com          # Base domain for exposure (default: portal.localhost)
+    port: 443                        # Port to expose services on (default: 8443)
+    protocol: https                  # Protocol, http or https (default: https)
+    traefikClusterIP: 10.96.188.4    # In-cluster IP of the Traefik gateway service (default: 10.96.188.4)
+    kcpFrontProxyClusterIP: 10.96.0.100  # In-cluster IP of the KCP front-proxy service (default: 10.96.0.100)
 ```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `baseDomain` | string | `portal.localhost` | Base domain the platform is served on. |
+| `port` | int | `8443` | External port. Standard ports 80/443 are omitted from `baseDomainPort`. |
+| `protocol` | string | `https` | URL scheme used for externally exposed services. |
+| `traefikClusterIP` | string | `10.96.188.4` | ClusterIP of the Traefik gateway `Service`, injected into profiles that pin it (e.g. `service.clusterIP`, `hostAliases`). |
+| `kcpFrontProxyClusterIP` | string | `10.96.0.100` | ClusterIP of the KCP front-proxy `Service`, injected where profiles reference it. |
+
+These values are the single source of truth for the exposure-derived template variables (see [Template Variables](#template-variables)); the operator computes the derived vars (`baseDomainPort`, `baseDomainWithPort`, `internalFrontProxyUrl`) from them.
 
 ### KCP Configuration
 
@@ -304,7 +316,7 @@ The operator renders deployment manifests directly from Go templates located in:
 - `gotemplates/infra/` — infrastructure components (cert-manager, traefik, gateway-api, etcd-druid, kcp-operator)
 - `gotemplates/components/` — application components (HelmReleases, OCM Resources for each service)
 
-These templates are rendered using the profile ConfigMap data merged with exposure-derived template variables (`baseDomain`, `baseDomainPort`, `port`, `protocol`). The gotemplates replace the previously used `platform-mesh-operator-components` and `platform-mesh-operator-infra-components` Helm charts.
+These templates are rendered using the profile ConfigMap data merged with exposure-derived template variables (`baseDomain`, `baseDomainPort`, `port`, `protocol`, `traefikClusterIP`, `kcpFrontProxyClusterIP`, `internalFrontProxyUrl`). The gotemplates replace the previously used `platform-mesh-operator-components` and `platform-mesh-operator-infra-components` Helm charts.
 
 ### Deployment Technologies
 
@@ -388,6 +400,7 @@ gotemplates/
 | `kubeConfigSecretKey` | `--remote-runtime-infra-secret-key` |
 | `<component>.enabled` | From profile infra section (e.g., `.certManager.enabled`) |
 | `<component>.values` | Helm values from profile |
+| `baseDomain`, `baseDomainPort`, `port`, `protocol`, `traefikClusterIP`, `kcpFrontProxyClusterIP`, `internalFrontProxyUrl` | Exposure-derived (from `spec.exposure`; see [Exposure Configuration](#exposure-configuration)) |
 
 **Component templates** (`gotemplates/components/`) receive:
 
@@ -403,8 +416,13 @@ gotemplates/
 | `deploymentTechnology` | `fluxcd` or `argocd` |
 | `destinationServer` | ArgoCD destination (from profile's `components.destinationServer`) |
 | `baseDomain` | From `spec.exposure.baseDomain` |
+| `baseDomainPort` | `baseDomain` with `:port` suffix (omitted for ports 80/443) |
+| `baseDomainWithPort` | `baseDomain` with `:port` suffix (omitted only for port 443) |
 | `port` | From `spec.exposure.port` |
-| `baseDomainWithPort` | Combined domain:port (port omitted if 443) |
+| `protocol` | From `spec.exposure.protocol` |
+| `traefikClusterIP` | From `spec.exposure.traefikClusterIP` |
+| `kcpFrontProxyClusterIP` | From `spec.exposure.kcpFrontProxyClusterIP` |
+| `internalFrontProxyUrl` | In-cluster KCP front-proxy URL, derived from operator KCP config |
 
 ##### deploymentNamespace (Two-Cluster Setup)
 
@@ -450,7 +468,7 @@ components:
           port: {{ .port }}
 ```
 
-Available variables in the profile template context: `baseDomain`, `baseDomainPort`, `port`, `protocol`, `helmReleaseNamespace`.
+Available variables in the profile template context: `baseDomain`, `baseDomainPort`, `port`, `protocol`, `traefikClusterIP`, `kcpFrontProxyClusterIP`, `internalFrontProxyUrl`, `helmReleaseNamespace`.
 
 #### Template Syntax Examples
 

--- a/operators/platform-mesh-operator/config/crd/core.platform-mesh.io_platformmeshes.yaml
+++ b/operators/platform-mesh-operator/config/crd/core.platform-mesh.io_platformmeshes.yaml
@@ -97,9 +97,13 @@ spec:
                 properties:
                   baseDomain:
                     type: string
+                  kcpFrontProxyClusterIP:
+                    type: string
                   port:
                     type: integer
                   protocol:
+                    type: string
+                  traefikClusterIP:
                     type: string
                 type: object
               featureToggles:

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiexport-providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiexport-providers.platform-mesh.io.yaml
@@ -71,12 +71,12 @@ spec:
   resources:
   - group: providers.platform-mesh.io
     name: providerpermissions
-    schema: v260814-b83d7328.providerpermissions.providers.platform-mesh.io
+    schema: v260901-c099a15f.providerpermissions.providers.platform-mesh.io
     storage:
       crd: {}
   - group: providers.platform-mesh.io
     name: providers
-    schema: v260814-b83d7328.providers.providers.platform-mesh.io
+    schema: v260901-c099a15f.providers.providers.platform-mesh.io
     storage:
       crd: {}
 status: {}

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providerpermissions.providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providerpermissions.providers.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260814-b83d7328.providerpermissions.providers.platform-mesh.io
+  name: v260901-c099a15f.providerpermissions.providers.platform-mesh.io
 spec:
   group: providers.platform-mesh.io
   names:

--- a/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providers.providers.platform-mesh.io.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/01-platform-mesh-system/apiresourceschema-providers.providers.platform-mesh.io.yaml
@@ -15,7 +15,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260814-b83d7328.providers.providers.platform-mesh.io
+  name: v260901-c099a15f.providers.providers.platform-mesh.io
 spec:
   group: providers.platform-mesh.io
   names:

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment.go
@@ -393,6 +393,21 @@ func (r *DeploymentSubroutine) templateVarsFromProfileInfra(ctx context.Context,
 	// Ensure helmReleaseNamespace is set: prefer deploymentNamespace, then existing helmReleaseNamespace, then inst.Namespace
 	tmplVars["helmReleaseNamespace"] = infraHelmReleaseNamespace(tmplVars, inst.Namespace)
 
+	// Inject exposure-derived vars so the infra profile can use {{ .traefikClusterIP }} etc.
+	for k, v := range getExposureParams(inst).templateVars(r.cfgOperator.KCP) {
+		tmplVars[k] = v
+	}
+
+	// Render any {{ }} template syntax embedded in profile values (e.g. service.spec.clusterIP)
+	// using the now-complete tmplVars as data.
+	rendered, err := renderTemplatesInValue(tmplVars, tmplVars)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to render template vars in infra profile")
+	}
+	if renderedMap, ok := rendered.(map[string]any); ok {
+		tmplVars = renderedMap
+	}
+
 	return tmplVars, nil
 }
 
@@ -549,6 +564,9 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 		return nil, errors.Wrap(err, "Failed to parse infra profile as YAML")
 	}
 
+	exposure := getExposureParams(inst)
+	exposureTemplateVars := exposure.templateVars(r.cfgOperator.KCP)
+
 	// Parse templateVars JSON into a map
 	var templateVarsMap map[string]any
 	if len(templateVars.Raw) > 0 {
@@ -573,6 +591,15 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 	templateVarsMap, err = merge.MergeMaps(componentsProfileMap, templateVarsMap, log)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to merge profile-components.yaml with templateVars")
+	}
+
+	// Inject exposure-derived vars so profile templates like {{ .traefikClusterIP }} render correctly.
+	// These are added after the templateVars merge so they can't be overridden by the profile config,
+	// but they are available when the profile YAML itself is rendered as a template.
+	{
+		for k, v := range exposureTemplateVars {
+			templateVarsMap[k] = v
+		}
 	}
 
 	// Render profile-components.yaml as a Go template with tv directly (merged values)
@@ -605,19 +632,10 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 
 	// Build template data for rendering templates in spec.Values
 	templateData := make(map[string]any)
-	_, baseDomainPort, _, _ := baseDomainPortProtocol(inst)
-
-	templateData["baseDomain"] = getBaseDomainFromInstance(inst)
-	templateData["baseDomainPort"] = baseDomainPort
-	templateData["port"] = "443"
-	if inst.Spec.Exposure != nil && inst.Spec.Exposure.Port != 0 {
-		templateData["port"] = fmt.Sprintf("%d", inst.Spec.Exposure.Port)
+	for k, v := range exposureTemplateVars {
+		templateData[k] = v
 	}
-	if templateData["port"] != "443" {
-		templateData["baseDomainWithPort"] = fmt.Sprintf("%s:%s", templateData["baseDomain"], templateData["port"])
-	} else {
-		templateData["baseDomainWithPort"] = templateData["baseDomain"]
-	}
+	templateData["baseDomainWithPort"] = exposure.baseDomainWithPort()
 
 	// Extract services from PlatformMesh.spec.Values
 	// spec.Values can either have services under a "services" key, or the entire spec.Values can be services
@@ -716,26 +734,12 @@ func (r *DeploymentSubroutine) buildComponentsTemplateVars(ctx context.Context, 
 		data["destinationServer"] = destinationServer
 	}
 
-	data["baseDomain"] = getBaseDomainFromInstance(inst)
-	data["port"] = "443"
-	if inst.Spec.Exposure != nil && inst.Spec.Exposure.Port != 0 {
-		data["port"] = fmt.Sprintf("%d", inst.Spec.Exposure.Port)
+	for k, v := range exposureTemplateVars {
+		data[k] = v
 	}
-	if data["port"] != "443" {
-		data["baseDomainWithPort"] = fmt.Sprintf("%s:%s", data["baseDomain"], data["port"])
-	} else {
-		data["baseDomainWithPort"] = data["baseDomain"]
-	}
+	data["baseDomainWithPort"] = exposure.baseDomainWithPort()
 
 	return data, nil
-}
-
-// getBaseDomainFromInstance extracts the base domain from PlatformMesh instance
-func getBaseDomainFromInstance(inst *pmcorev1alpha1.PlatformMesh) string {
-	if inst.Spec.Exposure == nil || inst.Spec.Exposure.BaseDomain == "" {
-		return "portal.localhost"
-	}
-	return inst.Spec.Exposure.BaseDomain
 }
 
 // calculateSyncWaves calculates ArgoCD sync waves based on dependsOn relationships

--- a/operators/platform-mesh-operator/pkg/subroutines/deployment_funcs_test.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/deployment_funcs_test.go
@@ -901,9 +901,9 @@ func (s *TemplateVarsTestSuite) Test_buildComponentsTemplateVars_BaseDomainWithD
 	result, err := sub.buildComponentsTemplateVars(context.Background(), inst, apiextensionsv1.JSON{})
 
 	s.Require().NoError(err)
-	s.Equal("443", result["port"])
-	// When port is 443, baseDomainWithPort should equal baseDomain
-	s.Equal("my.domain.com", result["baseDomainWithPort"])
+	s.Equal("8443", result["port"])
+	// When port is 8443 (non-standard), baseDomainWithPort includes the port
+	s.Equal("my.domain.com:8443", result["baseDomainWithPort"])
 }
 
 // ---- loadProfileSections tests ----

--- a/operators/platform-mesh-operator/pkg/subroutines/featuretoggles.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/featuretoggles.go
@@ -18,7 +18,6 @@ package subroutines
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -174,14 +173,10 @@ func (r *FeatureToggleSubroutine) applyKcpManifests(
 
 	dir := r.workspaceDirectory + kcpDir
 
-	baseDomain, baseDomainPort, port, protocol := baseDomainPortProtocol(inst)
-	tplValues := map[string]any{
-		"baseDomain":     baseDomain,
-		"protocol":       protocol,
-		"port":           fmt.Sprintf("%d", port),
-		"baseDomainPort": baseDomainPort,
+	tplValues := make(map[string]any)
+	for k, v := range getExposureParams(inst).templateVars(operatorCfg.KCP) {
+		tplValues[k] = v
 	}
-
 	err = ApplyDirStructure(ctx, dir, "root", cfg, tplValues, inst, r.kcpHelper)
 	if err != nil {
 		log.Err(err).Msg("Failed to apply dir structure")

--- a/operators/platform-mesh-operator/pkg/subroutines/kcpsetup.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/kcpsetup.go
@@ -183,11 +183,9 @@ func (r *KcpsetupSubroutine) createKcpResources(ctx context.Context, config *res
 		templateData[k] = v
 	}
 
-	baseDomain, baseDomainPort, port, protocol := baseDomainPortProtocol(inst)
-	templateData["baseDomain"] = baseDomain
-	templateData["baseDomainPort"] = baseDomainPort
-	templateData["port"] = fmt.Sprintf("%d", port)
-	templateData["protocol"] = protocol
+	for k, v := range getExposureParams(inst).templateVars(r.cfg.KCP) {
+		templateData[k] = v
+	}
 	templateData["featureDisableEmailVerification"] = HasFeatureToggle(inst, "feature-disable-email-verification")
 	templateData["featureDisableContentConfigurations"] = HasFeatureToggle(inst, "feature-disable-contentconfigurations")
 	templateData["featureEnableTerminalControllerManager"] = HasFeatureToggle(inst, "feature-enable-terminal-controller-manager")

--- a/operators/platform-mesh-operator/pkg/subroutines/subroutine_helpers.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/subroutine_helpers.go
@@ -418,44 +418,82 @@ func MergeValuesAndServices(inst *pmcorev1alpha1.PlatformMesh, templateVars apie
 	return apiextensionsv1.JSON{Raw: mergedRaw}, nil
 }
 
-func baseDomainPortProtocol(inst *pmcorev1alpha1.PlatformMesh) (string, string, int, string) {
-	var (
-		port           = 8443
-		baseDomain     = "portal.localhost"
-		protocol       = "https"
-		baseDomainPort string
-	)
+type exposureParams struct {
+	baseDomain             string
+	baseDomainPort         string
+	port                   int
+	protocol               string
+	traefikClusterIP       string
+	kcpFrontProxyClusterIP string
+}
+
+func getExposureParams(inst *pmcorev1alpha1.PlatformMesh) exposureParams {
+	p := exposureParams{
+		port:                   8443,
+		baseDomain:             "portal.localhost",
+		protocol:               "https",
+		traefikClusterIP:       "10.96.188.4",
+		kcpFrontProxyClusterIP: "10.96.0.100",
+	}
 
 	if inst.Spec.Exposure != nil {
 		if inst.Spec.Exposure.Port != 0 {
-			port = inst.Spec.Exposure.Port
+			p.port = inst.Spec.Exposure.Port
 		}
 		if inst.Spec.Exposure.BaseDomain != "" {
-			baseDomain = inst.Spec.Exposure.BaseDomain
+			p.baseDomain = inst.Spec.Exposure.BaseDomain
 		}
 		if inst.Spec.Exposure.Protocol != "" {
-			protocol = inst.Spec.Exposure.Protocol
+			p.protocol = inst.Spec.Exposure.Protocol
+		}
+		if inst.Spec.Exposure.TraefikClusterIP != "" {
+			p.traefikClusterIP = inst.Spec.Exposure.TraefikClusterIP
+		}
+		if inst.Spec.Exposure.KcpFrontProxyClusterIP != "" {
+			p.kcpFrontProxyClusterIP = inst.Spec.Exposure.KcpFrontProxyClusterIP
 		}
 	}
 
-	if port == 80 || port == 443 {
-		baseDomainPort = baseDomain
+	if p.port == 80 || p.port == 443 {
+		p.baseDomainPort = p.baseDomain
 	} else {
-		baseDomainPort = fmt.Sprintf("%s:%d", baseDomain, port)
+		p.baseDomainPort = fmt.Sprintf("%s:%d", p.baseDomain, p.port)
 	}
-	return baseDomain, baseDomainPort, port, protocol
+	return p
+}
+
+func (p exposureParams) portString() string {
+	return fmt.Sprintf("%d", p.port)
+}
+
+func (p exposureParams) baseDomainWithPort() string {
+	if p.port == 443 {
+		return p.baseDomain
+	}
+	return fmt.Sprintf("%s:%d", p.baseDomain, p.port)
+}
+
+func (p exposureParams) internalFrontProxyURL(kcp config.KCPConfig) string {
+	return fmt.Sprintf("https://%s-front-proxy.%s:%s", kcp.FrontProxyName, kcp.Namespace, kcp.FrontProxyPort)
+}
+
+func (p exposureParams) templateVars(kcp config.KCPConfig) map[string]any {
+	return map[string]any{
+		"baseDomain":             p.baseDomain,
+		"baseDomainPort":         p.baseDomainPort,
+		"port":                   p.portString(),
+		"protocol":               p.protocol,
+		"traefikClusterIP":       p.traefikClusterIP,
+		"kcpFrontProxyClusterIP": p.kcpFrontProxyClusterIP,
+		"internalFrontProxyUrl":  p.internalFrontProxyURL(kcp),
+	}
 }
 
 func TemplateVars(ctx context.Context, inst *pmcorev1alpha1.PlatformMesh, cl ctrlruntimeclient.Client) (apiextensionsv1.JSON, error) {
-	baseDomain, baseDomainPort, port, protocol := baseDomainPortProtocol(inst)
+	operatorCfg := pmconfig.LoadConfigFromContext(ctx).(config.OperatorConfig)
 
-	values := map[string]any{
-		"baseDomain":           baseDomain,
-		"protocol":             protocol,
-		"port":                 fmt.Sprintf("%d", port),
-		"baseDomainPort":       baseDomainPort,
-		"helmReleaseNamespace": inst.Namespace,
-	}
+	values := getExposureParams(inst).templateVars(operatorCfg.KCP)
+	values["helmReleaseNamespace"] = inst.Namespace
 
 	result := apiextensionsv1.JSON{}
 	result.Raw, _ = json.Marshal(values)

--- a/operators/platform-mesh-operator/test/e2e/kind/yaml/platform-mesh-resource/default-profile.yaml
+++ b/operators/platform-mesh-operator/test/e2e/kind/yaml/platform-mesh-resource/default-profile.yaml
@@ -79,7 +79,7 @@ data:
               experimentalChannel: true
           service:
             spec:
-              clusterIP: 10.96.188.4
+              clusterIP: "{{ .traefikClusterIP }}"
             type: NodePort
       etcdDruid:
         enabled: true
@@ -259,7 +259,7 @@ data:
             hostAliases:
               enabled: true
               entries:
-              - ip: "10.96.188.4"
+              - ip: "{{ .traefikClusterIP }}"
                 hostnames:
                 - "localhost"
                 - "portal.localhost"
@@ -298,7 +298,7 @@ data:
                 serviceAccount:
                   enabled: true
               frontProxy:
-                clusterIP: 10.96.0.100
+                clusterIP: "{{ .kcpFrontProxyClusterIP }}"
                 port: 8443
               image:
                 tag: v0.32.0
@@ -363,7 +363,7 @@ data:
             hostAliases:
               enabled: true
               values:
-                - ip: "10.96.188.4"
+                - ip: "{{ .traefikClusterIP }}"
                   hostnames:
                     - "localhost"
                     - "kcp.api.{{ .baseDomain }}"
@@ -451,10 +451,10 @@ data:
                   virtualWorkspaces:
                   - kubeconfig: /app/kubeconfig/kubeconfig
                     name: contentconfigurations
-                    url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations
+                    url: "{{ .internalFrontProxyUrl }}/services/contentconfigurations"
                   - kubeconfig: /app/kubeconfig/kubeconfig
                     name: marketplace
-                    url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace
+                    url: "{{ .internalFrontProxyUrl }}/services/marketplace"
                 enabled: true
             tracing:
               enabled: false
@@ -579,7 +579,7 @@ data:
             hostAliases:
               enabled: true
               entries:
-              - ip: "10.96.188.4"
+              - ip: "{{ .traefikClusterIP }}"
                 hostnames:
                 - "localhost"
                 - "portal.localhost"
@@ -683,7 +683,7 @@ data:
             hostAliases:
               enabled: true
             deployment:
-              serverUrl: https://frontproxy-front-proxy.platform-mesh-system:8443
+              serverUrl: "{{ .internalFrontProxyUrl }}"
               resourceSchemaName: "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io"
               resourceSchemaWorkspace: "root:platform-mesh-system"
         marketplace-ui:

--- a/operators/platform-mesh-operator/test/e2e/kind/yaml/platform-mesh-resource/platform-mesh.yaml
+++ b/operators/platform-mesh-operator/test/e2e/kind/yaml/platform-mesh-resource/platform-mesh.yaml
@@ -22,6 +22,8 @@ spec:
     port: 8443
     baseDomain: "portal.localhost"
     protocol: "https"
+    traefikClusterIP: "10.96.188.4"
+    kcpFrontProxyClusterIP: "10.96.0.100"
   ocm:
     repo:
       name: platform-mesh


### PR DESCRIPTION
Enhance `spec.exposure` configuration in PlatformMesh CRD and use it in the template replacement code. This enables users to configure exposure once and propagate the value via templateing, thus reducing configuration.


refers to https://github.com/platform-mesh/helm-charts/issues/2458