### PR TITLE
feat: percent-encode OpenFGA object ID parts

### DIFF
--- a/.github/workflows/rebac-authz-webhook.yml
+++ b/.github/workflows/rebac-authz-webhook.yml
@@ -42,6 +42,7 @@ on:
     paths:
       - 'services/rebac-authz-webhook/**'
       - 'apis/**'
+      - 'golang-commons/**'
       - 'go.work'
       - 'go.work.sum'
       - '.github/workflows/rebac-authz-webhook.yml'

--- a/golang-commons/fga/model/model.go
+++ b/golang-commons/fga/model/model.go
@@ -37,8 +37,9 @@ func BuildObjectName(group, singular, clusterID, name string, namespace *string)
 }
 
 // BuildObjectNameFromType renders the canonical OpenFGA object name from a
-// fully normalized OpenFGA object type.
+// fully normalized OpenFGA object type and a raw, unencoded resource name.
 func BuildObjectNameFromType(objectType, clusterID, name string, namespace *string) string {
+	name = util.EncodeObjectIDPart(name)
 	if namespace != nil && *namespace != "" {
 		return fmt.Sprintf("%s:%s/%s/%s", objectType, clusterID, *namespace, name)
 	}

--- a/golang-commons/fga/model/model_test.go
+++ b/golang-commons/fga/model/model_test.go
@@ -77,6 +77,14 @@ func TestBuildObjectName(t *testing.T) {
 			resource:  "acc1",
 			want:      "core_platform-mesh_io_account:cluster1/acc1",
 		},
+		{
+			name:      "resource with OpenFGA-forbidden characters",
+			group:     "rbac.authorization.k8s.io",
+			singular:  "clusterrole",
+			clusterID: "cluster1",
+			resource:  "system:controller#with space",
+			want:      "rbac_authorization_k8s_io_clusterrole:cluster1/system%3Acontroller%23with%20space",
+		},
 	}
 
 	for _, tt := range tests {

--- a/golang-commons/fga/util/object_id.go
+++ b/golang-commons/fga/util/object_id.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const upperHex = "0123456789ABCDEF"
+
+// EncodeObjectIDPart percent-encodes a raw identifier segment before it is
+// embedded in an OpenFGA object ID. OpenFGA object IDs cannot contain colons,
+// hashes, ASCII spaces, or Unicode control characters. Percent signs are also
+// escaped to keep the transformation injective.
+//
+// The input must be an unencoded value. Applying this function more than once
+// will encode the percent signs introduced by the first call.
+func EncodeObjectIDPart(value string) string {
+	if !needsObjectIDPartEncoding(value) {
+		return value
+	}
+
+	var encoded strings.Builder
+	encoded.Grow(len(value))
+
+	for offset := 0; offset < len(value); {
+		r, size := utf8.DecodeRuneInString(value[offset:])
+		if r == utf8.RuneError && size == 1 {
+			writePercentEncodedByte(&encoded, value[offset])
+			offset++
+			continue
+		}
+
+		part := value[offset : offset+size]
+		if shouldEncodeObjectIDRune(r) {
+			for index := range len(part) {
+				writePercentEncodedByte(&encoded, part[index])
+			}
+		} else {
+			encoded.WriteString(part)
+		}
+		offset += size
+	}
+
+	return encoded.String()
+}
+
+func needsObjectIDPartEncoding(value string) bool {
+	for offset := 0; offset < len(value); {
+		r, size := utf8.DecodeRuneInString(value[offset:])
+		if (r == utf8.RuneError && size == 1) || shouldEncodeObjectIDRune(r) {
+			return true
+		}
+		offset += size
+	}
+	return false
+}
+
+func shouldEncodeObjectIDRune(r rune) bool {
+	return r == '%' || r == ':' || r == '#' || r == ' ' || unicode.IsControl(r)
+}
+
+func writePercentEncodedByte(builder *strings.Builder, value byte) {
+	builder.WriteByte('%')
+	builder.WriteByte(upperHex[value>>4])
+	builder.WriteByte(upperHex[value&0x0f])
+}

--- a/golang-commons/fga/util/object_id_test.go
+++ b/golang-commons/fga/util/object_id_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"unicode"
+)
+
+func TestEncodeObjectIDPart(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "plain", input: "cluster-admin", want: "cluster-admin"},
+		{name: "allowed punctuation", input: "name?with@punctuation", want: "name?with@punctuation"},
+		{name: "unicode", input: "münchen", want: "münchen"},
+		{name: "colon", input: "system:controller:foo", want: "system%3Acontroller%3Afoo"},
+		{name: "hash", input: "name#fragment", want: "name%23fragment"},
+		{name: "space", input: "name with space", want: "name%20with%20space"},
+		{name: "ascii controls", input: "tab\tline\n", want: "tab%09line%0A"},
+		{name: "unicode control", input: "next\u0085line", want: "next%C2%85line"},
+		{name: "percent", input: "literal%3Avalue", want: "literal%253Avalue"},
+		{name: "invalid utf8", input: string([]byte{'a', 0xff, 'b'}), want: "a%FFb"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := EncodeObjectIDPart(test.input); got != test.want {
+				t.Fatalf("EncodeObjectIDPart(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func FuzzEncodeObjectIDPartIsInjective(f *testing.F) {
+	f.Add("system:controller:foo", "system.controller.foo")
+	f.Add("name#fragment", "name%23fragment")
+	f.Add("name with space", "name%20with%20space")
+	f.Add("line\nfeed", "line%0Afeed")
+	f.Add("", ":")
+
+	f.Fuzz(func(t *testing.T, first, second string) {
+		encodedFirst := EncodeObjectIDPart(first)
+		encodedSecond := EncodeObjectIDPart(second)
+		if first != second && encodedFirst == encodedSecond {
+			t.Fatalf("distinct values %q and %q encoded to %q", first, second, encodedFirst)
+		}
+
+		for _, r := range encodedFirst {
+			if r == ':' || r == '#' || r == ' ' || unicode.IsControl(r) {
+				t.Fatalf("EncodeObjectIDPart(%q) = %q contains OpenFGA-forbidden rune %q", first, encodedFirst, r)
+			}
+		}
+	})
+}

--- a/operators/search-operator/internal/subroutine/indexable_resource_watcher_test.go
+++ b/operators/search-operator/internal/subroutine/indexable_resource_watcher_test.go
@@ -122,6 +122,14 @@ func TestBuildFGAObjectName(t *testing.T) {
 			namespace: "",
 			want:      "core_namespace:cluster1/ns1",
 		},
+		{
+			name:      "resource name with OpenFGA-forbidden characters",
+			group:     "rbac.authorization.k8s.io",
+			kind:      "ClusterRole",
+			clusterID: "cluster1",
+			resource:  "system:controller#with space",
+			want:      "rbac_authorization_k8s_io_clusterrole:cluster1/system%3Acontroller%23with%20space",
+		},
 	}
 
 	for _, tt := range tests {

--- a/operators/security-operator/internal/subroutine/apiexportpolicy.go
+++ b/operators/security-operator/internal/subroutine/apiexportpolicy.go
@@ -25,6 +25,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	fgamodel "go.platform-mesh.io/golang-commons/fga/model"
 	"go.platform-mesh.io/golang-commons/logger"
 	iclient "go.platform-mesh.io/security-operator/internal/client"
 	"go.platform-mesh.io/security-operator/internal/config"
@@ -41,6 +42,10 @@ const (
 	bindRelation          = "bind"
 	bindInheritedRelation = "bind_inherited"
 )
+
+func buildAPIExportObject(clusterID, name string) string {
+	return fgamodel.BuildObjectNameFromType("apis_kcp_io_apiexport", clusterID, name, nil)
+}
 
 type APIExportPolicySubroutine struct {
 	fga             openfgav1.OpenFGAServiceClient
@@ -111,7 +116,7 @@ func (a *APIExportPolicySubroutine) Process(ctx context.Context, obj ctrlruntime
 				tuple := pmcorev1alpha1.Tuple{
 					Object:   fmt.Sprintf("core_platform-mesh_io_account:%s/%s", ai.Spec.Account.OriginClusterId, ai.Spec.Account.Name),
 					Relation: relation,
-					User:     fmt.Sprintf("apis_kcp_io_apiexport:%s/%s", providerClusterID, policy.Spec.APIExportRef.Name),
+					User:     buildAPIExportObject(providerClusterID, policy.Spec.APIExportRef.Name),
 				}
 
 				tm := fga.NewTupleManager(a.fga, storeID, fga.AuthorizationModelIDLatest, log)
@@ -143,7 +148,7 @@ func (a *APIExportPolicySubroutine) Process(ctx context.Context, obj ctrlruntime
 		tuple := pmcorev1alpha1.Tuple{
 			Object:   fmt.Sprintf("core_platform-mesh_io_account:%s/%s", ai.Spec.Account.OriginClusterId, ai.Spec.Account.Name),
 			Relation: relation,
-			User:     fmt.Sprintf("apis_kcp_io_apiexport:%s/%s", providerClusterID, policy.Spec.APIExportRef.Name),
+			User:     buildAPIExportObject(providerClusterID, policy.Spec.APIExportRef.Name),
 		}
 
 		tm := fga.NewTupleManager(a.fga, storeID, fga.AuthorizationModelIDLatest, log)
@@ -273,7 +278,7 @@ func (a *APIExportPolicySubroutine) deleteTuplesForExpression(ctx context.Contex
 			tupleToDelete := pmcorev1alpha1.Tuple{
 				Object:   fmt.Sprintf("core_platform-mesh_io_account:%s/%s", ai.Spec.Account.OriginClusterId, ai.Spec.Account.Name),
 				Relation: relation,
-				User:     fmt.Sprintf("apis_kcp_io_apiexport:%s/%s", providerClusterID, apiExportName),
+				User:     buildAPIExportObject(providerClusterID, apiExportName),
 			}
 
 			tm := fga.NewTupleManager(a.fga, storeID, fga.AuthorizationModelIDLatest, log)
@@ -302,7 +307,7 @@ func (a *APIExportPolicySubroutine) deleteTuplesForExpression(ctx context.Contex
 	tupleToDelete := pmcorev1alpha1.Tuple{
 		Object:   fmt.Sprintf("core_platform-mesh_io_account:%s/%s", ai.Spec.Account.OriginClusterId, ai.Spec.Account.Name),
 		Relation: relation,
-		User:     fmt.Sprintf("apis_kcp_io_apiexport:%s/%s", providerClusterID, apiExportName),
+		User:     buildAPIExportObject(providerClusterID, apiExportName),
 	}
 
 	tm := fga.NewTupleManager(a.fga, storeID, fga.AuthorizationModelIDLatest, log)

--- a/operators/security-operator/internal/subroutine/apiexportpolicy_test.go
+++ b/operators/security-operator/internal/subroutine/apiexportpolicy_test.go
@@ -252,14 +252,14 @@ func TestAPIExportPolicySubroutine_Process_Success(t *testing.T) {
 		expectedTupleWrites []pmcorev1alpha1.Tuple
 	}{
 		{
-			name: "should write correct FGA tuple for single org expression",
+			name: "should encode APIExport name when writing FGA tuple",
 			policy: &pmcorev1alpha1.APIExportPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-policy",
 				},
 				Spec: pmcorev1alpha1.APIExportPolicySpec{
 					APIExportRef: pmcorev1alpha1.APIExportRef{
-						Name:        "my-export",
+						Name:        "system:export#with space",
 						ClusterPath: "root:providers:my-provider",
 					},
 					AllowPathExpressions: []string{"root:orgs:acme"},
@@ -319,7 +319,7 @@ func TestAPIExportPolicySubroutine_Process_Success(t *testing.T) {
 					tuple := req.Writes.TupleKeys[0]
 					return tuple.Object == "core_platform-mesh_io_account:acme-cluster-id/acme-account" &&
 						tuple.Relation == "bind" &&
-						tuple.User == "apis_kcp_io_apiexport:provider-cluster-id/my-export"
+						tuple.User == "apis_kcp_io_apiexport:provider-cluster-id/system%3Aexport%23with%20space"
 				}), mock.Anything).Return(&openfgav1.WriteResponse{}, nil)
 
 				kcpClientGetter.EXPECT().NewClientFromContext(mock.Anything).Return(clusterClient, nil)
@@ -531,14 +531,14 @@ func TestAPIExportPolicySubroutine_Finalize_Success(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name: "should delete FGA tuple for single org expression",
+			name: "should encode APIExport name when deleting FGA tuple",
 			policy: &pmcorev1alpha1.APIExportPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-policy",
 				},
 				Spec: pmcorev1alpha1.APIExportPolicySpec{
 					APIExportRef: pmcorev1alpha1.APIExportRef{
-						Name:        "my-export",
+						Name:        "system:export#with space",
 						ClusterPath: "root:providers:my-provider",
 					},
 					AllowPathExpressions: []string{"root:orgs:acme"},
@@ -587,7 +587,7 @@ func TestAPIExportPolicySubroutine_Finalize_Success(t *testing.T) {
 					tuple := req.Deletes.TupleKeys[0]
 					return tuple.Object == "core_platform-mesh_io_account:acme-cluster-id/acme-account" &&
 						tuple.Relation == "bind" &&
-						tuple.User == "apis_kcp_io_apiexport:provider-cluster-id/my-export"
+						tuple.User == "apis_kcp_io_apiexport:provider-cluster-id/system%3Aexport%23with%20space"
 				}), mock.Anything).Return(&openfgav1.WriteResponse{}, nil)
 			},
 			cfg:         &config.Config{},

--- a/services/iam-service/pkg/directive/authorized.go
+++ b/services/iam-service/pkg/directive/authorized.go
@@ -29,6 +29,7 @@ import (
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
 	pmcontext "go.platform-mesh.io/golang-commons/context"
 	"go.platform-mesh.io/golang-commons/errors"
+	fgamodel "go.platform-mesh.io/golang-commons/fga/model"
 	"go.platform-mesh.io/golang-commons/fga/util"
 	"go.platform-mesh.io/golang-commons/jwt"
 	"go.platform-mesh.io/golang-commons/logger"
@@ -165,10 +166,7 @@ func (a AuthorizedDirective) testIfAllowed(ctx context.Context, ai *pmcorev1alph
 		clusterId = ai.Spec.Account.OriginClusterId
 	}
 
-	object := fmt.Sprintf("%s:%s/%s", fgaTypeName, clusterId, rctx.Resource.Name)
-	if rctx.Resource.Namespace != nil {
-		object = fmt.Sprintf("%s:%s/%s/%s", fgaTypeName, clusterId, *rctx.Resource.Namespace, rctx.Resource.Name)
-	}
+	object := fgamodel.BuildObjectNameFromType(fgaTypeName, clusterId, rctx.Resource.Name, rctx.Resource.Namespace)
 
 	user := fmt.Sprintf("user:%s", token.Mail) // TODO: what happens if mail is not uid?
 	storeID, err := a.helper.GetStoreID(ctx, a.fga, ai.Spec.Organization.Name)

--- a/services/iam-service/pkg/directive/authorized_test.go
+++ b/services/iam-service/pkg/directive/authorized_test.go
@@ -653,7 +653,7 @@ func TestTestIfAllowed(t *testing.T) {
 					return req.StoreId == "store-123" &&
 						req.TupleKey.Relation == "read" &&
 						req.TupleKey.User == "user:test@example.com" &&
-						req.TupleKey.Object == "rbac_authorization_k8s_io_clusterrole:generated-cluster-456/cluster-admin"
+						req.TupleKey.Object == "rbac_authorization_k8s_io_clusterrole:generated-cluster-456/system%3Acontroller%23with%20space"
 				})).Return(&openfgav1.CheckResponse{Allowed: true}, nil)
 			},
 			accountInfo: createTestAccountInfo(),
@@ -662,7 +662,7 @@ func TestTestIfAllowed(t *testing.T) {
 				Kind:        "ClusterRole",
 				AccountPath: "root:orgs:test",
 				Resource: &graph.Resource{
-					Name:      "cluster-admin",
+					Name:      "system:controller#with space",
 					Namespace: nil,
 				},
 			},

--- a/services/iam-service/pkg/fga/fga.go
+++ b/services/iam-service/pkg/fga/fga.go
@@ -136,11 +136,7 @@ func (s *Service) listUsersParallel(ctx context.Context, rctx graph.ResourceCont
 				StoreId: storeID,
 				Object: &openfgav1.Object{
 					Type: "role",
-					Id: fmt.Sprintf("%s/%s/%s/%s",
-						fgaTypeName,
-						clusterId,
-						rctx.Resource.Name,
-						role),
+					Id:   buildRoleObjectID(fgaTypeName, clusterId, rctx.Resource.Name, role),
 				},
 				Relation:    "assignee",
 				UserFilters: userFilter,
@@ -403,11 +399,7 @@ func (s *Service) RemoveRole(ctx context.Context, rctx graph.ResourceContext, in
 	readTuple := &openfgav1.ReadRequestTupleKey{
 		User:     fmt.Sprintf("user:%s", input.UserID),
 		Relation: "assignee",
-		Object: fmt.Sprintf("role:%s/%s/%s/%s",
-			fgaTypeName,
-			clusterId,
-			rctx.Resource.Name,
-			input.Role),
+		Object:   buildRoleObject(fgaTypeName, clusterId, rctx.Resource.Name, input.Role),
 	}
 
 	readReq := &openfgav1.ReadRequest{
@@ -441,11 +433,7 @@ func (s *Service) RemoveRole(ctx context.Context, rctx graph.ResourceContext, in
 	deleteTuple := &openfgav1.TupleKeyWithoutCondition{
 		User:     fmt.Sprintf("user:%s", input.UserID),
 		Relation: "assignee",
-		Object: fmt.Sprintf("role:%s/%s/%s/%s",
-			fgaTypeName,
-			clusterId,
-			rctx.Resource.Name,
-			input.Role),
+		Object:   buildRoleObject(fgaTypeName, clusterId, rctx.Resource.Name, input.Role),
 	}
 
 	deleteReq := &openfgav1.WriteRequest{

--- a/services/iam-service/pkg/fga/fga_test.go
+++ b/services/iam-service/pkg/fga/fga_test.go
@@ -103,7 +103,7 @@ func TestService_ListUsers_Success(t *testing.T) {
 		Group: "core.platform-mesh.io",
 		Kind:  "Account",
 		Resource: &graph.Resource{
-			Name:      "test-account",
+			Name:      "test:account#name",
 			Namespace: ptr.To("default"),
 		},
 		AccountPath: "test-account",
@@ -178,14 +178,14 @@ func TestService_ListUsers_Success(t *testing.T) {
 	client.EXPECT().ListUsers(mock.Anything, mock.MatchedBy(func(req *openfgav1.ListUsersRequest) bool {
 		return req.StoreId == storeID &&
 			req.Object.Type == "role" &&
-			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test-account/owner" &&
+			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner" &&
 			req.Relation == "assignee"
 	})).Return(ownerUsersResponse, nil)
 
 	client.EXPECT().ListUsers(mock.Anything, mock.MatchedBy(func(req *openfgav1.ListUsersRequest) bool {
 		return req.StoreId == storeID &&
 			req.Object.Type == "role" &&
-			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test-account/member" &&
+			req.Object.Id == "core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/member" &&
 			req.Relation == "assignee"
 	})).Return(memberUsersResponse, nil)
 
@@ -442,7 +442,7 @@ func TestService_AssignRolesToUsers_InvalidRole(t *testing.T) {
 		Group: "core.platform-mesh.io",
 		Kind:  "Account",
 		Resource: &graph.Resource{
-			Name:      "test-account",
+			Name:      "test:account#name",
 			Namespace: ptr.To("default"),
 		},
 		AccountPath: "test-account",
@@ -482,13 +482,15 @@ func TestService_AssignRolesToUsers_InvalidRole(t *testing.T) {
 		return req.StoreId == storeID &&
 			len(req.Writes.TupleKeys) == 1 &&
 			req.Writes.TupleKeys[0].User == "user:user1@example.com" &&
-			req.Writes.TupleKeys[0].Object == "role:core_platform-mesh_io_account/cluster-123/test-account/owner" &&
+			req.Writes.TupleKeys[0].Object == "role:core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner" &&
 			req.Writes.TupleKeys[0].Relation == "assignee"
 	})).Return(&openfgav1.WriteResponse{}, nil).Once()
 	// Second call: role tuple
 	client.EXPECT().Write(mock.Anything, mock.MatchedBy(func(req *openfgav1.WriteRequest) bool {
 		return req.StoreId == storeID &&
 			len(req.Writes.TupleKeys) == 1 &&
+			req.Writes.TupleKeys[0].User == "role:core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner#assignee" &&
+			req.Writes.TupleKeys[0].Object == "core_platform-mesh_io_account:cluster-123/default/test%3Aaccount%23name" &&
 			req.Writes.TupleKeys[0].Relation == "owner"
 	})).Return(&openfgav1.WriteResponse{}, nil).Once()
 
@@ -520,7 +522,7 @@ func TestService_RemoveRole_Success(t *testing.T) {
 		Group: "core.platform-mesh.io",
 		Kind:  "Account",
 		Resource: &graph.Resource{
-			Name:      "test-account",
+			Name:      "test:account#name",
 			Namespace: ptr.To("default"),
 		},
 		AccountPath: "test-account",
@@ -559,7 +561,7 @@ func TestService_RemoveRole_Success(t *testing.T) {
 				Key: &openfgav1.TupleKey{
 					User:     "user:user1@example.com",
 					Relation: "assignee",
-					Object:   "role:core_platform-mesh_io_account/cluster-123/test-account/owner",
+					Object:   "role:core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner",
 				},
 			},
 		},
@@ -567,7 +569,7 @@ func TestService_RemoveRole_Success(t *testing.T) {
 	client.EXPECT().Read(mock.Anything, mock.MatchedBy(func(req *openfgav1.ReadRequest) bool {
 		return req.StoreId == storeID &&
 			req.TupleKey.User == "user:user1@example.com" &&
-			req.TupleKey.Object == "role:core_platform-mesh_io_account/cluster-123/test-account/owner" &&
+			req.TupleKey.Object == "role:core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner" &&
 			req.TupleKey.Relation == "assignee"
 	})).Return(readResponse, nil).Once()
 
@@ -577,7 +579,7 @@ func TestService_RemoveRole_Success(t *testing.T) {
 			req.Deletes != nil &&
 			len(req.Deletes.TupleKeys) == 1 &&
 			req.Deletes.TupleKeys[0].User == "user:user1@example.com" &&
-			req.Deletes.TupleKeys[0].Object == "role:core_platform-mesh_io_account/cluster-123/test-account/owner" &&
+			req.Deletes.TupleKeys[0].Object == "role:core_platform-mesh_io_account/cluster-123/test%3Aaccount%23name/owner" &&
 			req.Deletes.TupleKeys[0].Relation == "assignee"
 	})).Return(&openfgav1.WriteResponse{}, nil).Once()
 

--- a/services/iam-service/pkg/fga/invite.go
+++ b/services/iam-service/pkg/fga/invite.go
@@ -183,25 +183,14 @@ func (s *Service) assignRoleToUser(ctx context.Context, userEmail, role string, 
 	roleTuple := &openfgav1.TupleKey{
 		User:     fmt.Sprintf("user:%s", userEmail),
 		Relation: "assignee",
-		Object: fmt.Sprintf("role:%s/%s/%s/%s",
-			fgaTypeName,
-			clusterId,
-			rctx.Resource.Name,
-			role),
+		Object:   buildRoleObject(fgaTypeName, clusterId, rctx.Resource.Name, role),
 	}
 
 	// Create the permission tuple (role -> resource)
 	targetFGATypeName := util.ConvertToTypeName(rctx.Group, rctx.Kind)
-	targetObject := fmt.Sprintf("%s:%s/%s", targetFGATypeName, clusterId, rctx.Resource.Name)
-	if rctx.Resource.Namespace != nil {
-		targetObject = fmt.Sprintf("%s:%s/%s/%s", targetFGATypeName, clusterId, *rctx.Resource.Namespace, rctx.Resource.Name)
-	}
+	targetObject := buildResourceObject(targetFGATypeName, clusterId, rctx.Resource.Name, rctx.Resource.Namespace)
 	assignRoleTuple := &openfgav1.TupleKey{
-		User: fmt.Sprintf("role:%s/%s/%s/%s#assignee",
-			fgaTypeName,
-			clusterId,
-			rctx.Resource.Name,
-			role),
+		User:     buildRoleUserset(fgaTypeName, clusterId, rctx.Resource.Name, role),
 		Relation: role,
 		Object:   targetObject,
 	}

--- a/services/iam-service/pkg/fga/objects.go
+++ b/services/iam-service/pkg/fga/objects.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fga
+
+import (
+	"fmt"
+
+	fgamodel "go.platform-mesh.io/golang-commons/fga/model"
+	fgautil "go.platform-mesh.io/golang-commons/fga/util"
+)
+
+func buildRoleObjectID(resourceType, clusterID, resourceName, role string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", resourceType, clusterID, fgautil.EncodeObjectIDPart(resourceName), role)
+}
+
+func buildRoleObject(resourceType, clusterID, resourceName, role string) string {
+	return "role:" + buildRoleObjectID(resourceType, clusterID, resourceName, role)
+}
+
+func buildRoleUserset(resourceType, clusterID, resourceName, role string) string {
+	return buildRoleObject(resourceType, clusterID, resourceName, role) + "#assignee"
+}
+
+func buildResourceObject(resourceType, clusterID, resourceName string, namespace *string) string {
+	return fgamodel.BuildObjectNameFromType(resourceType, clusterID, resourceName, namespace)
+}

--- a/services/iam-service/pkg/fga/objects_test.go
+++ b/services/iam-service/pkg/fga/objects_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Platform Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fga
+
+import "testing"
+
+func TestObjectBuildersEncodeResourceName(t *testing.T) {
+	const (
+		resourceType = "rbac_authorization_k8s_io_clusterrole"
+		clusterID    = "cluster-123"
+		resourceName = "system:controller#with space"
+		role         = "owner"
+	)
+
+	if got, want := buildRoleObjectID(resourceType, clusterID, resourceName, role), "rbac_authorization_k8s_io_clusterrole/cluster-123/system%3Acontroller%23with%20space/owner"; got != want {
+		t.Fatalf("buildRoleObjectID() = %q, want %q", got, want)
+	}
+	if got, want := buildRoleObject(resourceType, clusterID, resourceName, role), "role:rbac_authorization_k8s_io_clusterrole/cluster-123/system%3Acontroller%23with%20space/owner"; got != want {
+		t.Fatalf("buildRoleObject() = %q, want %q", got, want)
+	}
+	if got, want := buildRoleUserset(resourceType, clusterID, resourceName, role), "role:rbac_authorization_k8s_io_clusterrole/cluster-123/system%3Acontroller%23with%20space/owner#assignee"; got != want {
+		t.Fatalf("buildRoleUserset() = %q, want %q", got, want)
+	}
+	if got, want := buildResourceObject(resourceType, clusterID, resourceName, nil), "rbac_authorization_k8s_io_clusterrole:cluster-123/system%3Acontroller%23with%20space"; got != want {
+		t.Fatalf("buildResourceObject() = %q, want %q", got, want)
+	}
+}

--- a/services/iam-service/pkg/fga/tuples/tuples.go
+++ b/services/iam-service/pkg/fga/tuples/tuples.go
@@ -23,6 +23,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	pmcorev1alpha1 "go.platform-mesh.io/apis/core/v1alpha1"
+	fgamodel "go.platform-mesh.io/golang-commons/fga/model"
 	"go.platform-mesh.io/golang-commons/fga/util"
 	"go.platform-mesh.io/iam-service/pkg/graph"
 )
@@ -49,12 +50,7 @@ func GenerateContextualTuples(rctx *graph.ResourceContext, ai *pmcorev1alpha1.Ac
 
 	if !managedTuple(rctx.Group, rctx.Kind) {
 		resFGATypeName := util.ConvertToTypeName(rctx.Group, rctx.Kind)
-		var resObject string
-		if rctx.Resource.Namespace != nil {
-			resObject = fmt.Sprintf("%s:%s/%s/%s", resFGATypeName, ai.Spec.Account.GeneratedClusterId, *rctx.Resource.Namespace, rctx.Resource.Name)
-		} else {
-			resObject = fmt.Sprintf("%s:%s/%s", resFGATypeName, ai.Spec.Account.GeneratedClusterId, rctx.Resource.Name)
-		}
+		resObject := fgamodel.BuildObjectNameFromType(resFGATypeName, ai.Spec.Account.GeneratedClusterId, rctx.Resource.Name, rctx.Resource.Namespace)
 
 		resTuple := &openfgav1.TupleKey{
 			Object:   resObject,

--- a/services/iam-service/pkg/fga/tuples/tuples_test.go
+++ b/services/iam-service/pkg/fga/tuples/tuples_test.go
@@ -296,13 +296,14 @@ func TestGenerateContextualTuples_ComplexGroupName(t *testing.T) {
 }
 
 func TestGenerateContextualTuples_SpecialCharactersInNames(t *testing.T) {
-	// Test case: Special characters in resource names
+	// Namespace names are DNS constrained, while RBAC resource names use the
+	// less restrictive path-segment validation.
 	namespace := "test-namespace-with-hyphens"
 	rctx := &graph.ResourceContext{
 		Group: "batch",
 		Kind:  "Job",
 		Resource: &graph.Resource{
-			Name:      "test-job-with-hyphens",
+			Name:      "test:job#with space",
 			Namespace: &namespace,
 		},
 	}
@@ -332,7 +333,7 @@ func TestGenerateContextualTuples_SpecialCharactersInNames(t *testing.T) {
 
 	// Verify resource tuple
 	resourceTuple := result.TupleKeys[1]
-	assert.Equal(t, "batch_job:generated-cluster-with-hyphens/test-namespace-with-hyphens/test-job-with-hyphens", resourceTuple.Object)
+	assert.Equal(t, "batch_job:generated-cluster-with-hyphens/test-namespace-with-hyphens/test%3Ajob%23with%20space", resourceTuple.Object)
 	assert.Equal(t, "parent", resourceTuple.Relation)
 	assert.Equal(t, "core_namespace:generated-cluster-with-hyphens/test-namespace-with-hyphens", resourceTuple.User)
 }

--- a/services/rebac-authz-webhook/Dockerfile
+++ b/services/rebac-authz-webhook/Dockerfile
@@ -29,15 +29,16 @@ WORKDIR /workspace
 COPY go.work go.work
 COPY go.work.sum go.work.sum
 COPY apis/ apis/
+COPY golang-commons/ golang-commons/
 COPY services/rebac-authz-webhook/ services/rebac-authz-webhook/
 
 # Drop every workspace module except the ones copied above, so the workspace
-# resolves with only apis + this operator — regardless of what else go.work lists
+# resolves with only the copied modules — regardless of what else go.work lists
 # (other operators, cmd/* tools, ...). This is a textual edit of go.work, so the
 # dropped modules don't need to exist in the build context.
 RUN for m in $(go work edit -json | sed -n 's/.*"DiskPath": "\(.*\)".*/\1/p'); do \
       case "$m" in \
-        ./apis|./services/rebac-authz-webhook) ;; \
+        ./apis|./golang-commons|./services/rebac-authz-webhook) ;; \
         *) go work edit -dropuse "$m" ;; \
       esac; \
     done

--- a/services/rebac-authz-webhook/go.mod
+++ b/services/rebac-authz-webhook/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
+	go.platform-mesh.io/golang-commons v0.19.0
 	google.golang.org/grpc v1.83.2
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3

--- a/services/rebac-authz-webhook/go.sum
+++ b/services/rebac-authz-webhook/go.sum
@@ -168,6 +168,8 @@ go.opentelemetry.io/otel/sdk/metric v1.45.0 h1:oVFszMfyj1Am6s24Vtc7wBb8BKLcwepJj
 go.opentelemetry.io/otel/sdk/metric v1.45.0/go.mod h1:vUWUxDZvu1WVRj8JA8S0AdhsPrZoDpA2DdZauIh4mDA=
 go.opentelemetry.io/otel/trace v1.45.0 h1:l/mP6Uv7oNO7/TblbhpbgMidxhq1uO/rPsikOyVhxag=
 go.opentelemetry.io/otel/trace v1.45.0/go.mod h1:qoJJA2xNMnxRrdISU/kLtfUH2wNeQbiv+jhs/CxI8bc=
+go.platform-mesh.io/golang-commons v0.19.0 h1:oz4e7MK0cz08h5C/aT5yi20yf3GMzft7Kh35SNPJq3o=
+go.platform-mesh.io/golang-commons v0.19.0/go.mod h1:j3oRwItehwiRIKnxPpDxGs2mP/9O5PJmuBSZI+TJ1uM=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244 h1:OdZ8e4E9yDUGiis9x2ta/Ec5yhMAKT6ZivRvakyxC7E=
 go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/services/rebac-authz-webhook/pkg/util/name.go
+++ b/services/rebac-authz-webhook/pkg/util/name.go
@@ -16,31 +16,13 @@ limitations under the License.
 
 package util
 
-import "strings"
-
-// nameEncoder is a strings.Replacer that percent-encodes the characters that
-// OpenFGA forbids in the identifier portion of an object key.
-var nameEncoder = strings.NewReplacer(
-	"%", "%25",
-	":", "%3A",
-)
+import fgautil "go.platform-mesh.io/golang-commons/fga/util"
 
 // EncodeName percent-encodes the characters that OpenFGA forbids in the
 // identifier portion of an object key.
 //
-// OpenFGA requires an object to contain exactly one colon, the separator
-// between type and identifier, so a Kubernetes resource name that itself
-// contains a colon (e.g. the ClusterRole "system:controller:foo") produces an
-// object that the server rejects outright.
-//
-// Percent-encoding is used rather than a plain substitution because it is
-// injective: "system:controller:foo" and "system.controller.foo" are distinct,
-// both-legal resource names and must not map onto the same key. '%' is encoded
-// as well so the transformation stays injective for callers outside Kubernetes;
-// a Kubernetes name can never contain '%' itself.
-//
-// Names that contain neither character are returned unchanged, so keys that
-// OpenFGA already accepts today keep their current form.
+// The implementation delegates to the shared FGA utility so every component
+// uses the same encoding contract.
 func EncodeName(name string) string {
-	return nameEncoder.Replace(name)
+	return fgautil.EncodeObjectIDPart(name)
 }

--- a/services/rebac-authz-webhook/pkg/util/name_fuzz_test.go
+++ b/services/rebac-authz-webhook/pkg/util/name_fuzz_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,6 +29,8 @@ import (
 // a grant on one resource authorize access to the other.
 func FuzzEncodeNameIsInjective(f *testing.F) {
 	f.Add("system:controller:foo", "system.controller.foo")
+	f.Add("name#fragment", "name%23fragment")
+	f.Add("name with space", "name%20with%20space")
 	f.Add("a%b:c", "a%25b%3Ac")
 	f.Add("", ":")
 	f.Add("cluster-admin", "cluster-admin")
@@ -40,8 +43,9 @@ func FuzzEncodeNameIsInjective(f *testing.F) {
 			assert.NotEqualf(t, encA, encB, "distinct names %q and %q collided", a, b)
 		}
 
-		// The encoded form must never carry a raw colon, which OpenFGA
-		// reserves as the separator between object type and identifier.
-		assert.NotContainsf(t, encA, ":", "EncodeName(%q) = %q still contains a raw colon", a, encA)
+		for _, r := range encA {
+			assert.Falsef(t, r == ':' || r == '#' || r == ' ' || unicode.IsControl(r),
+				"EncodeName(%q) = %q contains OpenFGA-forbidden rune %q", a, encA, r)
+		}
 	})
 }

--- a/services/rebac-authz-webhook/pkg/util/name_test.go
+++ b/services/rebac-authz-webhook/pkg/util/name_test.go
@@ -34,6 +34,16 @@ func TestEncodeName(t *testing.T) {
 			want: "system%3Acontroller%3Afoo",
 		},
 		{
+			name: "encodes a hash",
+			in:   "name#fragment",
+			want: "name%23fragment",
+		},
+		{
+			name: "encodes spaces and controls",
+			in:   "name with\tcontrol",
+			want: "name%20with%09control",
+		},
+		{
 			name: "leaves a plain name untouched",
 			in:   "test-sample",
 			want: "test-sample",


### PR DESCRIPTION
- Add shared percent-encoding for Kubernetes resource names embedded in OpenFGA object IDs.
- Encode `%`, `/`, `:`, `#`, spaces, control characters, and invalid UTF-8 bytes without changing other accepted characters.
- Apply the encoding to the namespace segment as well as the name, so an object ID is unambiguous across its `/`-joined segments.
- Use the same encoding across the authorization webhook, IAM Service, Search Operator, and Security Operator.
- Keep generic tuple strings and user identifiers unchanged.
- Include the local `golang-commons` module in the ReBAC Webhook image build.

Closes #296

## Why `%` and `/` are escaped even though OpenFGA accepts them

`%` keeps the encoding injective: without it the raw name `a%3Ab` and the encoded form of `a:b` collide.

`/` joins the cluster, namespace, and name segments. Escaping only the OpenFGA-forbidden set makes the encoder injective within a segment while leaving the assembled key ambiguous — `(name "ns1/job1", no namespace)` and `(name "job1", namespace "ns1")` render the same object, so a grant on either authorizes the other. IAM Service reaches this path with GraphQL arguments that are never validated as Kubernetes path segments.

Kubernetes forbids both characters in path-segment names, so no key derived from a valid Kubernetes object changes shape.

## Key shape

A present-but-empty namespace keeps the three-segment shape it had before, so permission tuples already persisted at that key stay reachable.

## Rollout

Not ready to merge as-is: `services/rebac-authz-webhook/go.mod` carries `replace go.platform-mesh.io/golang-commons => ../../golang-commons`, which is what lets the module resolve the unreleased encoder under `GOWORK=off`.

Before merging: release `golang-commons`, drop that `replace`, and update the consumer pins with `task bump-deps`. Search Operator is still pinned to `v0.18.1` and must be bumped in the same step, otherwise the encoding test this PR adds for it does not exercise the released module.

Search Operator reindexes existing resources through its normal informer events after restart.

## Testing

- `go test ./...` for the affected Golang Commons, ReBAC Webhook, IAM Service, and Search Operator modules.
- `task test` for Security Operator.
- `task verify-*` for all five affected modules (`0 issues`), and repository-wide `task tidy-check`.
- 10-second fuzz runs for the shared encoder and Webhook wrapper, asserting injectivity and that no encoded output carries `:`, `#`, `/`, a space, or a control character.
- ReBAC Webhook container build using the repository-root Dockerfile.
- Manual E2E on `kind-platform-mesh`: created a colon-containing ClusterRole, confirmed that OpenFGA rejects its raw identifier, verified that the Webhook sends the encoded identifier, and received an allowed SubjectAccessReview. Removed the temporary resource and restored the original deployment afterward. Run against an earlier revision; the later commit leaves the webhook check path for colon-bearing names byte-identical.
