### PR TITLE
feat: make user claim configurable for orgs workspace

### DIFF
--- a/operators/platform-mesh-operator/internal/config/config.go
+++ b/operators/platform-mesh-operator/internal/config/config.go
@@ -31,6 +31,7 @@ type IDPConfig struct {
 	RegistrationAllowed                     bool
 	WelcomeAdditionalRedirectUris           []string
 	WelcomeAdditionalPostLogoutRedirectUris []string
+	UserClaim                               string
 }
 
 type DeploymentSubroutineConfig struct {
@@ -115,6 +116,9 @@ func NewOperatorConfig() OperatorConfig {
 			FrontProxyPort:         "8443",
 			ClusterAdminSecretName: "kcp-cluster-admin-client-cert",
 		},
+		IDP: IDPConfig{
+			UserClaim: "email",
+		},
 		Providers: NewProvidersConfig(),
 		Subroutines: SubroutinesConfig{
 			Deployment: DeploymentSubroutineConfig{
@@ -165,6 +169,7 @@ func (c *OperatorConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.IDP.RegistrationAllowed, "idp-registration-allowed", c.IDP.RegistrationAllowed, "Allow IDP registration")
 	fs.StringSliceVar(&c.IDP.WelcomeAdditionalRedirectUris, "idp-welcome-additional-redirect-uris", c.IDP.WelcomeAdditionalRedirectUris, "Additional redirect URIs for the welcome client (comma-separated)")
 	fs.StringSliceVar(&c.IDP.WelcomeAdditionalPostLogoutRedirectUris, "idp-welcome-additional-post-logout-redirect-uris", c.IDP.WelcomeAdditionalPostLogoutRedirectUris, "Additional post-logout redirect URIs for the welcome client (comma-separated)")
+	fs.StringVar(&c.IDP.UserClaim, "user-claim", c.IDP.UserClaim, "Set the ID token user claim for workspace authentication")
 
 	fs.BoolVar(&c.Subroutines.Deployment.Enabled, "subroutines-deployment-enabled", c.Subroutines.Deployment.Enabled, "Enable deployment subroutine")
 	fs.StringVar(&c.Subroutines.Deployment.AuthorizationWebhookSecretName, "authorization-webhook-secret-name", c.Subroutines.Deployment.AuthorizationWebhookSecretName, "Authorization webhook secret name")

--- a/operators/platform-mesh-operator/internal/config/config_test.go
+++ b/operators/platform-mesh-operator/internal/config/config_test.go
@@ -50,6 +50,8 @@ func TestNewOperatorConfig(t *testing.T) {
 	assert.Equal(t, "root:platform-mesh-system", cfg.Providers.ProvidersAPIExportEndpointSliceWorkspace)
 	assert.True(t, cfg.Subroutines.Provider.Workspace.Enabled)
 	assert.True(t, cfg.Subroutines.Provider.Kubeconfig.Enabled)
+
+	assert.Equal(t, "email", cfg.IDP.UserClaim)
 }
 
 func TestOperatorConfigAddFlags(t *testing.T) {
@@ -68,6 +70,7 @@ func TestOperatorConfigAddFlags(t *testing.T) {
 		"--idp-registration-allowed=true",
 		"--idp-welcome-additional-redirect-uris=https://extra.example.com/callback,https://other.example.com/callback",
 		"--idp-welcome-additional-post-logout-redirect-uris=https://extra.example.com/logout",
+		"--user-claim=sub",
 		"--subroutines-deployment-enabled=false",
 		"--authorization-webhook-secret-name=authz-secret",
 		"--authorization-webhook-secret-ca-name=authz-ca",
@@ -91,6 +94,7 @@ func TestOperatorConfigAddFlags(t *testing.T) {
 	assert.True(t, cfg.IDP.RegistrationAllowed)
 	assert.Equal(t, []string{"https://extra.example.com/callback", "https://other.example.com/callback"}, cfg.IDP.WelcomeAdditionalRedirectUris)
 	assert.Equal(t, []string{"https://extra.example.com/logout"}, cfg.IDP.WelcomeAdditionalPostLogoutRedirectUris)
+	assert.Equal(t, "sub", cfg.IDP.UserClaim)
 
 	assert.False(t, cfg.Subroutines.Deployment.Enabled)
 	assert.Equal(t, "authz-secret", cfg.Subroutines.Deployment.AuthorizationWebhookSecretName)

--- a/operators/platform-mesh-operator/manifests/kcp/workspace-authentication-configuration.yaml
+++ b/operators/platform-mesh-operator/manifests/kcp/workspace-authentication-configuration.yaml
@@ -38,9 +38,9 @@ spec:
           prefix: ""
         username:
       {{- if eq .featureDisableEmailVerification "true" }}
-          expression: claims.email
+          expression: claims.{{ .userClaim }}
       {{- else }}
-          claim: email
+          claim: {{ .userClaim }}
           prefix: ""
       {{- end }}
       {{- if eq .featureDisableEmailVerification "true" }}

--- a/operators/platform-mesh-operator/pkg/subroutines/kcpsetup.go
+++ b/operators/platform-mesh-operator/pkg/subroutines/kcpsetup.go
@@ -194,6 +194,7 @@ func (r *KcpsetupSubroutine) createKcpResources(ctx context.Context, config *res
 	templateData["registrationAllowed"] = r.cfg.IDP.RegistrationAllowed
 	templateData["welcomeAdditionalRedirectUris"] = r.cfg.IDP.WelcomeAdditionalRedirectUris
 	templateData["welcomeAdditionalPostLogoutRedirectUris"] = r.cfg.IDP.WelcomeAdditionalPostLogoutRedirectUris
+	templateData["userClaim"] = r.cfg.IDP.UserClaim
 
 	pmSystemClient, err := r.kcpHelper.NewKcpClient(config, "root:platform-mesh-system")
 	if err != nil {


### PR DESCRIPTION
On-behalf-of: @SAP aleh.yarshou@sap.com

This pr adds user claim configuration for orgs-authentication workspaceAuthenticationConfiguration resource. With hardcoded email claim OpenFGA will always work with email and authorization won't work

issue https://github.com/platform-mesh/platform-mesh/issues/341