### PR TITLE
Handle HTTP 201 response in security operator tests

### DIFF
--- a/operators/security-operator/pkg/clientreg/keycloak/admin.go
+++ b/operators/security-operator/pkg/clientreg/keycloak/admin.go
@@ -59,7 +59,8 @@ func (c *AdminClient) TokenForRegistration(ctx context.Context) (string, error) 
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != http.StatusOK {
+	// Keycloak <26.7 returned 200, 26.7+ returns the contractual 201.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return "", readErrorResponse(resp, "create initial access token")
 	}
 

--- a/operators/security-operator/pkg/clientreg/keycloak/keycloak_test.go
+++ b/operators/security-operator/pkg/clientreg/keycloak/keycloak_test.go
@@ -48,6 +48,18 @@ func listClientsJSON() string {
 }
 
 func TestAdminClient_TokenForRegistration(t *testing.T) {
+	tokenServer := func(status int) func(*testing.T) *httptest.Server {
+		return func(t *testing.T) *httptest.Server {
+			return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/admin/realms/test-realm/clients-initial-access", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				w.WriteHeader(status)
+				json.NewEncoder(w).Encode(map[string]string{"token": "initial-access-token-123"}) //nolint:errcheck
+			}))
+		}
+	}
+
 	tests := []struct {
 		name        string
 		setupServer func(t *testing.T) *httptest.Server
@@ -55,16 +67,14 @@ func TestAdminClient_TokenForRegistration(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name: "successful token retrieval",
-			setupServer: func(t *testing.T) *httptest.Server {
-				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					assert.Equal(t, http.MethodPost, r.Method)
-					assert.Equal(t, "/admin/realms/test-realm/clients-initial-access", r.URL.Path)
-					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-					json.NewEncoder(w).Encode(map[string]string{"token": "initial-access-token-123"}) //nolint:errcheck
-				}))
-			},
-			wantToken: "initial-access-token-123",
+			name:        "successful token retrieval, status 200",
+			setupServer: tokenServer(http.StatusOK),
+			wantToken:   "initial-access-token-123",
+		},
+		{
+			name:        "successful token retrieval, status 201",
+			setupServer: tokenServer(http.StatusCreated),
+			wantToken:   "initial-access-token-123",
 		},
 		{
 			name: "server returns error",


### PR DESCRIPTION
Closes #349 

Enables us to bump to a newer keycloak version. 